### PR TITLE
feat: impression FT — instructions page séparée + allergènes après ratios

### DIFF
--- a/app/bar/fiches/[id]/page.js
+++ b/app/bar/fiches/[id]/page.js
@@ -434,7 +434,17 @@ const loadFiche = async () => {
           ))}
         </div>
 
-        {/* ── INSTRUCTIONS — après récap financier ── */}
+        {/* Allergènes — sur la même page que le récap */}
+        {fiche.allergenes && fiche.allergenes.length > 0 && (
+          <div style={{ background: '#FCEBEB', borderRadius: '6px', padding: '12px', marginBottom: '16px', border: '0.5px solid #F09595' }}>
+            <div style={{ fontSize: '9px', color: '#A32D2D', textTransform: 'uppercase', letterSpacing: '2px', fontFamily: 'sans-serif', fontWeight: '600', marginBottom: '8px' }}>⚠ Allergènes présents</div>
+            <div style={{ fontSize: '11px', color: '#A32D2D', fontFamily: 'sans-serif', fontWeight: '500' }}>
+              {fiche.allergenes.map(id => { const a = ALLERGENES.find(a => a.id === id); return a ? `${a.emoji} ${a.label}` : null }).filter(Boolean).join('  •  ')}
+            </div>
+          </div>
+        )}
+
+        {/* ── INSTRUCTIONS — page séparée ── */}
         {fiche.instructions && (
           <div className="print-instructions" style={{ marginBottom: '20px', pageBreakBefore: 'always', marginTop: '0' }}>
             <div style={{ fontSize: '9px', letterSpacing: '3px', textTransform: 'uppercase', color: '#7C3AED', marginBottom: '10px', fontFamily: 'sans-serif', fontWeight: '600' }}>Instructions de préparation</div>
@@ -444,16 +454,6 @@ const loadFiche = async () => {
               lineHeight: '1.9', whiteSpace: 'pre-wrap'
             }}>
               {fiche.instructions}
-            </div>
-          </div>
-        )}
-
-        {/* Allergènes */}
-        {fiche.allergenes && fiche.allergenes.length > 0 && (
-          <div style={{ background: '#FCEBEB', borderRadius: '6px', padding: '12px', marginBottom: '16px', border: '0.5px solid #F09595' }}>
-            <div style={{ fontSize: '9px', color: '#A32D2D', textTransform: 'uppercase', letterSpacing: '2px', fontFamily: 'sans-serif', fontWeight: '600', marginBottom: '8px' }}>⚠ Allergènes présents</div>
-            <div style={{ fontSize: '11px', color: '#A32D2D', fontFamily: 'sans-serif', fontWeight: '500' }}>
-              {fiche.allergenes.map(id => { const a = ALLERGENES.find(a => a.id === id); return a ? `${a.emoji} ${a.label}` : null }).filter(Boolean).join('  •  ')}
             </div>
           </div>
         )}

--- a/app/fiches/[id]/page.js
+++ b/app/fiches/[id]/page.js
@@ -417,7 +417,17 @@ export default function FicheDetail() {
           ))}
         </div>
 
-        {/* ── INSTRUCTIONS — après récap financier ── */}
+        {/* Allergènes — sur la même page que le récap */}
+        {fiche.allergenes && fiche.allergenes.length > 0 && (
+          <div style={{ background: '#FCEBEB', borderRadius: '6px', padding: '12px', marginBottom: '16px', border: '0.5px solid #F09595' }}>
+            <div style={{ fontSize: '9px', color: '#A32D2D', textTransform: 'uppercase', letterSpacing: '2px', fontFamily: 'sans-serif', fontWeight: '600', marginBottom: '8px' }}>⚠ Allergènes présents</div>
+            <div style={{ fontSize: '11px', color: '#A32D2D', fontFamily: 'sans-serif', fontWeight: '500' }}>
+              {fiche.allergenes.map(id => { const a = ALLERGENES.find(a => a.id === id); return a ? `${a.emoji} ${a.label}` : null }).filter(Boolean).join('  •  ')}
+            </div>
+          </div>
+        )}
+
+        {/* ── INSTRUCTIONS — page séparée ── */}
         {fiche.instructions && (
           <div className="print-instructions" style={{ marginBottom: '20px', pageBreakBefore: 'always', marginTop: '0' }}>
             <div style={{ fontSize: '9px', letterSpacing: '3px', textTransform: 'uppercase', color: '#8B7355', marginBottom: '10px', fontFamily: 'sans-serif', fontWeight: '600' }}>Instructions de préparation</div>
@@ -427,16 +437,6 @@ export default function FicheDetail() {
               lineHeight: '1.9', whiteSpace: 'pre-wrap'
             }}>
               {fiche.instructions}
-            </div>
-          </div>
-        )}
-
-        {/* Allergènes */}
-        {fiche.allergenes && fiche.allergenes.length > 0 && (
-          <div style={{ background: '#FCEBEB', borderRadius: '6px', padding: '12px', marginBottom: '16px', border: '0.5px solid #F09595' }}>
-            <div style={{ fontSize: '9px', color: '#A32D2D', textTransform: 'uppercase', letterSpacing: '2px', fontFamily: 'sans-serif', fontWeight: '600', marginBottom: '8px' }}>⚠ Allergènes présents</div>
-            <div style={{ fontSize: '11px', color: '#A32D2D', fontFamily: 'sans-serif', fontWeight: '500' }}>
-              {fiche.allergenes.map(id => { const a = ALLERGENES.find(a => a.id === id); return a ? `${a.emoji} ${a.label}` : null }).filter(Boolean).join('  •  ')}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary

- **Instructions sur page séparée** : ajout de `page-break-before: always` sur le bloc instructions dans les versions impression des fiches cuisine et bar
- **Allergènes repositionnés** : la liste des allergènes apparaît désormais juste après le récap financier (même feuille), et non après les instructions

Fichiers modifiés :
- `app/fiches/[id]/page.js`
- `app/bar/fiches/[id]/page.js`

## Test plan

- [ ] Ouvrir une fiche cuisine avec instructions et allergènes → Ctrl+P → vérifier que les allergènes sont sur la page des ratios et les instructions sur une page séparée
- [ ] Idem pour une fiche bar
- [ ] Vérifier qu'une fiche sans instructions n'affiche pas de page blanche supplémentaire

https://claude.ai/code/session_01U7phmfn5aHh43xxCWJ8N29