### PR TITLE
fix: erreur hydration React #418 et CSP Axeptio

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -23,7 +23,7 @@ export default function RootLayout({ children }) {
         />
       </head>
       <body>
-        <Script id="axeptio-settings" strategy="beforeInteractive">
+        <Script id="axeptio-settings" strategy="afterInteractive">
           {`
 window.axeptioSettings = {
   clientId: "69c93192a77e258463cb2f3b",
@@ -43,7 +43,7 @@ window.axeptioSettings = {
         <Script
           id="axeptio-sdk"
           src="https://static.axept.io/sdk.js"
-          strategy="beforeInteractive"
+          strategy="afterInteractive"
         />
         <AnalyticsWrapper />
         <Providers>{children}</Providers>

--- a/middleware.js
+++ b/middleware.js
@@ -133,7 +133,7 @@ export function middleware(req) {
     [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://unpkg.com https://static.axept.io https://axept.io https://www.googletagmanager.com",
-      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net",
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net https://fonts.axept.io https://*.axept.io",
       "font-src 'self' https://fonts.gstatic.com",
       "img-src 'self' data: blob: https:",
       "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://static.axept.io https://axept.io https://*.axept.io https://cdn.jsdelivr.net https://unpkg.com https://www.google-analytics.com https://*.google-analytics.com https://analytics.google.com https://www.googletagmanager.com",


### PR DESCRIPTION
## Problème

Après le fix précédent, la navbar navigue bien (le log `navClientId` est correct) mais les pages restaient vides à cause d'une erreur React #418 visible dans la console.

## Cause

L'erreur `React #418` est une erreur d'hydration : le script Axeptio avec `strategy="beforeInteractive"` injectait son widget cookies dans le DOM **avant** que React hydrate. React constatait une divergence entre le HTML serveur et le DOM client → crash de l'hydration → toute l'app bascule en client rendering partiel et les pages n'affichent rien.

## Corrections

### `app/layout.js`
`beforeInteractive` → `afterInteractive` pour les deux scripts Axeptio. Le SDK se charge après l'hydration React, éliminant le conflit DOM.

### `middleware.js` (CSP)
Ajout de `https://fonts.axept.io` et `https://*.axept.io` dans `style-src` pour supprimer le blocage des polices Axeptio (qui causait un fallback supplémentaire vers Google Fonts et des warnings en console).