### PR TITLE
fix: calcul ratio unique cartes (ou = moyenne / coût plat)

### DIFF
--- a/app/cartes/[id]/page.js
+++ b/app/cartes/[id]/page.js
@@ -131,7 +131,7 @@ export default function CarteDetailPage() {
     const isSrc = src === 'edit'
     const secs = isSrc ? sections : (carte?.carte_sections || []).sort((a, b) => a.ordre - b.ordre)
 
-    let coutBase = 0, coutSupp = 0, totalSupp = 0
+    let coutMatiere = 0, totalSupp = 0
 
     for (const section of secs) {
       const items = isSrc ? section.items : (section.carte_items || []).sort((a, b) => a.ordre - b.ordre)
@@ -149,29 +149,28 @@ export default function CarteDetailPage() {
 
       for (const g of groups) {
         const etCost = isSrc ? (getFiche(g.et.ficheId)?.cout_portion || 0) : (g.et.fiches?.cout_portion || 0)
-        coutBase += etCost
         if (g.ous.length === 0) {
-          coutSupp += etCost
+          coutMatiere += etCost
         } else {
           const ouAvecSup = g.ous.find(o => Number(o.supplement) > 0)
           if (ouAvecSup) {
-            // ou avec supplément : remplace le coût du plat précédent
-            coutSupp += isSrc ? (getFiche(ouAvecSup.ficheId)?.cout_portion || 0) : (ouAvecSup.fiches?.cout_portion || 0)
+            // ou avec supplément : on retient le coût du plat ou
+            coutMatiere += isSrc ? (getFiche(ouAvecSup.ficheId)?.cout_portion || 0) : (ouAvecSup.fiches?.cout_portion || 0)
             totalSupp += Number(ouAvecSup.supplement)
           } else {
             // ou sans supplément : moyenne des plats liés
             const costs = [etCost, ...g.ous.map(o => isSrc ? (getFiche(o.ficheId)?.cout_portion || 0) : (o.fiches?.cout_portion || 0))]
-            coutSupp += costs.reduce((a, b) => a + b, 0) / costs.length
+            coutMatiere += costs.reduce((a, b) => a + b, 0) / costs.length
           }
         }
       }
     }
 
     const prix = isSrc ? (parseFloat(prixBase) || 0) : (Number(carte?.prix_base) || 0)
-    const ratioBase = prix > 0 && coutBase > 0 ? (coutBase / (prix / 1.10) * 100).toFixed(1) : null
-    const ratioSupp = (prix + totalSupp) > 0 && coutSupp > 0 ? (coutSupp / ((prix + totalSupp) / 1.10) * 100).toFixed(1) : null
+    const prixTotal = prix + totalSupp
+    const ratio = prixTotal > 0 && coutMatiere > 0 ? (coutMatiere / (prixTotal / 1.10) * 100).toFixed(1) : null
 
-    return { coutBase, coutSupp, totalSupp, ratioBase, ratioSupp }
+    return { coutMatiere, totalSupp, ratio }
   }
 
   const seuilVert = parseFloat(params['seuil_vert_cuisine'] || 28)
@@ -416,33 +415,24 @@ export default function CarteDetailPage() {
               </div>
             )}
 
-            {/* Récap food cost */}
+            {/* Récap ratio */}
             <div style={{ background: 'white', borderRadius: '12px', padding: '20px', border: `0.5px solid ${c.bordure}`, display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
               <div>
-                <div style={{ fontSize: '11px', color: c.texteMuted, fontWeight: '500', textTransform: 'uppercase' }}>Co&ucirc;t base</div>
-                <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: c.texte }}>{calc.coutBase.toFixed(2)} &euro;</div>
+                <div style={{ fontSize: '11px', color: c.texteMuted, fontWeight: '500', textTransform: 'uppercase' }}>Co&ucirc;t mati&egrave;re</div>
+                <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: c.texte }}>{calc.coutMatiere.toFixed(2)} &euro;</div>
               </div>
               {calc.totalSupp > 0 && (
                 <div>
-                  <div style={{ fontSize: '11px', color: '#D97706', fontWeight: '500', textTransform: 'uppercase' }}>Co&ucirc;t avec suppl.</div>
-                  <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: '#D97706' }}>{calc.coutSupp.toFixed(2)} &euro;</div>
+                  <div style={{ fontSize: '11px', color: '#D97706', fontWeight: '500', textTransform: 'uppercase' }}>Dont suppl. prix</div>
+                  <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: '#D97706' }}>+{calc.totalSupp.toFixed(0)} &euro;</div>
                 </div>
               )}
