### PR TITLE
refactor(ui): extract Card/Button/Alert primitives from inline styles

### DIFF
--- a/app/admin/page.js
+++ b/app/admin/page.js
@@ -9,6 +9,7 @@ import { useRole } from '../../lib/useRole'
 import { isSuperadminEmail } from '../../lib/superadmin'
 import Navbar from '../../components/Navbar'
 import ChefLoader from '../../components/ChefLoader'
+import { Alert } from '../../components/ui'
 
 export default function AdminPage() {
   const [profils, setProfils] = useState([])
@@ -256,15 +257,15 @@ export default function AdminPage() {
           </div>
 
           {error && (
-            <div style={{ background: '#FCEBEB', color: '#A32D2D', borderRadius: '8px', padding: '12px', fontSize: '13px', marginBottom: '12px', border: '0.5px solid #F09595' }}>
+            <Alert variant="error" style={{ marginBottom: '12px' }}>
               {error}
-            </div>
+            </Alert>
           )}
 
           {success && (
-            <div style={{ background: '#EAF3DE', color: '#3B6D11', borderRadius: '8px', padding: '12px', fontSize: '13px', marginBottom: '12px', border: '0.5px solid #4A7B6F40' }}>
+            <Alert variant="success" style={{ marginBottom: '12px' }}>
               ✓ {success}
-            </div>
+            </Alert>
           )}
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>

--- a/app/avis/nouveau/page.js
+++ b/app/avis/nouveau/page.js
@@ -6,6 +6,7 @@ import { theme, Logo } from '../../../lib/theme.jsx'
 import { useIsMobile } from '../../../lib/useIsMobile'
 import { useTheme } from '../../../lib/useTheme'
 import BackButton from '../../../components/BackButton'
+import { Alert, Card } from '../../../components/ui'
 
 export default function NouvelAvisPage() {
   const [form, setForm] = useState({
@@ -67,10 +68,10 @@ const handleSubmit = async () => {
 
       <div style={{ padding: isMobile ? '12px' : '24px', maxWidth: '700px', margin: '0 auto' }}>
 
-        {error && <div style={{ background: '#FCEBEB', color: '#A32D2D', borderRadius: '8px', padding: '12px 16px', fontSize: '13px', marginBottom: '16px' }}>{error}</div>}
+        {error && <Alert variant="error" style={{ marginBottom: '16px' }}>{error}</Alert>}
 
         {/* Établissement */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <div style={{ fontSize: '13px', fontWeight: '500', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '14px' }}>Établissement</div>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
             {[
@@ -87,10 +88,10 @@ const handleSubmit = async () => {
               }}>{opt.label}</div>
             ))}
           </div>
-        </div>
+        </Card>
 
         {/* Informations */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <div style={{ fontSize: '13px', fontWeight: '500', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '14px' }}>Informations</div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
             <div>
@@ -115,10 +116,10 @@ const handleSubmit = async () => {
               </div>
             </div>
           </div>
-        </div>
+        </Card>
 
         {/* Texte de l'avis */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <div style={{ fontSize: '13px', fontWeight: '500', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '14px' }}>Texte de l'avis *</div>
           <textarea value={form.review_text} onChange={e => set('review_text', e.target.value)}
             placeholder="Collez ici l'avis du client (dans n'importe quelle langue — la réponse sera générée dans la même langue)..."
@@ -128,10 +129,10 @@ const handleSubmit = async () => {
           <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '6px' }}>
             La réponse IA sera générée automatiquement dans la langue de l'avis
           </div>
-        </div>
+        </Card>
 
         {/* Sentiment manuel optionnel */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}` }}>
+        <Card c={c}>
           <div style={{ fontSize: '13px', fontWeight: '500', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '14px' }}>Sentiment <span style={{ fontWeight: '400', textTransform: 'none', fontSize: '11px' }}>(optionnel — calculé automatiquement si vide)</span></div>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '10px' }}>
             {[
@@ -148,7 +149,7 @@ const handleSubmit = async () => {
               }}>{opt.label}</div>
             ))}
           </div>
-        </div>
+        </Card>
       </div>
     </div>
   )

--- a/app/bar/fiches/[id]/modifier/page.js
+++ b/app/bar/fiches/[id]/modifier/page.js
@@ -11,6 +11,7 @@ import { ALLERGENES } from '../../../../../lib/allergenes'
 import IngredientSearch from '../../../../../components/IngredientSearch'
 import ChefLoader from '../../../../../components/ChefLoader'
 import BackButton from '../../../../../components/BackButton'
+import { Alert, Card } from '../../../../../components/ui'
 
 const CATEGORIES_ALCOOL = ['Cocktails', 'Vins', 'Champagnes', 'Bières', 'Spiritueux']
 
@@ -308,14 +309,14 @@ export default function ModifierBarFiche() {
           </div>
         )}
 
-        {error && <div style={{ background: '#FCEBEB', color: '#A32D2D', borderRadius: '8px', padding: '12px 16px', fontSize: '13px', marginBottom: '16px' }}>{error}</div>}
+        {error && <Alert variant="error" style={{ marginBottom: '16px' }}>{error}</Alert>}
 
         <div style={{ background: isAlcool ? '#FCEBEB' : '#EAF3DE', borderRadius: '8px', padding: '10px 14px', fontSize: '12px', marginBottom: '16px', border: `0.5px solid ${isAlcool ? '#F09595' : '#4A7B6F40'}`, color: isAlcool ? '#A32D2D' : '#3B6D11' }}>
           {isAlcool ? '🍷 TVA Alcool : 20%' : '🥤 TVA Sans alcool : 10%'}
         </div>
 
         {/* Infos générales */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <div style={{ fontSize: '13px', fontWeight: '500', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '14px' }}>Informations générales</div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
             <div>
@@ -390,10 +391,10 @@ export default function ModifierBarFiche() {
               />
             </div>
           </div>
-        </div>
+        </Card>
 
         {/* Ingrédients */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <div style={{ fontSize: '13px', fontWeight: '500', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '14px' }}>Ingrédients</div>
           {isMobile ? (
             <>
@@ -450,10 +451,10 @@ export default function ModifierBarFiche() {
           <button onClick={ajouterIngredient} style={{ background: '#EEEDFE', color: '#3C3489', border: '0.5px solid #AFA9EC', borderRadius: '8px', padding: '10px 16px', fontSize: '13px', cursor: 'pointer', marginTop: '8px', width: isMobile ? '100%' : 'auto' }}>
             + Ajouter un ingrédient
           </button>
-        </div>
+        </Card>
 
         {/* Instructions */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <div style={{ fontSize: '13px', fontWeight: '500', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '6px' }}>📋 Instructions de préparation</div>
           <div style={{ fontSize: '12px', color: c.texteMuted, marginBottom: '12px' }}>Les sauts de ligne seront respectés à l'écran et à l'impression.</div>
           <textarea value={instructions} onChange={e => setInstructions(e.target.value)} rows={8}
@@ -465,10 +466,10 @@ export default function ModifierBarFiche() {
               {instructions.split('\n').length} ligne{instructions.split('\n').length > 1 ? 's' : ''} — {instructions.length} caractères
             </div>
           )}
-        </div>
+        </Card>
 
         {/* Allergènes */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <div style={{ fontSize: '13px', fontWeight: '500', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '14px' }}>Allergènes</div>
           <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : 'repeat(auto-fill, minmax(200px, 1fr))', gap: '8px' }}>
             {ALLERGENES.map(a => (
@@ -484,7 +485,7 @@ export default function ModifierBarFiche() {
               {allergenes.length} allergène{allergenes.length > 1 ? 's' : ''} : {allergenes.map(id => ALLERGENES.find(a => a.id === id)?.label).join(', ')}
             </div>
           )}
-        </div>
+        </Card>
 
         {/* Récapitulatif */}
         <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '20px', border: `0.5px solid ${c.bordure}`, display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : 'repeat(auto-fit, minmax(140px, 1fr))', gap: '10px' }}>

--- a/app/bar/fiches/[id]/page.js
+++ b/app/bar/fiches/[id]/page.js
@@ -11,6 +11,7 @@ import { ALLERGENES } from '../../../../lib/allergenes'
 import { AllergenesBlock } from '../../../../components/FicheDetailShared'
 import ChefLoader from '../../../../components/ChefLoader'
 import BackButton from '../../../../components/BackButton'
+import { Card } from '../../../../components/ui'
 
 export default function BarFicheDetail() {
   const [fiche, setFiche] = useState(null)
@@ -233,7 +234,7 @@ const loadFiche = async () => {
       <div className="no-print" style={{ padding: isMobile ? '12px' : '24px', maxWidth: '800px', margin: '0 auto' }}>
 
         {/* Infos générales */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '12px' }}>
             <div style={{ flex: 1 }}>
               <h1 style={{ fontSize: isMobile ? '18px' : '22px', fontWeight: '500', marginBottom: '8px', color: c.texte }}>{fiche.nom}</h1>
@@ -251,7 +252,7 @@ const loadFiche = async () => {
             <p style={{ fontSize: '14px', color: c.texteMuted, lineHeight: '1.6', marginTop: '8px' }}>{fiche.description}</p>
           )}
           <AllergenesBlock allergenes={fiche.allergenes} allergenesCascade={allergenesCascade} c={c} />
-        </div>
+        </Card>
 
         {/* Ingrédients */}
         <div style={{ background: c.blanc, borderRadius: '12px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px', overflow: 'hidden' }}>

--- a/app/bar/fiches/nouvelle/page.js
+++ b/app/bar/fiches/nouvelle/page.js
@@ -10,6 +10,7 @@ import { log } from '../../../../lib/useLog'
 import { ALLERGENES } from '../../../../lib/allergenes'
 import IngredientSearch from '../../../../components/IngredientSearch'
 import BackButton from '../../../../components/BackButton'
+import { Alert, Card } from '../../../../components/ui'
 
 const CATEGORIES_ALCOOL = ['Cocktails', 'Vins', 'Champagnes', 'Bières', 'Spiritueux']
 
@@ -287,14 +288,14 @@ export default function NouvelleBarFiche() {
           </div>
         )}
 
-        {error && <div style={{ background: '#FCEBEB', color: '#A32D2D', borderRadius: '8px', padding: '12px 16px', fontSize: '13px', marginBottom: '16px' }}>{error}</div>}
+        {error && <Alert variant="error" style={{ marginBottom: '16px' }}>{error}</Alert>}
 
         <div style={{ background: isAlcool ? '#FCEBEB' : '#EAF3DE', borderRadius: '8px', padding: '10px 14px', fontSize: '12px', marginBottom: '16px', border: `0.5px solid ${isAlcool ? '#F09595' : '#4A7B6F40'}`, color: isAlcool ? '#A32D2D' : '#3B6D11' }}>
           {isAlcool ? '🍷 TVA Alcool : 20%' : '🥤 TVA Sans alcool : 10%'}
         </div>
 
         {/* Informations générales */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <div style={{ fontSize: '13px', fontWeight: '500', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '14px' }}>Informations générales</div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
             <div>
@@ -376,10 +377,10 @@ export default function NouvelleBarFiche() {
               />
             </div>
           </div>
-        </div>
+        </Card>
 
         {/* Ingrédients */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <div style={{ fontSize: '13px', fontWeight: '500', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '14px' }}>Ingrédients & Préparations</div>
           {isMobile ? (
             <>
@@ -436,10 +437,10 @@ export default function NouvelleBarFiche() {
           <button onClick={ajouterIngredient} style={{ background: '#EEEDFE', color: '#3C3489', border: '0.5px solid #AFA9EC', borderRadius: '8px', padding: '10px 16px', fontSize: '13px', cursor: 'pointer', marginTop: '8px', width: isMobile ? '100%' : 'auto' }}>
             + Ajouter un ingrédient
           </button>
-        </div>
+        </Card>
 
         {/* Allergènes */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <div style={{ fontSize: '13px', fontWeight: '500', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '14px' }}>Allergènes</div>
           <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : 'repeat(auto-fill, minmax(200px, 1fr))', gap: '8px' }}>
             {ALLERGENES.map(a => (
@@ -455,7 +456,7 @@ export default function NouvelleBarFiche() {
               {allergenes.length} allergène{allergenes.length > 1 ? 's' : ''} : {allergenes.map(id => ALLERGENES.find(a => a.id === id)?.label).join(', ')}
             </div>
           )}
-        </div>
+        </Card>
 
         {/* Récapitulatif */}
         <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '20px', border: `0.5px solid ${c.bordure}`, display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : 'repeat(auto-fit, minmax(140px, 1fr))', gap: '12px' }}>

--- a/app/cartes/[id]/page.js
+++ b/app/cartes/[id]/page.js
@@ -8,6 +8,7 @@ import { useIsMobile } from '../../../lib/useIsMobile'
 import { log } from '../../../lib/useLog'
 import { ALLERGENES } from '../../../lib/allergenes'
 import ChefLoader from '../../../components/ChefLoader'
+import { Alert } from '../../../components/ui'
 
 const genId = () => crypto.randomUUID()
 
@@ -394,9 +395,9 @@ export default function CarteDetailPage() {
       <div className="no-print" style={{ padding: isMobile ? '12px' : '24px', maxWidth: '900px', margin: '0 auto' }}>
 
         {error && (
-          <div style={{ background: '#FCEBEB', color: '#A32D2D', borderRadius: '8px', padding: '12px 16px', fontSize: '13px', marginBottom: '20px' }}>
+          <Alert variant="error" style={{ marginBottom: '20px' }}>
             {error}
-          </div>
+          </Alert>
         )}
 
         {/* ── Mode Vue ── */}

--- a/app/cartes/nouveau/page.js
+++ b/app/cartes/nouveau/page.js
@@ -7,6 +7,7 @@ import { useTheme } from '../../../lib/useTheme'
 import { useIsMobile } from '../../../lib/useIsMobile'
 import { log } from '../../../lib/useLog'
 import BackButton from '../../../components/BackButton'
+import { Alert } from '../../../components/ui'
 
 const genId = () => crypto.randomUUID()
 
@@ -271,9 +272,9 @@ export default function NouvelleCarte() {
       <div style={{ padding: isMobile ? '12px' : '24px', maxWidth: '900px', margin: '0 auto' }}>
 
         {error && (
-          <div style={{ background: '#FCEBEB', color: '#A32D2D', borderRadius: '8px', padding: '12px 16px', fontSize: '13px', marginBottom: '20px' }}>
+          <Alert variant="error" style={{ marginBottom: '20px' }}>
             {error}
-          </div>
+          </Alert>
         )}
 
         {/* Informations */}

--- a/app/fiches/[id]/modifier/page.js
+++ b/app/fiches/[id]/modifier/page.js
@@ -12,6 +12,7 @@ import IngredientSearch from '../../../../components/IngredientSearch'
 import FichePhoto from '../../../../components/FichePhoto'
 import ChefLoader from '../../../../components/ChefLoader'
 import BackButton from '../../../../components/BackButton'
+import { Card, Alert } from '../../../../components/ui'
 
 import { isIngredientPossible } from '../../../../lib/foodCost'
 import { UNITES_PRODUCTION } from '../../../../lib/constants'
@@ -324,10 +325,10 @@ export default function ModifierFiche() {
           </div>
         )}
 
-        {error && <div style={{ background: '#FCEBEB', color: '#A32D2D', borderRadius: '8px', padding: '12px 16px', fontSize: '13px', marginBottom: '16px' }}>{error}</div>}
+        {error && <Alert variant="error" style={{ marginBottom: '16px' }}>{error}</Alert>}
 
         {/* Informations générales */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <div style={{ fontSize: '13px', fontWeight: '500', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '14px' }}>Informations générales</div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
             <div>
@@ -416,7 +417,7 @@ export default function ModifierFiche() {
               />
             </div>
           </div>
-        </div>
+        </Card>
 
         {/* Photo */}
         {clientId && (
@@ -434,7 +435,7 @@ export default function ModifierFiche() {
         )}
 
         {/* Ingrédients */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <div style={{ fontSize: '13px', fontWeight: '500', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '14px' }}>Ingrédients</div>
           {isMobile ? (
             <>
@@ -491,10 +492,10 @@ export default function ModifierFiche() {
           <button onClick={ajouterIngredient} style={{ background: c.vertClair, color: c.vert, border: `0.5px solid ${c.vert}40`, borderRadius: '8px', padding: '10px 16px', fontSize: '13px', cursor: 'pointer', marginTop: '8px', width: isMobile ? '100%' : 'auto' }}>
             + Ajouter un ingrédient
           </button>
-        </div>
+        </Card>
 
         {/* Instructions */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <div style={{ fontSize: '13px', fontWeight: '500', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '6px' }}>📋 Instructions de préparation</div>
           <div style={{ fontSize: '12px', color: c.texteMuted, marginBottom: '12px' }}>Les sauts de ligne seront respectés à l'écran et à l'impression.</div>
           <textarea value={instructions} onChange={e => setInstructions(e.target.value)} rows={8}
@@ -506,10 +507,10 @@ export default function ModifierFiche() {
               {instructions.split('\n').length} ligne{instructions.split('\n').length > 1 ? 's' : ''} — {instructions.length} caractères
             </div>
           )}
-        </div>
+        </Card>
 
         {/* Allergènes */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <div style={{ fontSize: '13px', fontWeight: '500', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '14px' }}>Allergènes</div>
           <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : 'repeat(auto-fill, minmax(200px, 1fr))', gap: '8px' }}>
             {ALLERGENES.map(a => (
@@ -521,11 +522,11 @@ export default function ModifierFiche() {
             ))}
           </div>
           {allergenes.length > 0 && (
-            <div style={{ marginTop: '12px', padding: '10px 14px', background: '#FCEBEB', borderRadius: '8px', fontSize: '12px', color: '#A32D2D', border: '0.5px solid #F09595' }}>
+            <Alert variant="error" style={{ marginTop: '12px', fontSize: '12px' }}>
               {allergenes.length} allergène{allergenes.length > 1 ? 's' : ''} : {allergenes.map(id => ALLERGENES.find(a => a.id === id)?.label).join(', ')}
-            </div>
+            </Alert>
           )}
-        </div>
+        </Card>
 
         {/* Récapitulatif */}
         <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '20px', border: `0.5px solid ${c.bordure}`, display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : 'repeat(auto-fit, minmax(140px, 1fr))', gap: '10px' }}>

--- a/app/fiches/[id]/page.js
+++ b/app/fiches/[id]/page.js
@@ -12,6 +12,7 @@ import FichePhoto, { FicheHeaderInfo, FicheHeaderInfoStyles } from '../../../com
 import { AllergenesBlock, FicheDetailNavbar } from '../../../components/FicheDetailShared'
 import ChefLoader from '../../../components/ChefLoader'
 import BackButton from '../../../components/BackButton'
+import { Card } from '../../../components/ui'
 
 export default function FicheDetail() {
   const [fiche, setFiche] = useState(null)
@@ -220,7 +221,7 @@ export default function FicheDetail() {
       <div className="no-print" style={{ padding: isMobile ? '12px' : '24px', maxWidth: '800px', margin: '0 auto' }}>
 
         {/* Infos générales */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <h1 style={{ fontSize: isMobile ? '18px' : '22px', fontWeight: '500', marginBottom: '10px', color: c.texte, width: '100%' }}>{fiche.nom}</h1>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '14px', flexWrap: 'wrap', gap: '10px' }}>
             <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap', flex: '1 1 auto', minWidth: 0 }}>
@@ -264,7 +265,7 @@ export default function FicheDetail() {
               Supprimer cette fiche
             </button>
           )}
-        </div>
+        </Card>
 
         {/* Ingrédients */}
         <div className="fiche-ingredients-after-header" style={{ background: c.blanc, borderRadius: '12px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px', overflow: 'hidden' }}>

--- a/app/fiches/nouvelle/page.js
+++ b/app/fiches/nouvelle/page.js
@@ -13,6 +13,7 @@ import BackButton from '../../../components/BackButton'
 
 import { isIngredientPossible } from '../../../lib/foodCost'
 import { UNITES_PRODUCTION } from '../../../lib/constants'
+import { Alert, Card } from '../../../components/ui'
 
 export default function NouvelleFiche() {
   const [nom, setNom] = useState('')
@@ -284,7 +285,7 @@ export default function NouvelleFiche() {
           </div>
         )}
 
-        {error && <div style={{ background: '#FCEBEB', color: '#A32D2D', borderRadius: '8px', padding: '12px 16px', fontSize: '13px', marginBottom: '16px' }}>{error}</div>}
+        {error && <Alert variant="error" style={{ marginBottom: '16px' }}>{error}</Alert>}
 
         {isSousFiche && (
           <div style={{ background: c.violetClair, color: '#3C3489', borderRadius: '8px', padding: '10px 14px', fontSize: '13px', marginBottom: '16px', display: 'flex', alignItems: 'center', gap: '8px', border: '0.5px solid #AFA9EC' }}>
@@ -387,7 +388,7 @@ export default function NouvelleFiche() {
         </div>
 
         {/* Ingrédients */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <div style={{ fontSize: '13px', fontWeight: '500', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '14px' }}>Ingrédients</div>
           {isMobile ? (
             <>
@@ -444,10 +445,10 @@ export default function NouvelleFiche() {
           <button onClick={ajouterIngredient} style={{ background: c.vertClair, color: c.vert, border: `0.5px solid ${c.vert}40`, borderRadius: '8px', padding: '10px 16px', fontSize: '13px', cursor: 'pointer', marginTop: '8px', width: isMobile ? '100%' : 'auto' }}>
             + Ajouter un ingrédient
           </button>
-        </div>
+        </Card>
 
         {/* Allergènes */}
-        <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}`, marginBottom: '12px' }}>
+        <Card c={c} style={{ marginBottom: '12px' }}>
           <div style={{ fontSize: '13px', fontWeight: '500', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '14px' }}>Allergènes</div>
           <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : 'repeat(auto-fill, minmax(200px, 1fr))', gap: '8px' }}>
             {ALLERGENES.map(a => (
@@ -463,7 +464,7 @@ export default function NouvelleFiche() {
               {allergenes.length} allergène{allergenes.length > 1 ? 's' : ''} : {allergenes.map(id => ALLERGENES.find(a => a.id === id)?.label).join(', ')}
             </div>
           )}
-        </div>
+        </Card>
 
         {/* Récapitulatif */}
         <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '20px', border: `0.5px solid ${c.bordure}`, display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : 'repeat(auto-fit, minmax(140px, 1fr))', gap: '12px' }}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -51,3 +51,149 @@ body {
     visibility: hidden !important;
   }
 }
+
+/* ──────────────────────────────────────────────────────────────
+ * Design tokens Skalcook
+ *
+ * 2 familles :
+ *  - STRUCTUREL (radius, spacing, typo, border) : totalement statique
+ *  - SÉMANTIQUE FIXE (rouge/vert/orange/bleu) : indépendant du branding client
+ *
+ * Les couleurs dynamiques (c.accent, c.principal, c.fond, c.blanc, c.bordure,
+ * c.texte, c.texteMuted) restent servies par useTheme() et passées en props
+ * aux primitives, car elles dépendent du branding client et du dark mode.
+ * ────────────────────────────────────────────────────────────── */
+
+:root {
+  /* — Radius — */
+  --sk-radius-sm: 6px;
+  --sk-radius-md: 8px;
+  --sk-radius-lg: 12px;
+  --sk-radius-xl: 16px;
+  --sk-radius-pill: 20px;
+
+  /* — Spacing (padding interne) — */
+  --sk-pad-xs: 8px;
+  --sk-pad-sm: 12px;
+  --sk-pad-md: 16px;
+  --sk-pad-lg: 24px;
+
+  /* — Typo — */
+  --sk-fs-xs: 10px;
+  --sk-fs-sm: 12px;
+  --sk-fs-md: 13px;
+  --sk-fs-lg: 15px;
+  --sk-fs-xl: 18px;
+  --sk-fw-med: 500;
+  --sk-fw-bold: 600;
+
+  /* — Bordure fine récurrente — */
+  --sk-border-hair: 0.5px;
+
+  /* — Couleurs sémantiques fixes (non impactées par le branding) — */
+  --sk-rouge: #DC2626;
+  --sk-rouge-clair: #FCEBEB;
+  --sk-rouge-bord: #F09595;
+  --sk-rouge-texte: #A32D2D;
+
+  --sk-orange: #D97706;
+  --sk-orange-clair: #FAEEDA;
+  --sk-orange-bord: #F0C595;
+  --sk-orange-texte: #854F0B;
+
+  --sk-vert: #16A34A;
+  --sk-vert-clair: #EAF3DE;
+  --sk-vert-bord: #B5D095;
+  --sk-vert-texte: #3B6D11;
+
+  --sk-bleu: #6366F1;
+  --sk-bleu-clair: #EEF2FF;
+  --sk-bleu-bord: #C7CFFB;
+  --sk-bleu-texte: #3730A3;
+}
+
+/* ──────────────────────────────────────────────────────────────
+ * Primitives UI (Card, Button, Alert)
+ * Consomment les tokens ci-dessus.
+ * ────────────────────────────────────────────────────────────── */
+
+/* ─── Card ─── */
+.sk-card {
+  border-radius: var(--sk-radius-lg);
+  /* background + border color sont injectés via style={} (branding dépendant) */
+}
+.sk-card--pad-sm { padding: var(--sk-pad-sm); }
+.sk-card--pad-md { padding: var(--sk-pad-md); }
+.sk-card--pad-lg { padding: var(--sk-pad-lg); }
+.sk-card--pad-responsive { padding: var(--sk-pad-md); }
+@media (min-width: 768px) {
+  .sk-card--pad-responsive { padding: var(--sk-pad-lg); }
+}
+
+/* ─── Button ─── */
+.sk-btn {
+  border: none;
+  border-radius: var(--sk-radius-md);
+  padding: 9px 18px;
+  font-size: var(--sk-fs-md);
+  font-weight: var(--sk-fw-bold);
+  cursor: pointer;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.sk-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.sk-btn--ghost {
+  background: transparent;
+  border: var(--sk-border-hair) solid transparent;
+  font-weight: var(--sk-fw-med);
+}
+.sk-btn--danger {
+  background: transparent;
+  color: var(--sk-rouge-texte);
+  border: var(--sk-border-hair) solid var(--sk-rouge-bord);
+  font-weight: var(--sk-fw-med);
+}
+.sk-btn--danger-solid {
+  background: var(--sk-rouge-texte);
+  color: #fff;
+}
+.sk-btn--sm { padding: 6px 10px; font-size: var(--sk-fs-md); font-weight: var(--sk-fw-med); }
+
+/* ─── Alert ─── */
+.sk-alert {
+  border-radius: var(--sk-radius-md);
+  padding: var(--sk-pad-sm);
+  border-width: var(--sk-border-hair);
+  border-style: solid;
+  font-size: var(--sk-fs-md);
+}
+.sk-alert--error {
+  background: var(--sk-rouge-clair);
+  border-color: var(--sk-rouge-bord);
+  color: var(--sk-rouge-texte);
+}
+.sk-alert--warn {
+  background: var(--sk-orange-clair);
+  border-color: var(--sk-orange-bord);
+  color: var(--sk-orange-texte);
+}
+.sk-alert--success {
+  background: var(--sk-vert-clair);
+  border-color: var(--sk-vert-bord);
+  color: var(--sk-vert-texte);
+}
+.sk-alert--info {
+  background: var(--sk-bleu-clair);
+  border-color: var(--sk-bleu-bord);
+  color: var(--sk-bleu-texte);
+}
+.sk-alert__title {
+  font-size: var(--sk-fs-xs);
+  font-weight: var(--sk-fw-med);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: var(--sk-pad-xs);
+}

--- a/app/mon-compte/page.js
+++ b/app/mon-compte/page.js
@@ -8,6 +8,7 @@ import { useIsMobile } from '../../lib/useIsMobile'
 import { Logo } from '../../lib/theme.jsx'
 import ChefLoader from '../../components/ChefLoader'
 import BackButton from '../../components/BackButton'
+import { Card, Button, Alert } from '../../components/ui'
 
 const TABS = [
   { id: 'profil',        label: 'Mon Profil' },
@@ -286,7 +287,7 @@ export default function MonCompte() {
         </div>
 
         {tab === 'profil' && (
-          <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}` }}>
+          <Card c={c}>
             <h2 style={{ fontSize: '16px', fontWeight: '600', color: c.texte, marginBottom: '20px' }}>Mon Profil</h2>
             <div style={fieldStyle}>
               <label style={labelStyle}>Nom complet</label>
@@ -302,14 +303,14 @@ export default function MonCompte() {
               <input style={inputStyle} value={editProfil.telephone} onChange={e => setEditProfil({ ...editProfil, telephone: e.target.value })} placeholder="+33 6 00 00 00 00" />
             </div>
             <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', marginTop: '8px' }}>
-              <button onClick={saveProfil} disabled={saving} style={{ background: c.accent, color: 'white', border: 'none', borderRadius: '8px', padding: '9px 18px', fontSize: '13px', fontWeight: '600', cursor: 'pointer' }}>Enregistrer</button>
+              <Button variant="primary" c={c} onClick={saveProfil} disabled={saving}>Enregistrer</Button>
               <button onClick={sendResetPassword} disabled={pwdSent} style={{ background: 'transparent', color: c.accent, border: `0.5px solid ${c.accent}`, borderRadius: '8px', padding: '9px 18px', fontSize: '13px', cursor: 'pointer' }}>{pwdSent ? 'Email envoyé ✓' : 'Changer mon mot de passe'}</button>
             </div>
-          </div>
+          </Card>
         )}
 
         {tab === 'etablissement' && isAdmin && (
-          <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}` }}>
+          <Card c={c}>
             <h2 style={{ fontSize: '16px', fontWeight: '600', color: c.texte, marginBottom: '4px' }}>Informations légales de l'établissement</h2>
             <p style={{ fontSize: '13px', color: c.texteMuted, marginBottom: '20px' }}>Ces informations apparaissent sur vos factures et documents officiels.</p>
             {[
@@ -325,13 +326,13 @@ export default function MonCompte() {
                 <input style={inputStyle} value={editClient[key] || ''} onChange={e => setEditClient({ ...editClient, [key]: e.target.value })} placeholder={placeholder} />
               </div>
             ))}
-            <button onClick={saveEtablissement} disabled={saving} style={{ background: c.accent, color: 'white', border: 'none', borderRadius: '8px', padding: '9px 18px', fontSize: '13px', fontWeight: '600', cursor: 'pointer', marginTop: '8px' }}>Enregistrer</button>
-          </div>
+            <Button variant="primary" c={c} onClick={saveEtablissement} disabled={saving} style={{ marginTop: '8px' }}>Enregistrer</Button>
+          </Card>
         )}
 
         {tab === 'abonnement' && isAdmin && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-            <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}` }}>
+            <Card c={c}>
               <h2 style={{ fontSize: '16px', fontWeight: '600', color: c.texte, marginBottom: '16px' }}>Mon abonnement</h2>
               <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr', gap: '10px' }}>
                 <div style={{ background: c.fond, borderRadius: '8px', padding: '12px' }}>
@@ -344,12 +345,12 @@ export default function MonCompte() {
                 </div>
               </div>
               {client.demande_resiliation && (
-                <div style={{ marginTop: '16px', padding: '12px', background: '#FCEBEB', borderRadius: '8px', border: '0.5px solid #F09595', fontSize: '13px', color: '#A32D2D' }}>
+                <Alert variant="error" style={{ marginTop: '16px' }}>
                   ⚠ Une demande de résiliation est en cours de traitement par notre équipe.
-                </div>
+                </Alert>
               )}
-            </div>
-            <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}` }}>
+            </Card>
+            <Card c={c}>
               <h2 style={{ fontSize: '16px', fontWeight: '600', color: c.texte, marginBottom: '16px' }}>Documents contractuels</h2>
               <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
                 {[
@@ -367,35 +368,35 @@ export default function MonCompte() {
                   CGU acceptées le {new Date(client.date_cgu).toLocaleDateString('fr-FR')} (version {client.version_cgu || '1.0'})
                 </div>
               )}
-            </div>
+            </Card>
             {!client.demande_resiliation && (
-              <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}` }}>
+              <Card c={c}>
                 <h2 style={{ fontSize: '16px', fontWeight: '600', color: c.texte, marginBottom: '8px' }}>Résilier mon abonnement</h2>
                 <p style={{ fontSize: '13px', color: c.texteMuted, marginBottom: '16px' }}>Conformément à la loi du 16 août 2022 (résiliation en ligne), vous pouvez résilier votre abonnement à tout moment. Notre équipe traitera votre demande sous 48h.</p>
                 {!showResil ? (
-                  <button onClick={() => setShowResil(true)} style={{ background: 'transparent', color: '#A32D2D', border: '0.5px solid #F09595', borderRadius: '8px', padding: '9px 18px', fontSize: '13px', cursor: 'pointer' }}>Résilier mon abonnement</button>
+                  <Button variant="danger" onClick={() => setShowResil(true)}>Résilier mon abonnement</Button>
                 ) : (
-                  <div style={{ background: '#FCEBEB', borderRadius: '10px', padding: '16px', border: '0.5px solid #F09595' }}>
-                    <p style={{ fontSize: '13px', color: '#A32D2D', marginBottom: '12px', fontWeight: '500' }}>Tapez <strong>résilier</strong> pour confirmer votre demande.</p>
+                  <Alert variant="error">
+                    <p style={{ marginBottom: '12px', fontWeight: '500' }}>Tapez <strong>résilier</strong> pour confirmer votre demande.</p>
                     <input style={{ ...inputStyle, border: '0.5px solid #F09595', marginBottom: '12px' }} value={resilConf} onChange={e => setResilConf(e.target.value)} placeholder='Tapez "résilier"' />
                     <div style={{ display: 'flex', gap: '8px' }}>
-                      <button onClick={confirmerResiliation} disabled={saving} style={{ background: '#A32D2D', color: 'white', border: 'none', borderRadius: '8px', padding: '9px 18px', fontSize: '13px', fontWeight: '600', cursor: 'pointer' }}>Confirmer la résiliation</button>
-                      <button onClick={() => { setShowResil(false); setResilConf('') }} style={{ background: 'transparent', color: '#A32D2D', border: '0.5px solid #F09595', borderRadius: '8px', padding: '9px 18px', fontSize: '13px', cursor: 'pointer' }}>Annuler</button>
+                      <Button variant="danger-solid" onClick={confirmerResiliation} disabled={saving}>Confirmer la résiliation</Button>
+                      <Button variant="danger" onClick={() => { setShowResil(false); setResilConf('') }}>Annuler</Button>
                     </div>
-                  </div>
+                  </Alert>
                 )}
-              </div>
+              </Card>
             )}
           </div>
         )}
 
         {tab === 'donnees' && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-            <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}` }}>
