### PR TITLE
fix: calcul ratio cartes + renommer FC en Ratio

### DIFF
--- a/app/cartes/[id]/page.js
+++ b/app/cartes/[id]/page.js
@@ -128,21 +128,50 @@ export default function CarteDetailPage() {
   }
 
   const calculs = (src) => {
-    const items = getAllItems(src)
     const isSrc = src === 'edit'
+    const secs = isSrc ? sections : (carte?.carte_sections || []).sort((a, b) => a.ordre - b.ordre)
 
-    const rel = (i) => isSrc ? (i.relation || 'et') : (i.relation || 'et')
-    const cp = (i) => isSrc ? (getFiche(i.ficheId)?.cout_portion || 0) : (i.fiches?.cout_portion || 0)
+    let coutBase = 0, coutSupp = 0, totalSupp = 0
 
-    const coutBase = items.filter(i => rel(i) !== 'ou').reduce((s, i) => s + cp(i), 0)
-    const coutTotal = items.reduce((s, i) => s + cp(i), 0)
-    const totalSupp = items.filter(i => rel(i) === 'ou').reduce((s, i) => s + (Number(i.supplement) || 0), 0)
+    for (const section of secs) {
+      const items = isSrc ? section.items : (section.carte_items || []).sort((a, b) => a.ordre - b.ordre)
+      let groups = [], current = null
+      for (const item of items) {
+        const r = isSrc ? (item.relation || 'et') : (item.relation || 'et')
+        if (r === 'et') {
+          if (current) groups.push(current)
+          current = { et: item, ous: [] }
+        } else if (current) {
+          current.ous.push(item)
+        }
+      }
+      if (current) groups.push(current)
+
+      for (const g of groups) {
+        const etCost = isSrc ? (getFiche(g.et.ficheId)?.cout_portion || 0) : (g.et.fiches?.cout_portion || 0)
+        coutBase += etCost
+        if (g.ous.length === 0) {
+          coutSupp += etCost
+        } else {
+          const ouAvecSup = g.ous.find(o => Number(o.supplement) > 0)
+          if (ouAvecSup) {
+            // ou avec supplément : remplace le coût du plat précédent
+            coutSupp += isSrc ? (getFiche(ouAvecSup.ficheId)?.cout_portion || 0) : (ouAvecSup.fiches?.cout_portion || 0)
+            totalSupp += Number(ouAvecSup.supplement)
+          } else {
+            // ou sans supplément : moyenne des plats liés
+            const costs = [etCost, ...g.ous.map(o => isSrc ? (getFiche(o.ficheId)?.cout_portion || 0) : (o.fiches?.cout_portion || 0))]
+            coutSupp += costs.reduce((a, b) => a + b, 0) / costs.length
+          }
+        }
+      }
+    }
 
     const prix = isSrc ? (parseFloat(prixBase) || 0) : (Number(carte?.prix_base) || 0)
-    const fcBase = prix > 0 && coutBase > 0 ? (coutBase / (prix / 1.10) * 100).toFixed(1) : null
-    const fcSupp = (prix + totalSupp) > 0 && coutTotal > 0 ? (coutTotal / ((prix + totalSupp) / 1.10) * 100).toFixed(1) : null
+    const ratioBase = prix > 0 && coutBase > 0 ? (coutBase / (prix / 1.10) * 100).toFixed(1) : null
+    const ratioSupp = (prix + totalSupp) > 0 && coutSupp > 0 ? (coutSupp / ((prix + totalSupp) / 1.10) * 100).toFixed(1) : null
 
-    return { coutBase, coutTotal, totalSupp, fcBase, fcSupp }
+    return { coutBase, coutSupp, totalSupp, ratioBase, ratioSupp }
   }
 
   const seuilVert = parseFloat(params['seuil_vert_cuisine'] || 28)
