### PR TITLE
fix(navigation): boutons retour reviennent à la page précédente

### DIFF
--- a/app/avis/nouveau/page.js
+++ b/app/avis/nouveau/page.js
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { theme, Logo } from '../../../lib/theme.jsx'
 import { useIsMobile } from '../../../lib/useIsMobile'
 import { useTheme } from '../../../lib/useTheme'
+import BackButton from '../../../components/BackButton'
 
 export default function NouvelAvisPage() {
   const [form, setForm] = useState({
@@ -53,10 +54,7 @@ const handleSubmit = async () => {
       }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           <Logo height={28} couleur="white" nom={nomEtablissement} onClick={() => router.push("/dashboard")} />
-          <button onClick={() => router.back()} style={{
-            background: 'transparent', border: '0.5px solid rgba(255,255,255,0.2)',
-            borderRadius: '8px', padding: '6px 10px', fontSize: '13px', cursor: 'pointer', color: 'rgba(255,255,255,0.7)'
-          }}>← Retour</button>
+          <BackButton fallback="/dashboard" />
           {!isMobile && <span style={{ fontSize: '14px', fontWeight: '500', color: 'white' }}>Nouvel avis client</span>}
         </div>
         <button onClick={handleSubmit} disabled={loading} style={{

--- a/app/bar/fiches/[id]/modifier/page.js
+++ b/app/bar/fiches/[id]/modifier/page.js
@@ -10,6 +10,7 @@ import { log } from '../../../../../lib/useLog'
 import { ALLERGENES } from '../../../../../lib/allergenes'
 import IngredientSearch from '../../../../../components/IngredientSearch'
 import ChefLoader from '../../../../../components/ChefLoader'
+import BackButton from '../../../../../components/BackButton'
 
 const CATEGORIES_ALCOOL = ['Cocktails', 'Vins', 'Champagnes', 'Bières', 'Spiritueux']
 
@@ -280,10 +281,7 @@ export default function ModifierBarFiche() {
       }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           <Logo height={28} couleur="white" nom={nomEtablissement} onClick={() => router.push("/bar/dashboard")} />
-          <button onClick={() => router.push(`/bar/fiches/${params_route.id}`)} style={{
-            background: 'transparent', border: '0.5px solid rgba(255,255,255,0.2)',
-            borderRadius: '8px', padding: '6px 10px', fontSize: '13px', cursor: 'pointer', color: 'rgba(255,255,255,0.7)'
-          }}>← Retour</button>
+          <BackButton fallback={`/bar/fiches/${params_route.id}`} />
           {!isMobile && <span style={{ fontSize: '14px', fontWeight: '500', color: 'white' }}>Modifier — {nom}</span>}
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>

--- a/app/bar/fiches/[id]/page.js
+++ b/app/bar/fiches/[id]/page.js
@@ -10,6 +10,7 @@ import { log } from '../../../../lib/useLog'
 import { ALLERGENES } from '../../../../lib/allergenes'
 import { AllergenesBlock } from '../../../../components/FicheDetailShared'
 import ChefLoader from '../../../../components/ChefLoader'
+import BackButton from '../../../../components/BackButton'
 
 export default function BarFicheDetail() {
   const [fiche, setFiche] = useState(null)
@@ -203,10 +204,7 @@ const loadFiche = async () => {
       }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           <Logo height={28} couleur="white" nom={nomEtablissement} onClick={() => router.push("/bar/dashboard")} />
-          <button onClick={() => router.push('/bar/fiches')} style={{
-            background: 'transparent', border: '0.5px solid rgba(255,255,255,0.2)',
-            borderRadius: '8px', padding: '6px 10px', fontSize: '13px', cursor: 'pointer', color: 'rgba(255,255,255,0.7)'
-          }}>← {!isMobile && 'Retour'}</button>
+          <BackButton fallback="/bar/fiches" label={isMobile ? '←' : '← Retour'} />
           {!isMobile && <span style={{ fontSize: '15px', fontWeight: '500', color: 'white' }}>{fiche.nom}</span>}
         </div>
         <div style={{ display: 'flex', gap: '6px' }}>

--- a/app/bar/fiches/nouvelle/page.js
+++ b/app/bar/fiches/nouvelle/page.js
@@ -9,6 +9,7 @@ import { useAutosave } from '../../../../lib/useAutosave'
 import { log } from '../../../../lib/useLog'
 import { ALLERGENES } from '../../../../lib/allergenes'
 import IngredientSearch from '../../../../components/IngredientSearch'
+import BackButton from '../../../../components/BackButton'
 
 const CATEGORIES_ALCOOL = ['Cocktails', 'Vins', 'Champagnes', 'Bières', 'Spiritueux']
 
@@ -254,10 +255,7 @@ export default function NouvelleBarFiche() {
       }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           <Logo height={28} couleur="white" nom={nomEtablissement} onClick={() => router.push("/bar/dashboard")} />
-          <button onClick={() => router.push('/bar/dashboard')} style={{
-            background: 'transparent', border: '0.5px solid rgba(255,255,255,0.2)',
-            borderRadius: '8px', padding: '6px 10px', fontSize: '13px', cursor: 'pointer', color: 'rgba(255,255,255,0.7)'
-          }}>← Retour</button>
+          <BackButton fallback="/bar/fiches" />
           {!isMobile && <span style={{ fontSize: '14px', fontWeight: '500', color: 'white' }}>
             {isSousFiche ? 'Nouvelle sous-fiche bar' : 'Nouvelle fiche bar'}
           </span>}

--- a/app/cartes/nouveau/page.js
+++ b/app/cartes/nouveau/page.js
@@ -6,6 +6,7 @@ import { theme, Logo } from '../../../lib/theme.jsx'
 import { useTheme } from '../../../lib/useTheme'
 import { useIsMobile } from '../../../lib/useIsMobile'
 import { log } from '../../../lib/useLog'
+import BackButton from '../../../components/BackButton'
 
 const genId = () => crypto.randomUUID()
 
@@ -249,11 +250,7 @@ export default function NouvelleCarte() {
             <Logo height={isMobile ? 26 : 30} couleur="white" nom={nomEtablissement} onClick={() => router.push('/fiches')} />
           </div>
           {!isMobile && <span style={{ color: 'rgba(255,255,255,0.3)', fontSize: '13px' }}>|</span>}
-          <button type="button" onClick={() => router.push('/cartes')} style={{
-            background: 'transparent', border: '0.5px solid rgba(255,255,255,0.2)',
-            borderRadius: '8px', padding: isMobile ? '6px 10px' : '6px 12px', fontSize: isMobile ? '12px' : '13px',
-            cursor: 'pointer', color: 'rgba(255,255,255,0.7)', flexShrink: 0,
-          }}>&larr; Retour</button>
+          <BackButton fallback="/cartes" style={{ padding: isMobile ? '6px 10px' : '6px 12px', fontSize: isMobile ? '12px' : '13px', flexShrink: 0 }} />
           <span style={{
             fontSize: isMobile ? '14px' : '15px', fontWeight: '500', color: 'white',
             minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',

--- a/app/controle-gestion/achats/[id]/page.js
+++ b/app/controle-gestion/achats/[id]/page.js
@@ -8,6 +8,7 @@ import { useTheme } from '../../../../lib/useTheme'
 import { useRole } from '../../../../lib/useRole'
 import { normDesig, makeLigneId } from '../../../../lib/achatsHelpers'
 import Navbar from '../../../../components/Navbar'
+import BackButton from '../../../../components/BackButton'
 
 function formatEuro(n) {
   if (n == null || Number.isNaN(Number(n))) return '—'
@@ -279,10 +280,11 @@ export default function AchatsDetailPage() {
 
         {/* ── Barre actions ── */}
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 8, marginBottom: 4 }}>
-          <button onClick={() => router.push('/controle-gestion/achats')}
-            style={{ background: 'transparent', border: 'none', cursor: 'pointer', color: c.texteMuted, fontSize: 13, padding: 0 }}>
-            ← Retour aux achats
-          </button>
+          <BackButton
+            fallback="/controle-gestion/achats"
+            label="← Retour aux achats"
+            style={{ background: 'transparent', border: 'none', color: c.texteMuted, fontSize: 13, padding: 0 }}
+          />
           {role === 'admin' && !loading && facture && (
             <div style={{ display: 'flex', gap: 8 }}>
               {isBl && (

--- a/app/fiches/[id]/modifier/page.js
+++ b/app/fiches/[id]/modifier/page.js
@@ -11,6 +11,7 @@ import { ALLERGENES } from '../../../../lib/allergenes'
 import IngredientSearch from '../../../../components/IngredientSearch'
 import FichePhoto from '../../../../components/FichePhoto'
 import ChefLoader from '../../../../components/ChefLoader'
+import BackButton from '../../../../components/BackButton'
 
 import { isIngredientPossible } from '../../../../lib/foodCost'
 import { UNITES_PRODUCTION } from '../../../../lib/constants'
@@ -296,10 +297,7 @@ export default function ModifierFiche() {
       }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           <Logo height={28} couleur="white" nom={nomEtablissement} onClick={() => router.push("/dashboard")} />
-          <button onClick={() => router.push(`/fiches/${params_route.id}`)} style={{
-            background: 'transparent', border: '0.5px solid rgba(255,255,255,0.2)',
-            borderRadius: '8px', padding: '6px 10px', fontSize: '13px', cursor: 'pointer', color: 'rgba(255,255,255,0.7)'
-          }}>← Retour</button>
+          <BackButton fallback={`/fiches/${params_route.id}`} />
           {!isMobile && <span style={{ fontSize: '14px', fontWeight: '500', color: 'white' }}>Modifier — {nom}</span>}
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>

--- a/app/fiches/[id]/page.js
+++ b/app/fiches/[id]/page.js
@@ -11,6 +11,7 @@ import { ALLERGENES } from '../../../lib/allergenes'
 import FichePhoto, { FicheHeaderInfo, FicheHeaderInfoStyles } from '../../../components/FichePhoto'
 import { AllergenesBlock, FicheDetailNavbar } from '../../../components/FicheDetailShared'
 import ChefLoader from '../../../components/ChefLoader'
+import BackButton from '../../../components/BackButton'
 
 export default function FicheDetail() {
   const [fiche, setFiche] = useState(null)
@@ -190,10 +191,7 @@ export default function FicheDetail() {
       }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           <Logo height={28} couleur="white" nom={nomEtablissement} onClick={() => router.push("/dashboard")} />
-          <button onClick={() => router.push('/fiches')} style={{
-            background: 'transparent', border: '0.5px solid rgba(255,255,255,0.2)',
-            borderRadius: '8px', padding: '6px 10px', fontSize: '13px', cursor: 'pointer', color: 'rgba(255,255,255,0.7)'
-          }}>← {!isMobile && 'Retour'}</button>
+          <BackButton fallback="/fiches" label={isMobile ? '←' : '← Retour'} />
           {!isMobile && <span style={{ fontSize: '15px', fontWeight: '500', color: 'white' }}>{fiche.nom}</span>}
         </div>
         <div style={{ display: 'flex', gap: '6px' }}>

--- a/app/fiches/nouvelle/page.js
+++ b/app/fiches/nouvelle/page.js
@@ -9,6 +9,7 @@ import { useAutosave } from '../../../lib/useAutosave'
 import { log } from '../../../lib/useLog'
 import { ALLERGENES } from '../../../lib/allergenes'
 import IngredientSearch from '../../../components/IngredientSearch'
+import BackButton from '../../../components/BackButton'
 
 import { isIngredientPossible } from '../../../lib/foodCost'
 import { UNITES_PRODUCTION } from '../../../lib/constants'
@@ -248,10 +249,7 @@ export default function NouvelleFiche() {
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           <Logo height={28} couleur="white" nom={nomEtablissement} onClick={() => router.push("/dashboard")} />
           {!isMobile && <span style={{ color: 'rgba(255,255,255,0.3)' }}>|</span>}
-          <button onClick={() => router.push('/dashboard')} style={{
-            background: 'transparent', border: '0.5px solid rgba(255,255,255,0.2)',
-            borderRadius: '8px', padding: '6px 10px', fontSize: '13px', cursor: 'pointer', color: 'rgba(255,255,255,0.7)'
-          }}>← Retour</button>
+          <BackButton fallback="/fiches" />
           {!isMobile && <span style={{ fontSize: '14px', fontWeight: '500', color: 'white' }}>{isSousFiche ? 'Nouvelle sous-fiche' : 'Nouvelle fiche technique'}</span>}
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>

--- a/app/menus/[id]/page.js
+++ b/app/menus/[id]/page.js
@@ -7,6 +7,7 @@ import { useTheme } from '../../../lib/useTheme'
 import { useIsMobile } from '../../../lib/useIsMobile'
 import { log } from '../../../lib/useLog'
 import ChefLoader from '../../../components/ChefLoader'
+import BackButton from '../../../components/BackButton'
 
 export default function MenuDetail() {
   const { nomEtablissement } = useTheme()
@@ -185,11 +186,7 @@ useEffect(() => {
         <div style={{ display: 'flex', alignItems: 'center', gap: isMobile ? '8px' : '12px', minWidth: 0, flex: '1 1 auto', overflow: 'hidden' }}>
           <Logo height={28} couleur="white" nom={nomEtablissement} onClick={() => router.push('/fiches')} />
           {!isMobile && <span style={{ color: 'rgba(255,255,255,0.3)', flexShrink: 0 }}>|</span>}
-          <button onClick={() => router.push('/menus')} style={{
-            background: 'transparent', border: '0.5px solid rgba(255,255,255,0.2)',
-            borderRadius: '8px', padding: isMobile ? '5px 8px' : '6px 12px', fontSize: '13px',
-            cursor: 'pointer', color: 'rgba(255,255,255,0.7)', flexShrink: 0,
-          }}>← Retour</button>
+          <BackButton fallback="/menus" style={{ padding: isMobile ? '5px 8px' : '6px 12px', flexShrink: 0 }} />
           <span style={{
             fontSize: '14px', fontWeight: '500', color: 'white',
             overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',

--- a/app/menus/nouveau/page.js
+++ b/app/menus/nouveau/page.js
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { theme, Logo } from '../../../lib/theme.jsx'
 import { useTheme } from '../../../lib/useTheme'
 import { log } from '../../../lib/useLog'
+import BackButton from '../../../components/BackButton'
 
 export default function NouveauMenu() {
   const { nomEtablissement } = useTheme()
@@ -135,11 +136,7 @@ export default function NouveauMenu() {
         <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
           <Logo height={30} couleur="white" nom={nomEtablissement} onClick={() => router.push("/fiches")} />
           <span style={{ color: 'rgba(255,255,255,0.3)', fontSize: '13px' }}>|</span>
-          <button onClick={() => router.push('/menus')} style={{
-            background: 'transparent', border: '0.5px solid rgba(255,255,255,0.2)',
-            borderRadius: '8px', padding: '6px 12px', fontSize: '13px',
-            cursor: 'pointer', color: 'rgba(255,255,255,0.7)'
-          }}>← Retour</button>
+          <BackButton fallback="/menus" style={{ padding: '6px 12px' }} />
           <span style={{ fontSize: '15px', fontWeight: '500', color: 'white' }}>Nouveau menu</span>
         </div>
         <button onClick={handleSubmit} disabled={loading} style={{

--- a/app/mon-compte/page.js
+++ b/app/mon-compte/page.js
@@ -7,6 +7,7 @@ import { useRole } from '../../lib/useRole'
 import { useIsMobile } from '../../lib/useIsMobile'
 import { Logo } from '../../lib/theme.jsx'
 import ChefLoader from '../../components/ChefLoader'
+import BackButton from '../../components/BackButton'
 
 const TABS = [
   { id: 'profil',        label: 'Mon Profil' },
@@ -257,10 +258,7 @@ export default function MonCompte() {
       }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
           <Logo height={28} couleur="white" nom={nomEtablissement} onClick={() => router.push('/dashboard')} />
-          <button onClick={() => router.back()} style={{
-            background: 'transparent', border: '0.5px solid rgba(255,255,255,0.2)',
-            borderRadius: '8px', padding: '6px 10px', fontSize: '13px', cursor: 'pointer', color: 'rgba(255,255,255,0.7)',
-          }}>← Retour</button>
+          <BackButton fallback="/dashboard" />
           {!isMobile && <span style={{ fontSize: '15px', fontWeight: '500', color: 'white' }}>Mon Compte</span>}
         </div>
       </div>

--- a/components/BackButton.jsx
+++ b/components/BackButton.jsx
@@ -1,0 +1,60 @@
+'use client'
+import { useRouter } from 'next/navigation'
+
+/**
+ * BackButton — bouton retour intelligent.
+ *
+ * Comportement :
+ *  - Si au moins une navigation interne a eu lieu dans la session courante,
+ *    exécute `router.back()` (retour vers la page précédemment consultée).
+ *  - Sinon (arrivée directe sur la page, refresh, lien externe),
+ *    redirige vers la route de fallback (par défaut `/dashboard`).
+ *
+ * Le flag `skalcook:hasInternalNav` est posé par `<NavigationTracker />`
+ * monté dans `components/Providers.jsx`.
+ */
+export default function BackButton({
+  fallback = '/dashboard',
+  label = '← Retour',
+  style,
+  className,
+}) {
+  const router = useRouter()
+
+  const handleClick = () => {
+    let hasInternalNav = false
+    try {
+      hasInternalNav =
+        typeof window !== 'undefined' &&
+        window.sessionStorage.getItem('skalcook:hasInternalNav') === '1'
+    } catch {
+      // sessionStorage indisponible (mode privé strict) → fallback
+    }
+
+    if (hasInternalNav) {
+      router.back()
+    } else {
+      router.push(fallback)
+    }
+  }
+
+  const defaultStyle = {
+    background: 'transparent',
+    border: '0.5px solid rgba(255,255,255,0.2)',
+    borderRadius: '8px',
+    padding: '6px 10px',
+    fontSize: '13px',
+    cursor: 'pointer',
+    color: 'rgba(255,255,255,0.7)',
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      className={className}
+      style={{ ...defaultStyle, ...style }}
+    >
+      {label}
+    </button>
+  )
+}

--- a/components/NavigationTracker.jsx
+++ b/components/NavigationTracker.jsx
@@ -1,0 +1,32 @@
+'use client'
+import { useEffect, useRef } from 'react'
+import { usePathname } from 'next/navigation'
+
+/**
+ * NavigationTracker — pose un flag en sessionStorage dès qu'une navigation
+ * interne a eu lieu dans l'app. Consommé par `<BackButton />` pour décider
+ * entre `router.back()` et un fallback.
+ *
+ * Le premier rendu (chargement initial de la page) n'est pas compté comme
+ * une navigation interne : ainsi, si l'utilisateur arrive directement sur
+ * une page (lien externe, refresh, nouvel onglet), le flag reste à 0 et le
+ * bouton retour utilise son fallback contextuel.
+ */
+export default function NavigationTracker() {
+  const pathname = usePathname()
+  const isFirstRender = useRef(true)
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    try {
+      sessionStorage.setItem('skalcook:hasInternalNav', '1')
+    } catch {
+      // sessionStorage indisponible → on ignore silencieusement
+    }
+  }, [pathname])
+
+  return null
+}

--- a/components/Providers.jsx
+++ b/components/Providers.jsx
@@ -1,9 +1,11 @@
 'use client'
 import { TenantProvider } from '../lib/useTenant'
+import NavigationTracker from './NavigationTracker'
 
 export default function Providers({ children }) {
   return (
     <TenantProvider>
+      <NavigationTracker />
       {children}
     </TenantProvider>
   )


### PR DESCRIPTION
## Summary
- Composant partagé `<BackButton>` qui utilise `router.back()` si navigation interne détectée, sinon fallback contextuel
- `<NavigationTracker />` monté dans Providers pose un flag en sessionStorage dès la première navigation interne
- 12 pages migrées — les boutons retour ne tombent plus systématiquement sur `/dashboard`

## Problème résolu
Les boutons retour renvoyaient quasi-systématiquement au `/dashboard` via des `router.push('/dashboard')` codés en dur, même quand l'utilisateur venait d'ouvrir une fiche depuis `/fiches`. Friction UX importante.

## Comportement nouveau
- Si navigation interne dans l'app → `router.back()` (retour réel à la page précédemment vue)
- Si arrivée directe (lien externe, refresh, nouvel onglet) → fallback contextuel par section :
  - `/fiches/[id]` et `/fiches/nouvelle` → `/fiches`
  - `/bar/fiches/*` → `/bar/fiches`
  - `/menus/*` → `/menus`
  - `/cartes/nouveau` → `/cartes`
  - `/controle-gestion/achats/[id]` → `/controle-gestion/achats`
  - `/mon-compte`, `/avis/nouveau` → `/dashboard`

## Pages non modifiées
- `superadmin/*` : retour vers `/superadmin` est déjà correct + loader custom à préserver
- `inventaire/nouveau` : logique conditionnelle d'étapes
- `reset-password`, `nouveau-mot-de-passe` : liens "Retour à la connexion" contextuels

## Test plan
- [ ] Ouvrir `/fiches` → cliquer une fiche → cliquer "Modifier" → cliquer "← Retour" : doit revenir sur la fiche (pas sur `/fiches`)
- [ ] Ouvrir directement `/fiches/[id]` dans un nouvel onglet → cliquer "← Retour" : doit fallback sur `/fiches`
- [ ] Même test côté bar (`/bar/fiches/*`), menus, cartes
- [ ] Vérifier qu'aucune régression sur les pages non migrées (superadmin, inventaire, reset password)

🤖 Generated with [Claude Code](https://claude.com/claude-code)