+            <Card c={c}>
               <h2 style={{ fontSize: '16px', fontWeight: '600', color: c.texte, marginBottom: '8px' }}>Portabilité des données</h2>
               <p style={{ fontSize: '13px', color: c.texteMuted, marginBottom: '16px', lineHeight: '1.6' }}>Conformément au RGPD (article 20), vous pouvez télécharger l'ensemble des données de votre établissement au format JSON{isAdmin ? ', et les restaurer depuis un export' : ''}.</p>
               <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
-                <button onClick={exportData} style={{ background: c.accent, color: 'white', border: 'none', borderRadius: '8px', padding: '9px 18px', fontSize: '13px', fontWeight: '600', cursor: 'pointer' }}>Télécharger mes données (JSON)</button>
+                <Button variant="primary" c={c} onClick={exportData}>Télécharger mes données (JSON)</Button>
                 {isAdmin && (
                   <label style={{ background: c.blanc, color: c.accent, border: `0.5px solid ${c.accent}`, borderRadius: '8px', padding: '9px 18px', fontSize: '13px', fontWeight: '600', cursor: importing ? 'not-allowed' : 'pointer', opacity: importing ? 0.6 : 1 }}>
                     {importing ? 'Import en cours…' : 'Importer un fichier JSON'}
@@ -403,8 +404,8 @@ export default function MonCompte() {
                   </label>
                 )}
               </div>
-            </div>
-            <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: `0.5px solid ${c.bordure}` }}>
+            </Card>
+            <Card c={c}>
               <h2 style={{ fontSize: '16px', fontWeight: '600', color: c.texte, marginBottom: '8px' }}>Responsable du traitement</h2>
               <div style={{ fontSize: '13px', color: c.texteMuted, lineHeight: '1.8' }}>
                 <div><strong style={{ color: c.texte }}>Éditeur :</strong> Skalcook SAS</div>