-              {calc.ratioBase && (() => {
-                const s = fcColor(calc.ratioBase)
+              {calc.ratio && (() => {
+                const s = fcColor(calc.ratio)
                 return (
                   <div style={{ background: s.bg, borderRadius: '8px', padding: '14px' }}>
-                    <div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>Ratio base</div>
-                    <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{calc.ratioBase} %</div>
-                  </div>
-                )
-              })()}
-              {calc.ratioSupp && calc.totalSupp > 0 && (() => {
-                const s = fcColor(calc.ratioSupp)
-                return (
-                  <div style={{ background: s.bg, borderRadius: '8px', padding: '14px' }}>
-                    <div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>Ratio + suppl.</div>
-                    <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{calc.ratioSupp} %</div>
+                    <div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>Ratio</div>
+                    <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{calc.ratio} %</div>
                   </div>
                 )
               })()}
@@ -526,11 +516,10 @@ export default function CarteDetailPage() {
             {/* Récap édition */}
             <div style={{ background: 'white', borderRadius: '12px', padding: '20px', border: `0.5px solid ${c.bordure}`, display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
               <div>
-                <div style={{ fontSize: '11px', color: c.texteMuted, fontWeight: '500', textTransform: 'uppercase' }}>Co&ucirc;t base</div>
-                <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: c.texte }}>{calc.coutBase.toFixed(2)} &euro;</div>
+                <div style={{ fontSize: '11px', color: c.texteMuted, fontWeight: '500', textTransform: 'uppercase' }}>Co&ucirc;t mati&egrave;re</div>
+                <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: c.texte }}>{calc.coutMatiere.toFixed(2)} &euro;</div>
               </div>
-              {calc.ratioBase && (() => { const s = fcColor(calc.ratioBase); return (<div style={{ background: s.bg, borderRadius: '8px', padding: '14px' }}><div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>Ratio base</div><div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{calc.ratioBase} %</div></div>) })()}
-              {calc.ratioSupp && calc.totalSupp > 0 && (() => { const s = fcColor(calc.ratioSupp); return (<div style={{ background: s.bg, borderRadius: '8px', padding: '14px' }}><div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>Ratio + suppl.</div><div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{calc.ratioSupp} %</div></div>) })()}
+              {calc.ratio && (() => { const s = fcColor(calc.ratio); return (<div style={{ background: s.bg, borderRadius: '8px', padding: '14px' }}><div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>Ratio</div><div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{calc.ratio} %</div></div>) })()}
             </div>
           </>
         )}

--- a/app/cartes/nouveau/page.js
+++ b/app/cartes/nouveau/page.js
@@ -96,7 +96,7 @@ export default function NouvelleCarte() {
   const getFiche = (ficheId) => fiches.find(f => f.id === ficheId)
 
   const calculerCouts = () => {
-    let coutBase = 0, coutSupp = 0, totalSuppPrix = 0
+    let coutMatiere = 0, totalSuppPrix = 0
     for (const section of sections) {
       let groups = [], current = null
       for (const item of section.items) {
@@ -110,41 +110,39 @@ export default function NouvelleCarte() {
       if (current) groups.push(current)
       for (const g of groups) {
         const etCost = getFiche(g.et.ficheId)?.cout_portion || 0
-        coutBase += etCost
         if (g.ous.length === 0) {
-          coutSupp += etCost
+          coutMatiere += etCost
         } else {
           const ouAvecSup = g.ous.find(o => Number(o.supplement) > 0)
           if (ouAvecSup) {
-            coutSupp += (getFiche(ouAvecSup.ficheId)?.cout_portion || 0)
+            // ou avec supplément : on retient le coût du plat ou
+            coutMatiere += (getFiche(ouAvecSup.ficheId)?.cout_portion || 0)
             totalSuppPrix += Number(ouAvecSup.supplement)
           } else {
+            // ou sans supplément : moyenne des plats liés
             const costs = [etCost, ...g.ous.map(o => getFiche(o.ficheId)?.cout_portion || 0)]
-            coutSupp += costs.reduce((a, b) => a + b, 0) / costs.length
+            coutMatiere += costs.reduce((a, b) => a + b, 0) / costs.length
           }
         }
       }
     }
-    return { coutBase, coutSupp, totalSuppPrix }
+    return { coutMatiere, totalSuppPrix }
   }
 
-  const { coutBase, coutSupp, totalSuppPrix: totalSupplements } = calculerCouts()
+  const { coutMatiere, totalSuppPrix: totalSupplements } = calculerCouts()
 
   const prix = parseFloat(prixBase) || 0
+  const prixTotal = prix + totalSupplements
 
-  const ratioBase = prix > 0 && coutBase > 0
-    ? (coutBase / (prix / 1.10) * 100).toFixed(1)
-    : null
-
-  const ratioAvecSupp = (prix + totalSupplements) > 0 && coutSupp > 0
-    ? (coutSupp / ((prix + totalSupplements) / 1.10) * 100).toFixed(1)
+  const ratio = prixTotal > 0 && coutMatiere > 0
+    ? (coutMatiere / (prixTotal / 1.10) * 100).toFixed(1)
     : null
 
   const seuilVert = parseFloat(params['seuil_vert_cuisine'] || 28)
   const seuilOrange = parseFloat(params['seuil_orange_cuisine'] || 35)
 
-  const prixIndicatif = coutBase > 0
-    ? (coutBase / (seuilVert / 100) * (1 + parseFloat(params['tva_restauration'] || 10) / 100)).toFixed(2)
+  const prixIndicatif = coutMatiere > 0
+    ? (coutMatiere / (seuilVert / 100) * (1 + parseFloat(params['tva_restauration'] || 10) / 100)).toFixed(2)
     : null
 
   const fcColor = (fc) => {
@@ -410,30 +408,21 @@ export default function NouvelleCarte() {
           border: `0.5px solid ${c.bordure}`, display: 'flex', gap: '16px', flexWrap: 'wrap', alignItems: 'flex-start'
         }}>
           <div>
-            <div style={{ fontSize: '11px', color: c.texteMuted, fontWeight: '500', textTransform: 'uppercase' }}>Co&ucirc;t base</div>
-            <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: c.texte }}>{coutBase.toFixed(2)} &euro;</div>
+            <div style={{ fontSize: '11px', color: c.texteMuted, fontWeight: '500', textTransform: 'uppercase' }}>Co&ucirc;t mati&egrave;re</div>
+            <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: c.texte }}>{coutMatiere.toFixed(2)} &euro;</div>
           </div>
           {totalSupplements > 0 && (
             <div>
-              <div style={{ fontSize: '11px', color: '#D97706', fontWeight: '500', textTransform: 'uppercase' }}>Co&ucirc;t avec suppl.</div>
-              <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: '#D97706' }}>{coutSupp.toFixed(2)} &euro;</div>
+              <div style={{ fontSize: '11px', color: '#D97706', fontWeight: '500', textTransform: 'uppercase' }}>Dont suppl. prix</div>
+              <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: '#D97706' }}>+{totalSupplements.toFixed(0)} &euro;</div>
             </div>
           )}
