### PR TITLE
fix(navbar): éléments cuisine invisibles quand modules_actifs est null

### DIFF
--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -59,7 +59,8 @@ export default function Navbar({ section = 'cuisine' }) {
   const LOGO_EMOJI         = isBar ? '🍸'                   : '🍽️'
 
   // ─── Modules / Rôles ─────────────────────────────────────────────────────────
-  const modules     = tenant?.modules_actifs || (isBar ? ['fiches', 'sous-fiches', 'recap', 'ingredients'] : [])
+  const DEFAULT_CUISINE_MODULES = ['fiches', 'sous-fiches', 'recap', 'ingredients', 'menus', 'cartes', 'avis', 'ardoise']
+  const modules     = tenant?.modules_actifs || (isBar ? ['fiches', 'sous-fiches', 'recap', 'ingredients'] : DEFAULT_CUISINE_MODULES)
   const hasModule   = (id) => modules.includes(id)
   const hasBar      = typeof tenant?.has_bar === 'boolean' ? tenant.has_bar : hasModule('bar')
   const peutModifier = isBar ? (role === 'admin' || role === 'bar') : (role === 'admin' || role === 'cuisine')

--- a/lib/useTenant.js
+++ b/lib/useTenant.js
@@ -89,7 +89,26 @@ export function TenantProvider({ children }) {
           .eq('slug', slug)
           .maybeSingle()
 
-        setTenant(withHasBar(data || null))
+        if (data) {
+          setTenant(withHasBar(data))
+          return
+        }
+
+        // Fallback: cookie tenant_slug posé par le middleware (Vercel preview, URL sans sous-domaine client).
+        const cookieSlug = document.cookie
+          .split('; ')
+          .find(r => r.startsWith('tenant_slug='))
+          ?.split('=')[1]
+        if (cookieSlug && cookieSlug !== slug) {
+          const { data: cookieData } = await supabase
+            .from('clients')
+            .select('*')
+            .eq('slug', cookieSlug)
+            .maybeSingle()
+          if (cookieData) { setTenant(withHasBar(cookieData)); return }
+        }
+
+        setTenant(null)
       } catch (err) {
         console.error('Tenant load error:', err)
       } finally {


### PR DESCRIPTION
## Problème

Les éléments de la navbar (section cuisine) n'affichaient rien quand on cliquait dessus en production. Deux bugs distincts causaient ce comportement.

## Bug 1 — Modules cuisine vides par défaut (`Navbar.jsx`)

```js
// AVANT
const modules = tenant?.modules_actifs || (isBar ? ['fiches', ...] : [])
//                                                                    ↑ cuisine → [] = bug
```

Quand `tenant.modules_actifs` est `null`/non configuré, la section bar avait une liste par défaut mais la cuisine tombait sur `[]`. Résultat : tous les items gated par `hasModule()` disparaissaient (Fiches, Sous-fiches, Contenus entier filtré), seul "Archives" restait visible.

**Fix :** ajout de `DEFAULT_CUISINE_MODULES` comme fallback, symétrique au fallback bar existant.

## Bug 2 — `useTenant.js` ignorait le cookie `tenant_slug` du middleware

Le middleware détecte correctement le tenant sur les URLs Vercel preview et pose un cookie `tenant_slug`, mais `useTenant.js` côté client utilisait uniquement `window.location.hostname` et ignorait ce cookie. Sur une URL Vercel (`ft-manager.vercel.app`), le slug résolvait vers `ft-manager` (aucun match en DB) → `tenant = null`.

**Fix :** fallback cookie après l'échec de détection par hostname.