@@ -412,12 +413,12 @@ export default function MonCompte() {
                 <div><strong style={{ color: c.texte }}>Délai de réponse :</strong> 30 jours maximum (RGPD)</div>
               </div>
               <a href="/politique-confidentialite" target="_blank" rel="noopener noreferrer" style={{ color: c.accent, fontSize: '13px', textDecoration: 'none', fontWeight: '500', display: 'inline-block', marginTop: '12px' }}>Politique de confidentialité →</a>
-            </div>
-            <div style={{ background: '#FCEBEB', borderRadius: '12px', padding: isMobile ? '16px' : '24px', border: '0.5px solid #F09595' }}>
-              <h2 style={{ fontSize: '16px', fontWeight: '600', color: '#A32D2D', marginBottom: '8px' }}>Supprimer mon compte</h2>
-              <p style={{ fontSize: '13px', color: '#A32D2D', marginBottom: '16px', lineHeight: '1.6', opacity: 0.85 }}>Conformément au RGPD (article 17), vous pouvez supprimer votre compte. Vos accès seront révoqués immédiatement. Les données de l'établissement restent accessibles aux autres administrateurs.</p>
-              <button onClick={supprimerCompte} style={{ background: 'transparent', color: '#A32D2D', border: '0.5px solid #F09595', borderRadius: '8px', padding: '9px 18px', fontSize: '13px', cursor: 'pointer' }}>Supprimer mon compte</button>
-            </div>
+            </Card>
+            <Alert variant="error" style={{ borderRadius: '12px', padding: isMobile ? '16px' : '24px' }}>
+              <h2 style={{ fontSize: '16px', fontWeight: '600', marginBottom: '8px' }}>Supprimer mon compte</h2>
+              <p style={{ marginBottom: '16px', lineHeight: '1.6', opacity: 0.85 }}>Conformément au RGPD (article 17), vous pouvez supprimer votre compte. Vos accès seront révoqués immédiatement. Les données de l'établissement restent accessibles aux autres administrateurs.</p>
+              <Button variant="danger" onClick={supprimerCompte}>Supprimer mon compte</Button>
+            </Alert>
           </div>
         )}
       </div>