-          {ratioBase && (() => {
-            const s = fcColor(ratioBase)
+          {ratio && (() => {
+            const s = fcColor(ratio)
             return (
               <div style={{ background: s.bg, borderRadius: '8px', padding: '14px' }}>
-                <div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>Ratio base</div>
-                <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{ratioBase} %</div>
-              </div>
-            )
-          })()}
-          {ratioAvecSupp && totalSupplements > 0 && (() => {
-            const s = fcColor(ratioAvecSupp)
-            return (
-              <div style={{ background: s.bg, borderRadius: '8px', padding: '14px' }}>
-                <div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>Ratio + suppl.</div>
-                <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{ratioAvecSupp} %</div>
+                <div style={{ fontSize: '11px', fontWeight: '500', textTransform: 'uppercase', color: s.color }}>Ratio</div>
+                <div style={{ fontSize: '22px', fontWeight: '500', marginTop: '4px', color: s.color }}>{ratio} %</div>
               </div>
             )
           })()}

--- a/app/cartes/page.js
+++ b/app/cartes/page.js
@@ -39,9 +39,9 @@ export default function CartesPage() {
   const getAllItems = (carte) =>
     (carte.carte_sections || []).flatMap(s => s.carte_items || [])
 
-  // Calcul des coûts par groupes (et + ou)
+  // Calcul unique du coût matière avec logique ou
   const calculerCouts = (carte) => {
-    let coutBase = 0, coutSupp = 0, totalSuppPrix = 0
+    let coutMatiere = 0, totalSuppPrix = 0
     for (const section of (carte.carte_sections || []).sort((a, b) => a.ordre - b.ordre)) {
       const items = (section.carte_items || []).sort((a, b) => a.ordre - b.ordre)
       let groups = [], current = null
@@ -56,37 +56,30 @@ export default function CartesPage() {
       if (current) groups.push(current)
       for (const g of groups) {
         const etCost = g.et.fiches?.cout_portion || 0
-        coutBase += etCost
         if (g.ous.length === 0) {
-          coutSupp += etCost
+          coutMatiere += etCost
         } else {
           const ouAvecSupp = g.ous.find(o => Number(o.supplement) > 0)
           if (ouAvecSupp) {
-            // ou avec supplément : remplace le coût du plat précédent
-            coutSupp += (ouAvecSupp.fiches?.cout_portion || 0)
+            // ou avec supplément : on retient le coût du plat ou
+            coutMatiere += (ouAvecSupp.fiches?.cout_portion || 0)
             totalSuppPrix += Number(ouAvecSupp.supplement)
           } else {
             // ou sans supplément : moyenne des plats liés
             const costs = [etCost, ...g.ous.map(o => o.fiches?.cout_portion || 0)]
-            coutSupp += costs.reduce((a, b) => a + b, 0) / costs.length
+            coutMatiere += costs.reduce((a, b) => a + b, 0) / costs.length
           }
         }
       }
     }
-    return { coutBase, coutSupp, totalSuppPrix }
+    return { coutMatiere, totalSuppPrix }
   }
 
-  const ratioBase = (carte) => {
-    const { coutBase } = calculerCouts(carte)
-    if (!carte.prix_base || !coutBase) return null
-    return (coutBase / (carte.prix_base / 1.10) * 100).toFixed(1)
-  }
-
-  const ratioAvecSupp = (carte) => {
-    const { coutSupp, totalSuppPrix } = calculerCouts(carte)
+  const getRatio = (carte) => {
+    const { coutMatiere, totalSuppPrix } = calculerCouts(carte)
     const prixTotal = (Number(carte.prix_base) || 0) + totalSuppPrix
-    if (!prixTotal || !coutSupp) return null
-    return (coutSupp / (prixTotal / 1.10) * 100).toFixed(1)
+    if (!prixTotal || !coutMatiere) return null
+    return (coutMatiere / (prixTotal / 1.10) * 100).toFixed(1)
   }
 
   const handleDelete = async (id) => {
@@ -143,12 +136,9 @@ export default function CartesPage() {
             gap: isMobile ? '10px' : '16px'
           }}>
             {cartes.map(carte => {
-              const r1 = ratioBase(carte)
-              const r2 = ratioAvecSupp(carte)
-              const { totalSuppPrix } = calculerCouts(carte)
-              const c1 = fcColor(r1)
-              const c2 = fcColor(r2)
-              const hasOu = getAllItems(carte).some(i => i.relation === 'ou')
+              const ratio = getRatio(carte)
+              const { coutMatiere, totalSuppPrix } = calculerCouts(carte)
+              const rc = fcColor(ratio)
 
               return (
                 <div key={carte.id} style={{
@@ -218,20 +208,20 @@ export default function CartesPage() {
                   </div>
 
                   {/* Ratio */}
-                  <div style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
-                    {r1 && (
-                      <div style={{ flex: 1, borderRadius: '8px', padding: '8px', textAlign: 'center', background: c1.bg }}>
-                        <div style={{ fontSize: '10px', textTransform: 'uppercase', color: c1.color }}>Ratio base</div>
-                        <div style={{ fontSize: '14px', fontWeight: '500', color: c1.color }}>{r1} %</div>
+                  {ratio && (
+                    <div style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
+                      <div style={{ flex: 1, borderRadius: '8px', padding: '8px', textAlign: 'center', background: rc.bg }}>
+                        <div style={{ fontSize: '10px', textTransform: 'uppercase', color: rc.color }}>Ratio</div>
+                        <div style={{ fontSize: '14px', fontWeight: '500', color: rc.color }}>{ratio} %</div>
                       </div>
-                    )}
-                    {r2 && hasOu && (
-                      <div style={{ flex: 1, borderRadius: '8px', padding: '8px', textAlign: 'center', background: c2.bg }}>
-                        <div style={{ fontSize: '10px', textTransform: 'uppercase', color: c2.color }}>Ratio + suppl.</div>
-                        <div style={{ fontSize: '14px', fontWeight: '500', color: c2.color }}>{r2} %</div>
-                      </div>
-                    )}
-                  </div>
+                      {coutMatiere > 0 && (
+                        <div style={{ flex: 1, borderRadius: '8px', padding: '8px', textAlign: 'center', background: c.fond }}>
+                          <div style={{ fontSize: '10px', textTransform: 'uppercase', color: c.texteMuted }}>Coût matière</div>
+                          <div style={{ fontSize: '14px', fontWeight: '500', color: c.texte }}>{coutMatiere.toFixed(2)} €</div>
+                        </div>
+                      )}
+                    </div>
+                  )}
 
                   {/* Actions */}
                   <div style={{ display: 'flex', gap: '6px' }}>


### PR DESCRIPTION
## Summary
- **ou sans supplément** : coût matière = moyenne des deux plats liés (ex: 2€ et 4€ → 3€)
- **ou avec supplément** : coût matière = coût du plat alternatif (ex: 4€), supplément ajouté au prix de vente
- Un seul ratio affiché par carte (plus de séparation base/suppl)
- Label : « Coût matière » + « Ratio »

https://claude.ai/code/session_01U7phmfn5aHh43xxCWJ8N29