### PR TITLE
fix(csp): autoriser fonts.axept.io dans font-src

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -134,7 +134,7 @@ export function middleware(req) {
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://unpkg.com https://static.axept.io https://axept.io https://www.googletagmanager.com",
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net https://fonts.axept.io https://*.axept.io",
-      "font-src 'self' https://fonts.gstatic.com",
+      "font-src 'self' https://fonts.gstatic.com https://fonts.axept.io",
       "img-src 'self' data: blob: https:",
       "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://static.axept.io https://axept.io https://*.axept.io https://cdn.jsdelivr.net https://unpkg.com https://www.google-analytics.com https://*.google-analytics.com https://analytics.google.com https://www.googletagmanager.com",
       "frame-ancestors 'none'",


### PR DESCRIPTION
Axeptio proxifie les polices Google via `fonts.axept.io/fonts.gstatic.com/...`. La directive `font-src` n'autorisait que `fonts.gstatic.com`, bloquant toutes les polices du widget Axeptio.