--- a/app/nouveau-mot-de-passe/page.js
+++ b/app/nouveau-mot-de-passe/page.js
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react'
 import { supabase } from '../../lib/supabase'
 import { useRouter } from 'next/navigation'
 import { theme, Logo } from '../../lib/theme.jsx'
+import { Alert } from '../../components/ui'
 
 export default function NouveauMotDePassePage() {
   const [password, setPassword] = useState('')
@@ -81,7 +82,7 @@ export default function NouveauMotDePassePage() {
               </h2>
 
               {error && (
-                <div style={{ background: '#FCEBEB', color: '#A32D2D', borderRadius: '8px', padding: '12px 14px', fontSize: '13px', marginBottom: '16px' }}>
+                <Alert variant="error" style={{ marginBottom: '16px' }}>
                   {error}
                   {error.includes('expiré') && (
                     <div style={{ marginTop: '8px' }}>
@@ -90,7 +91,7 @@ export default function NouveauMotDePassePage() {
                       </span>
                     </div>
                   )}
-                </div>
+                </Alert>
               )}
 
               {sessionReady && (

--- a/app/reset-password/page.js
+++ b/app/reset-password/page.js
@@ -4,6 +4,7 @@ import { supabase } from '../../lib/supabase'
 import { useRouter } from 'next/navigation'
 import { theme, Logo } from '../../lib/theme.jsx'
 import { useTheme } from '../../lib/useTheme'
+import { Alert } from '../../components/ui'
 
 export default function ResetPasswordPage() {
   const [email, setEmail] = useState('')
@@ -73,9 +74,9 @@ export default function ResetPasswordPage() {
               </p>
 
               {error && (
-                <div style={{ background: '#FCEBEB', color: '#A32D2D', borderRadius: '8px', padding: '12px 14px', fontSize: '13px', marginBottom: '16px' }}>
+                <Alert variant="error" style={{ marginBottom: '16px' }}>
                   {error}
-                </div>
+                </Alert>
               )}
 
               <form onSubmit={handleReset}>

--- a/components/FicheDetailShared.jsx
+++ b/components/FicheDetailShared.jsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ALLERGENES } from '../lib/allergenes'
+import { Alert } from './ui'
 
 /**
  * Shared allergen display block for fiche detail pages.
@@ -13,10 +14,7 @@ export function AllergenesBlock({ allergenes = [], allergenesCascade = [], c }) 
   const cascadeOnly = allergenesCascade.filter(id => !directAllergens.includes(id))
 
   return (
-    <div style={{ background: '#FCEBEB', borderRadius: '8px', padding: '12px', marginTop: '12px', border: '0.5px solid #F09595' }}>
-      <div style={{ fontSize: '11px', color: '#A32D2D', fontWeight: '500', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '8px' }}>
-        Allergènes présents
-      </div>
+    <Alert variant="error" title="Allergènes présents" style={{ marginTop: '12px' }}>
       {directAllergens.length > 0 && (
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginBottom: cascadeOnly.length > 0 ? '10px' : 0 }}>
           {directAllergens.map(id => {
@@ -44,7 +42,7 @@ export function AllergenesBlock({ allergenes = [], allergenesCascade = [], c }) 
           </div>
         </>
       )}
-    </div>
+    </Alert>
   )
 }
 

--- a/components/ui/Alert.jsx
+++ b/components/ui/Alert.jsx
@@ -1,0 +1,34 @@
+'use client'
+
+/**
+ * <Alert> — bandeau sémantique (erreur / warn / info / success).
+ *
+ * Couleurs entièrement pilotées par tokens CSS (sémantiques fixes,
+ * indépendantes du branding client).
+ *
+ * Props :
+ *   variant   : 'error' (défaut) | 'warn' | 'info' | 'success'
+ *   title     : optionnel — libellé en tête (uppercased, petit)
+ *   className : classes additionnelles
+ *   style     : style inline additionnel (échappatoire)
+ */
+export function Alert({
+  variant = 'error',
+  title,
+  className = '',
+  style,
+  children,
+  ...rest
+}) {
+  return (
+    <div
+      className={`sk-alert sk-alert--${variant} ${className}`.trim()}
+      style={style}
+      role={variant === 'error' ? 'alert' : 'status'}
+      {...rest}
+    >
+      {title && <div className="sk-alert__title">{title}</div>}
+      {children}
+    </div>
+  )
+}

--- a/components/ui/Button.jsx
+++ b/components/ui/Button.jsx
@@ -1,0 +1,50 @@
+'use client'
+
+/**
+ * <Button> — bouton avec variants sémantiques.
+ *
+ * Props :
+ *   variant   : 'primary' (défaut, utilise c.accent) | 'ghost' | 'danger' | 'danger-solid'
+ *   size      : 'md' (défaut) | 'sm'
+ *   c         : requis pour variant='primary' ou 'ghost' (couleurs dynamiques)
+ *   className : classes additionnelles
+ *   style     : style inline additionnel (échappatoire)
+ *   disabled, onClick, type, … : passés au <button>
+ */
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  c,
+  className = '',
+  style,
+  children,
+  ...rest
+}) {
+  const variantClass =
+    variant === 'ghost' ? 'sk-btn--ghost' :
+    variant === 'danger' ? 'sk-btn--danger' :
+    variant === 'danger-solid' ? 'sk-btn--danger-solid' :
+    '' // primary = pas de classe, on passe le style dynamique
+  const sizeClass = size === 'sm' ? 'sk-btn--sm' : ''
+
+  // Couleurs dynamiques injectées inline selon variant
+  const dynStyle = {}
+  if (variant === 'primary' && c) {
+    dynStyle.background = c.accent
+    dynStyle.color = '#fff'
+  }
+  if (variant === 'ghost' && c) {
+    dynStyle.color = c.texte
+    dynStyle.borderColor = c.bordure
+  }
+
+  return (
+    <button
+      className={`sk-btn ${variantClass} ${sizeClass} ${className}`.replace(/\s+/g, ' ').trim()}
+      style={{ ...dynStyle, ...style }}
+      {...rest}
+    >
+      {children}
+    </button>
+  )
+}

--- a/components/ui/Card.jsx
+++ b/components/ui/Card.jsx
@@ -1,0 +1,43 @@
+'use client'
+
+/**
+ * <Card> — conteneur surface (background blanc, radius, border fine).
+ *
+ * Structurel (radius/padding) piloté par CSS tokens.
+ * Couleurs dynamiques (fond + bordure) injectées via `c` car dépendantes du
+ * branding client et du dark mode.
+ *
+ * Props :
+ *   c         : objet couleurs de useTheme() — REQUIS
+ *   padding   : 'sm' | 'md' | 'lg' | 'responsive' (défaut) | 'none'
+ *   tone      : 'surface' (défaut, c.blanc) | 'muted' (c.fond)
+ *   as        : tag HTML (défaut 'div')
+ *   className : classes additionnelles
+ *   style     : style inline additionnel (échappatoire)
+ */
+export function Card({
+  c,
+  padding = 'responsive',
+  tone = 'surface',
+  as: Tag = 'div',
+  className = '',
+  style,
+  children,
+  ...rest
+}) {
+  const background = tone === 'muted' ? c.fond : c.blanc
+  const padClass = padding === 'none' ? '' : `sk-card--pad-${padding}`
+  return (
+    <Tag
+      className={`sk-card ${padClass} ${className}`.trim()}
+      style={{
+        background,
+        border: `0.5px solid ${c.bordure}`,
+        ...style,
+      }}
+      {...rest}
+    >
+      {children}
+    </Tag>
+  )
+}

--- a/components/ui/index.js
+++ b/components/ui/index.js
@@ -1,0 +1,3 @@
+export { Card } from './Card'
+export { Button } from './Button'
+export { Alert } from './Alert'


### PR DESCRIPTION
## Summary
- Introduit des design tokens CSS (radius, spacing, couleurs sémantiques) dans `globals.css`
- Crée 3 primitives UI réutilisables : `<Card>`, `<Button>`, `<Alert>`
- Migre 14 fichiers (49 usages : 26 Card, 16 Alert, 7 Button)
- Préserve le branding client dynamique via le pattern `c` prop (useTheme)

## Test plan
- [ ] `/mon-compte` — onglets Profil / Établissement / Abonnement / Données
- [ ] `/fiches/[id]` + `/modifier` + `/nouvelle` (bandeau allergènes, erreurs form)
- [ ] `/bar/fiches/[id]` + `/modifier` + `/nouvelle`
- [ ] `/cartes/[id]`, `/cartes/nouveau` (bandeaux erreur)
- [ ] `/admin` (création utilisateur — erreur + succès)
- [ ] `/avis/nouveau`, `/reset-password`, `/nouveau-mot-de-passe`
- [ ] Pas de régression visuelle sur les ~1000 `style={{}}` non migrés

🤖 Generated with [Claude Code](https://claude.com/claude-code)