@@ -395,25 +424,25 @@ export default function CarteDetailPage() {
               </div>
               {calc.totalSupp > 0 && (
                 <div>
-                  <div style={{ fontSize: '11px', color: '#D97706', fontWeight: '500', textTransform: 'uppercase' }}>Co&ucirc;t total</div>
-                  <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: '#D97706' }}>{calc.coutTotal.toFixed(2)} &euro;</div>
+                  <div style={{ fontSize: '11px', color: '#D97706', fontWeight: '500', textTransform: 'uppercase' }}>Co&ucirc;t avec suppl.</div>
+                  <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: '#D97706' }}>{calc.coutSupp.toFixed(2)} &euro;</div>
                 </div>
               )}
-              {calc.fcBase && (() => {
-                const s = fcColor(calc.fcBase)
+              {calc.ratioBase && (() => {
+                const s = fcColor(calc.ratioBase)
                 return (
                   <div style={{ background: s.bg, borderRadius: '8px', padding: '14px' }}>
-                    <div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>FC base</div>
-                    <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{calc.fcBase} %</div>
+                    <div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>Ratio base</div>
+                    <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{calc.ratioBase} %</div>
                   </div>
                 )
               })()}
-              {calc.fcSupp && calc.totalSupp > 0 && (() => {
-                const s = fcColor(calc.fcSupp)
+              {calc.ratioSupp && calc.totalSupp > 0 && (() => {
+                const s = fcColor(calc.ratioSupp)
                 return (
                   <div style={{ background: s.bg, borderRadius: '8px', padding: '14px' }}>
-                    <div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>FC + suppl.</div>
-                    <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{calc.fcSupp} %</div>
+                    <div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>Ratio + suppl.</div>
+                    <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{calc.ratioSupp} %</div>
                   </div>
                 )
               })()}
@@ -500,8 +529,8 @@ export default function CarteDetailPage() {
                 <div style={{ fontSize: '11px', color: c.texteMuted, fontWeight: '500', textTransform: 'uppercase' }}>Co&ucirc;t base</div>
                 <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: c.texte }}>{calc.coutBase.toFixed(2)} &euro;</div>
               </div>
-              {calc.fcBase && (() => { const s = fcColor(calc.fcBase); return (<div style={{ background: s.bg, borderRadius: '8px', padding: '14px' }}><div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>FC base</div><div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{calc.fcBase} %</div></div>) })()}
-              {calc.fcSupp && calc.totalSupp > 0 && (() => { const s = fcColor(calc.fcSupp); return (<div style={{ background: s.bg, borderRadius: '8px', padding: '14px' }}><div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>FC + suppl.</div><div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{calc.fcSupp} %</div></div>) })()}
+              {calc.ratioBase && (() => { const s = fcColor(calc.ratioBase); return (<div style={{ background: s.bg, borderRadius: '8px', padding: '14px' }}><div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>Ratio base</div><div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{calc.ratioBase} %</div></div>) })()}
+              {calc.ratioSupp && calc.totalSupp > 0 && (() => { const s = fcColor(calc.ratioSupp); return (<div style={{ background: s.bg, borderRadius: '8px', padding: '14px' }}><div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>Ratio + suppl.</div><div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{calc.ratioSupp} %</div></div>) })()}
             </div>
           </>
         )}

--- a/app/cartes/nouveau/page.js
+++ b/app/cartes/nouveau/page.js
@@ -91,31 +91,53 @@ export default function NouvelleCarte() {
     setSections(copy)
   }
 
-  // ── Food cost ──
-
-  const allItems = sections.flatMap(s => s.items)
+  // ── Calcul des coûts ──
 
   const getFiche = (ficheId) => fiches.find(f => f.id === ficheId)
 
-  const coutBase = allItems
-    .filter(i => i.relation !== 'ou')
-    .reduce((s, i) => s + (getFiche(i.ficheId)?.cout_portion || 0), 0)
+  const calculerCouts = () => {
+    let coutBase = 0, coutSupp = 0, totalSuppPrix = 0
+    for (const section of sections) {
+      let groups = [], current = null
+      for (const item of section.items) {
+        if ((item.relation || 'et') === 'et') {
+          if (current) groups.push(current)
+          current = { et: item, ous: [] }
+        } else if (current) {
+          current.ous.push(item)
+        }
+      }
+      if (current) groups.push(current)
+      for (const g of groups) {
+        const etCost = getFiche(g.et.ficheId)?.cout_portion || 0
+        coutBase += etCost
+        if (g.ous.length === 0) {
+          coutSupp += etCost
+        } else {
+          const ouAvecSup = g.ous.find(o => Number(o.supplement) > 0)
+          if (ouAvecSup) {
+            coutSupp += (getFiche(ouAvecSup.ficheId)?.cout_portion || 0)
+            totalSuppPrix += Number(ouAvecSup.supplement)
+          } else {
+            const costs = [etCost, ...g.ous.map(o => getFiche(o.ficheId)?.cout_portion || 0)]
+            coutSupp += costs.reduce((a, b) => a + b, 0) / costs.length
+          }
+        }
+      }
+    }
+    return { coutBase, coutSupp, totalSuppPrix }
+  }
 
-  const coutTotal = allItems
-    .reduce((s, i) => s + (getFiche(i.ficheId)?.cout_portion || 0), 0)
-
-  const totalSupplements = allItems
-    .filter(i => i.relation === 'ou')
-    .reduce((s, i) => s + (Number(i.supplement) || 0), 0)
+  const { coutBase, coutSupp, totalSuppPrix: totalSupplements } = calculerCouts()
 
   const prix = parseFloat(prixBase) || 0
 
-  const fcBase = prix > 0 && coutBase > 0
+  const ratioBase = prix > 0 && coutBase > 0
     ? (coutBase / (prix / 1.10) * 100).toFixed(1)
     : null
 
-  const fcAvecSupp = (prix + totalSupplements) > 0 && coutTotal > 0
-    ? (coutTotal / ((prix + totalSupplements) / 1.10) * 100).toFixed(1)
+  const ratioAvecSupp = (prix + totalSupplements) > 0 && coutSupp > 0
+    ? (coutSupp / ((prix + totalSupplements) / 1.10) * 100).toFixed(1)
     : null
 
   const seuilVert = parseFloat(params['seuil_vert_cuisine'] || 28)
@@ -266,7 +288,7 @@ export default function NouvelleCarte() {
               />
               {prixIndicatif && (
                 <div style={{ fontSize: '11px', color: c.vert, marginTop: '4px' }}>
-                  Prix indicatif ({seuilVert}% FC) : <strong>{prixIndicatif} &euro;</strong>
+                  Prix indicatif ({seuilVert}% Ratio) : <strong>{prixIndicatif} &euro;</strong>
                 </div>
               )}
             </div>
@@ -394,24 +416,24 @@ export default function NouvelleCarte() {
           {totalSupplements > 0 && (
             <div>
               <div style={{ fontSize: '11px', color: '#D97706', fontWeight: '500', textTransform: 'uppercase' }}>Co&ucirc;t avec suppl.</div>
-              <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: '#D97706' }}>{coutTotal.toFixed(2)} &euro;</div>
+              <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: '#D97706' }}>{coutSupp.toFixed(2)} &euro;</div>
             </div>
           )}
-          {fcBase && (() => {
-            const s = fcColor(fcBase)
+          {ratioBase && (() => {
+            const s = fcColor(ratioBase)
             return (
               <div style={{ background: s.bg, borderRadius: '8px', padding: '14px' }}>
-                <div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>Food cost base</div>
-                <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{fcBase} %</div>
+                <div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>Ratio base</div>
+                <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{ratioBase} %</div>
               </div>
             )
           })()}
-          {fcAvecSupp && totalSupplements > 0 && (() => {
-            const s = fcColor(fcAvecSupp)
+          {ratioAvecSupp && totalSupplements > 0 && (() => {
+            const s = fcColor(ratioAvecSupp)
             return (
               <div style={{ background: s.bg, borderRadius: '8px', padding: '14px' }}>
-                <div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>FC + suppl.</div>
-                <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{fcAvecSupp} %</div>
+                <div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>Ratio + suppl.</div>
+                <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{ratioAvecSupp} %</div>
               </div>
             )
           })()}
@@ -419,7 +441,7 @@ export default function NouvelleCarte() {
             <div style={{ background: c.vertClair, borderRadius: '8px', padding: '14px' }}>
               <div style={{ fontSize: '11px', color: c.vert, fontWeight: '500', textTransform: 'uppercase' }}>Prix indicatif TTC</div>
               <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: c.vert }}>{prixIndicatif} &euro;</div>
-              <div style={{ fontSize: '10px', color: c.vert, opacity: 0.8 }}>Bas&eacute; sur {seuilVert}% FC</div>
+              <div style={{ fontSize: '10px', color: c.vert, opacity: 0.8 }}>Bas&eacute; sur {seuilVert}% Ratio</div>
             </div>
           )}
         </div>

--- a/app/cartes/page.js
+++ b/app/cartes/page.js
@@ -39,34 +39,54 @@ export default function CartesPage() {
   const getAllItems = (carte) =>
     (carte.carte_sections || []).flatMap(s => s.carte_items || [])
 
-  // FC base = seulement les items "et" (inclus)
-  const coutBase = (carte) =>
-    getAllItems(carte)
-      .filter(i => i.relation !== 'ou')
-      .reduce((s, i) => s + (i.fiches?.cout_portion || 0), 0)
-
-  // FC total = tous les items (et + ou)
-  const coutTotal = (carte) =>
-    getAllItems(carte)
-      .reduce((s, i) => s + (i.fiches?.cout_portion || 0), 0)
-
-  const totalSupplements = (carte) =>
-    getAllItems(carte)
-      .filter(i => i.relation === 'ou')
-      .reduce((s, i) => s + (Number(i.supplement) || 0), 0)
-
-  const fcBase = (carte) => {
-    const cb = coutBase(carte)
-    if (!carte.prix_base || !cb) return null
-    return (cb / (carte.prix_base / 1.10) * 100).toFixed(1)
+  // Calcul des coûts par groupes (et + ou)
+  const calculerCouts = (carte) => {
+    let coutBase = 0, coutSupp = 0, totalSuppPrix = 0
+    for (const section of (carte.carte_sections || []).sort((a, b) => a.ordre - b.ordre)) {
+      const items = (section.carte_items || []).sort((a, b) => a.ordre - b.ordre)
+      let groups = [], current = null
+      for (const item of items) {
+        if ((item.relation || 'et') === 'et') {
+          if (current) groups.push(current)
+          current = { et: item, ous: [] }
+        } else if (current) {
+          current.ous.push(item)
+        }
+      }
+      if (current) groups.push(current)
+      for (const g of groups) {
+        const etCost = g.et.fiches?.cout_portion || 0
+        coutBase += etCost
+        if (g.ous.length === 0) {
+          coutSupp += etCost
+        } else {
+          const ouAvecSupp = g.ous.find(o => Number(o.supplement) > 0)
+          if (ouAvecSupp) {
+            // ou avec supplément : remplace le coût du plat précédent
+            coutSupp += (ouAvecSupp.fiches?.cout_portion || 0)
+            totalSuppPrix += Number(ouAvecSupp.supplement)
+          } else {
+            // ou sans supplément : moyenne des plats liés
+            const costs = [etCost, ...g.ous.map(o => o.fiches?.cout_portion || 0)]
+            coutSupp += costs.reduce((a, b) => a + b, 0) / costs.length
+          }
+        }
+      }
+    }
+    return { coutBase, coutSupp, totalSuppPrix }
   }
 
-  const fcAvecSupp = (carte) => {
-    const ct = coutTotal(carte)
-    const ts = totalSupplements(carte)
-    const prixTotal = (Number(carte.prix_base) || 0) + ts
-    if (!prixTotal || !ct) return null
-    return (ct / (prixTotal / 1.10) * 100).toFixed(1)
+  const ratioBase = (carte) => {
+    const { coutBase } = calculerCouts(carte)
+    if (!carte.prix_base || !coutBase) return null
+    return (coutBase / (carte.prix_base / 1.10) * 100).toFixed(1)
+  }
+
+  const ratioAvecSupp = (carte) => {
+    const { coutSupp, totalSuppPrix } = calculerCouts(carte)
+    const prixTotal = (Number(carte.prix_base) || 0) + totalSuppPrix
+    if (!prixTotal || !coutSupp) return null
+    return (coutSupp / (prixTotal / 1.10) * 100).toFixed(1)
   }
 
   const handleDelete = async (id) => {
@@ -123,11 +143,11 @@ export default function CartesPage() {
             gap: isMobile ? '10px' : '16px'
           }}>
             {cartes.map(carte => {
-              const fc1 = fcBase(carte)
-              const fc2 = fcAvecSupp(carte)
-              const ts = totalSupplements(carte)
-              const c1 = fcColor(fc1)
-              const c2 = fcColor(fc2)
+              const r1 = ratioBase(carte)
+              const r2 = ratioAvecSupp(carte)
+              const { totalSuppPrix } = calculerCouts(carte)
+              const c1 = fcColor(r1)
+              const c2 = fcColor(r2)
               const hasOu = getAllItems(carte).some(i => i.relation === 'ou')
 
               return (
@@ -197,18 +217,18 @@ export default function CartesPage() {
                       })}
                   </div>
 
-                  {/* Food cost */}
+                  {/* Ratio */}
                   <div style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
-                    {fc1 && (
+                    {r1 && (
                       <div style={{ flex: 1, borderRadius: '8px', padding: '8px', textAlign: 'center', background: c1.bg }}>
-                        <div style={{ fontSize: '10px', textTransform: 'uppercase', color: c1.color }}>FC base</div>
-                        <div style={{ fontSize: '14px', fontWeight: '500', color: c1.color }}>{fc1} %</div>
+                        <div style={{ fontSize: '10px', textTransform: 'uppercase', color: c1.color }}>Ratio base</div>
+                        <div style={{ fontSize: '14px', fontWeight: '500', color: c1.color }}>{r1} %</div>
                       </div>
                     )}
-                    {fc2 && hasOu && (
+                    {r2 && hasOu && (
                       <div style={{ flex: 1, borderRadius: '8px', padding: '8px', textAlign: 'center', background: c2.bg }}>
-                        <div style={{ fontSize: '10px', textTransform: 'uppercase', color: c2.color }}>FC + suppl.</div>
-                        <div style={{ fontSize: '14px', fontWeight: '500', color: c2.color }}>{fc2} %</div>
+                        <div style={{ fontSize: '10px', textTransform: 'uppercase', color: c2.color }}>Ratio + suppl.</div>
+                        <div style={{ fontSize: '14px', fontWeight: '500', color: c2.color }}>{r2} %</div>
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
## Summary
- **Calcul ratio corrigé** : "ou" avec supplément remplace le coût du plat précédent, "ou" sans supplément fait la moyenne des deux plats liés
- **Renommage FC → Ratio** sur les 3 pages cartes (liste, nouveau, détail) pour harmoniser avec les fiches techniques

## Fichiers modifiés
- `app/cartes/page.js`
- `app/cartes/nouveau/page.js`
- `app/cartes/[id]/page.js`

https://claude.ai/code/session_01U7phmfn5aHh43xxCWJ8N29