### PR TITLE
refactor(ui): add Badge primitive (46 instances migrated)

### DIFF
--- a/app/admin/logs/page.js
+++ b/app/admin/logs/page.js
@@ -9,6 +9,7 @@ import { useTheme } from '../../../lib/useTheme'
 import { useRole } from '../../../lib/useRole'
 import Navbar from '../../../components/Navbar'
 import ChefLoader from '../../../components/ChefLoader'
+import { Badge } from '../../../components/ui'
 
 export default function LogsPage() {
   const [logs, setLogs] = useState([])
@@ -111,13 +112,9 @@ export default function LogsPage() {
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '10px' }}>
                   <div>
                     <div style={{ fontSize: '14px', fontWeight: '500', color: c.texte }}>{user.nom}</div>
-                    <span style={{
-                      background: user.role === 'admin' ? '#F0E8E0' : user.role === 'cuisine' ? '#EAF3DE' : user.role === 'bar' ? '#EEEDFE' : '#FAEEDA',
-                      color: user.role === 'admin' ? '#2C1810' : user.role === 'cuisine' ? '#3B6D11' : user.role === 'bar' ? '#3C3489' : '#854F0B',
-                      borderRadius: '20px', padding: '2px 8px', fontSize: '10px', fontWeight: '500'
-                    }}>
+                    <Badge bg={user.role === 'admin' ? '#F0E8E0' : user.role === 'cuisine' ? '#EAF3DE' : user.role === 'bar' ? '#EEEDFE' : '#FAEEDA'} color={user.role === 'admin' ? '#2C1810' : user.role === 'cuisine' ? '#3B6D11' : user.role === 'bar' ? '#3C3489' : '#854F0B'} size="sm">
                       {user.role}
-                    </span>
+                    </Badge>
                   </div>
                   <div style={{ fontSize: '24px', fontWeight: '500', color: c.texte }}>{user.total}</div>
                 </div>
@@ -191,8 +188,8 @@ export default function LogsPage() {
                 <div key={log.id} style={{ background: c.blanc, borderRadius: '10px', padding: '14px', border: `0.5px solid ${c.bordure}`, marginBottom: '8px' }}>
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '8px' }}>
                     <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
-                      <span style={{ background: ac.bg, color: ac.color, borderRadius: '20px', padding: '2px 8px', fontSize: '11px', fontWeight: '600' }}>{log.action}</span>
-                      <span style={{ background: sc.bg, color: sc.color, borderRadius: '20px', padding: '2px 8px', fontSize: '11px', fontWeight: '500' }}>{log.section}</span>
+                      <Badge bg={ac.bg} color={ac.color} size="sm">{log.action}</Badge>
+                      <Badge bg={sc.bg} color={sc.color} size="sm">{log.section}</Badge>
                     </div>
                     <span style={{ fontSize: '11px', color: c.texteMuted }}>{formatDate(log.created_at)}</span>
                   </div>
@@ -231,10 +228,10 @@ export default function LogsPage() {
                         <div style={{ fontSize: '11px', color: c.texteMuted }}>{log.user_role}</div>
                       </td>
                       <td style={{ padding: '10px 16px' }}>
-                        <span style={{ background: ac.bg, color: ac.color, borderRadius: '20px', padding: '3px 10px', fontSize: '11px', fontWeight: '600' }}>{log.action}</span>
+                        <Badge bg={ac.bg} color={ac.color}>{log.action}</Badge>
                       </td>
                       <td style={{ padding: '10px 16px' }}>
-                        <span style={{ background: sc.bg, color: sc.color, borderRadius: '20px', padding: '3px 10px', fontSize: '11px', fontWeight: '500' }}>{log.section}</span>
+                        <Badge bg={sc.bg} color={sc.color}>{log.section}</Badge>
                       </td>
                       <td style={{ padding: '10px 16px', fontWeight: '500', color: c.texte }}>{log.entite_nom || '—'}</td>
                       <td style={{ padding: '10px 16px', color: c.texteMuted, fontSize: '12px' }}>{log.details || '—'}</td>

--- a/app/bar/dashboard/page.js
+++ b/app/bar/dashboard/page.js
@@ -8,6 +8,7 @@ import { useRole } from '../../../lib/useRole'
 import { calculerFoodCost, foodCostColor, getSeuilsFromParams } from '../../../lib/foodCost'
 import Navbar from '../../../components/Navbar'
 import ChefLoader from '../../../components/ChefLoader'
+import { Badge } from '../../../components/ui'
 
 export default function BarDashboardPage() {
   const [fiches, setFiches] = useState([])
@@ -93,9 +94,9 @@ export default function BarDashboardPage() {
           {nom && (
             <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
               <span style={{ fontSize: '12px', color: c.texteMuted }}>Bonjour, <strong style={{ color: c.texte }}>{nom}</strong></span>
-              <span style={{ background: '#EEEDFE', color: '#3C3489', borderRadius: '20px', padding: '3px 10px', fontSize: '11px', fontWeight: '500' }}>
+              <Badge bg={'#EEEDFE'} color={'#3C3489'}>
                 {role === 'admin' ? 'Administrateur' : role === 'bar' ? 'Bar' : 'Directeur'}
-              </span>
+              </Badge>
             </div>
           )}
         </div>
@@ -151,7 +152,7 @@ export default function BarDashboardPage() {
                         <div style={{ fontSize: '13px', fontWeight: '500', color: c.texte }}>{fiche.nom}</div>
                         <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '2px' }}>{fiche.categorie}</div>
                       </div>
-                      <span style={{ background: '#FCEBEB', color: '#A32D2D', borderRadius: '20px', padding: '3px 10px', fontSize: '12px', fontWeight: '600' }}>{fc.toFixed(1)}%</span>
+                      <Badge bg={'#FCEBEB'} color={'#A32D2D'}>{fc.toFixed(1)}%</Badge>
                     </div>
                   )
                 })}
@@ -193,9 +194,9 @@ export default function BarDashboardPage() {
             }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
                 <div style={{ fontSize: '13px', fontWeight: '500', color: '#3C3489' }}>📈 Ingrédients Bar avec prix modifiés</div>
-                <span style={{ background: '#EEEDFE', color: '#3C3489', borderRadius: '20px', padding: '2px 10px', fontSize: '11px', fontWeight: '600' }}>
+                <Badge bg={'#EEEDFE'} color={'#3C3489'} size="sm">
                   {ingredientsPrixHausse.length} alertes
-                </span>
+                </Badge>
               </div>
               <div style={{ fontSize: '14px', color: '#3C3489', fontWeight: '500' }}>
                 {isPrixExpanded ? '− Masquer' : '+ Développer'}
@@ -222,9 +223,9 @@ export default function BarDashboardPage() {
                           <td style={{ padding: '10px 16px', textAlign: 'right', color: c.texte }}>{ing.prix_kg ? `${Number(ing.prix_kg).toFixed(2)} €` : '—'}</td>
                           <td style={{ padding: '10px 16px', textAlign: 'right' }}>
                             {variation !== null && (
-                              <span style={{ background: hausse ? '#FCEBEB' : '#EAF3DE', color: hausse ? '#A32D2D' : '#3B6D11', borderRadius: '20px', padding: '2px 8px', fontSize: '12px', fontWeight: '500' }}>
+                              <Badge bg={hausse ? '#FCEBEB' : '#EAF3DE'} color={hausse ? '#A32D2D' : '#3B6D11'} size="sm">
                                 {hausse ? '+' : ''}{variation.toFixed(1)}%
-                              </span>
+                              </Badge>
                             )}
                           </td>
                           <td style={{ padding: '10px 16px', textAlign: 'right', color: c.texteMuted, fontSize: '12px' }}>

--- a/app/bar/fiches/[id]/page.js
+++ b/app/bar/fiches/[id]/page.js
@@ -11,7 +11,7 @@ import { ALLERGENES } from '../../../../lib/allergenes'
 import { AllergenesBlock } from '../../../../components/FicheDetailShared'
 import ChefLoader from '../../../../components/ChefLoader'
 import BackButton from '../../../../components/BackButton'
-import { Card } from '../../../../components/ui'
+import { Card , Badge } from '../../../../components/ui'
 
 export default function BarFicheDetail() {
   const [fiche, setFiche] = useState(null)
@@ -239,8 +239,8 @@ const loadFiche = async () => {
             <div style={{ flex: 1 }}>
               <h1 style={{ fontSize: isMobile ? '18px' : '22px', fontWeight: '500', marginBottom: '8px', color: c.texte }}>{fiche.nom}</h1>
               <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
-                {fiche.categorie && <span style={{ background: '#EEEDFE', color: '#3C3489', borderRadius: '20px', padding: '3px 12px', fontSize: '12px', fontWeight: '500' }}>{fiche.categorie}</span>}
-                {fiche.saison && <span style={{ background: c.fond, color: c.texteMuted, borderRadius: '20px', padding: '3px 12px', fontSize: '12px', border: `0.5px solid ${c.bordure}` }}>{fiche.saison}</span>}
+                {fiche.categorie && <Badge bg={'#EEEDFE'} color={'#3C3489'}>{fiche.categorie}</Badge>}
+                {fiche.saison && <Badge bg={c.fond} color={c.texteMuted} border={`0.5px solid ${c.bordure}`}>{fiche.saison}</Badge>}
               </div>
             </div>
             <div style={{ background: '#3C3489', color: '#C4956A', borderRadius: '10px', padding: '8px 14px', textAlign: 'center', flexShrink: 0, marginLeft: '12px' }}>

--- a/app/bar/sous-fiches/page.js
+++ b/app/bar/sous-fiches/page.js
@@ -8,6 +8,7 @@ import { useRole } from '../../../lib/useRole'
 import Navbar from '../../../components/Navbar'
 import { ALLERGENES } from '../../../lib/allergenes'
 import ChefLoader from '../../../components/ChefLoader'
+import { Badge } from '../../../components/ui'
 
 export default function BarSousFichesPage() {
   const [fiches, setFiches] = useState([])
@@ -107,9 +108,9 @@ export default function BarSousFichesPage() {
                       {fiche.allergenes.map(id => {
                         const a = ALLERGENES.find(al => al.id === id)
                         return a ? (
-                          <span key={id} title={a.label} style={{ background: '#FCEBEB', color: '#A32D2D', border: '0.5px solid #F09595', borderRadius: '20px', padding: '2px 8px', fontSize: '11px', fontWeight: '500' }}>
+                          <Badge key={id} title={a.label} bg={'#FCEBEB'} color={'#A32D2D'} border="0.5px solid #F09595" size="sm">
                             {a.emoji} {a.label}
-                          </span>
+                          </Badge>
                         ) : null
                       })}
                     </div>

--- a/app/cartes/[id]/page.js
+++ b/app/cartes/[id]/page.js
@@ -8,7 +8,7 @@ import { useIsMobile } from '../../../lib/useIsMobile'
 import { log } from '../../../lib/useLog'
 import { ALLERGENES } from '../../../lib/allergenes'
 import ChefLoader from '../../../components/ChefLoader'
-import { Alert } from '../../../components/ui'
+import { Alert , Badge } from '../../../components/ui'
 
 const genId = () => crypto.randomUUID()
 
@@ -408,7 +408,7 @@ export default function CarteDetailPage() {
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '12px' }}>
                 <div>
                   <div style={{ fontSize: '20px', fontWeight: '500', color: c.texte }}>{carte.nom}</div>
-                  {carte.saison && <span style={{ background: c.accentClair, color: c.principal, borderRadius: '20px', padding: '2px 10px', fontSize: '11px', fontWeight: '500' }}>{carte.saison}</span>}
+                  {carte.saison && <Badge bg={c.accentClair} color={c.principal} size="sm">{carte.saison}</Badge>}
                 </div>
                 <div style={{ textAlign: 'right' }}>
                   <div style={{ fontSize: '10px', color: c.texteMuted, textTransform: 'uppercase' }}>{vueSupp ? 'Prix + suppl.' : 'Prix base'}</div>

--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -12,6 +12,7 @@ import Navbar from '../../components/Navbar'
 import InventaireBanner from '../../components/InventaireBanner'
 import * as XLSX from 'xlsx'
 import ChefLoader from '../../components/ChefLoader'
+import { Badge } from '../../components/ui'
 
 export default function DashboardPage() {
   const [fiches, setFiches] = useState([])
@@ -131,13 +132,9 @@ export default function DashboardPage() {
           {nom && (
             <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
               <span style={{ fontSize: '12px', color: c.texteMuted }}>Bonjour, <strong style={{ color: c.texte }}>{nom}</strong></span>
-              <span style={{
-                background: role === 'admin' ? '#F0E8E0' : role === 'cuisine' ? '#EAF3DE' : '#FAEEDA',
-                color: role === 'admin' ? '#2C1810' : role === 'cuisine' ? '#3B6D11' : '#854F0B',
-                borderRadius: '20px', padding: '3px 10px', fontSize: '11px', fontWeight: '500'
-              }}>
+              <Badge bg={role === 'admin' ? '#F0E8E0' : role === 'cuisine' ? '#EAF3DE' : '#FAEEDA'} color={role === 'admin' ? '#2C1810' : role === 'cuisine' ? '#3B6D11' : '#854F0B'}>
                 {role === 'admin' ? 'Administrateur' : role === 'cuisine' ? 'Cuisine' : 'Directeur'}
-              </span>
+              </Badge>
             </div>
           )}
         </div>
@@ -193,7 +190,7 @@ export default function DashboardPage() {
                         <div style={{ fontSize: '13px', fontWeight: '500', color: c.texte }}>{fiche.nom}</div>
                         <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '2px' }}>{fiche.categorie}</div>
                       </div>
-                      <span style={{ background: '#FCEBEB', color: '#A32D2D', borderRadius: '20px', padding: '3px 10px', fontSize: '12px', fontWeight: '600' }}>{fc.toFixed(1)}%</span>
+                      <Badge bg={'#FCEBEB'} color={'#A32D2D'}>{fc.toFixed(1)}%</Badge>
                     </div>
                   )
                 })}
@@ -233,9 +230,9 @@ export default function DashboardPage() {
             }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
                 <div style={{ fontSize: '13px', fontWeight: '500', color: c.texte }}>📈 Ingrédients avec prix modifiés récemment</div>
-                <span style={{ background: '#FAEEDA', color: '#854F0B', borderRadius: '20px', padding: '2px 10px', fontSize: '11px', fontWeight: '600' }}>
+                <Badge bg={'#FAEEDA'} color={'#854F0B'} size="sm">
                   {ingredientsPrixHausse.length} alertes
-                </span>
+                </Badge>
               </div>
               <div style={{ fontSize: '16px', color: c.texteMuted, fontWeight: '300' }}>
                 {isPrixExpanded ? '− Masquer' : '+ Développer'}
@@ -262,9 +259,9 @@ export default function DashboardPage() {
                           <td style={{ padding: '10px 16px', textAlign: 'right', color: c.texte }}>{ing.prix_kg ? `${Number(ing.prix_kg).toFixed(2)} €` : '—'}</td>
                           <td style={{ padding: '10px 16px', textAlign: 'right' }}>
                             {variation !== null && (
-                              <span style={{ background: hausse ? '#FCEBEB' : '#EAF3DE', color: hausse ? '#A32D2D' : '#3B6D11', borderRadius: '20px', padding: '2px 8px', fontSize: '12px', fontWeight: '500' }}>
+                              <Badge bg={hausse ? '#FCEBEB' : '#EAF3DE'} color={hausse ? '#A32D2D' : '#3B6D11'} size="sm">
                                 {hausse ? '+' : ''}{variation.toFixed(1)}%
-                              </span>
+                              </Badge>
                             )}
                           </td>
                           <td style={{ padding: '10px 16px', textAlign: 'right', color: c.texteMuted, fontSize: '12px' }}>
@@ -288,9 +285,9 @@ export default function DashboardPage() {
               style={{ display: 'flex', alignItems: 'center', gap: '10px', cursor: 'pointer' }}
             >
               <div style={{ fontSize: '13px', fontWeight: '500', color: c.texte }}>⚠️ Tableau des allergènes</div>
-              <span style={{ background: '#FCEBEB', color: '#A32D2D', borderRadius: '20px', padding: '2px 8px', fontSize: '11px', fontWeight: '500' }}>
+              <Badge bg={'#FCEBEB'} color={'#A32D2D'} size="sm">
                 {fichesAvecAllergenes.length} fiche{fichesAvecAllergenes.length > 1 ? 's' : ''}
-              </span>
+              </Badge>
             </div>
             <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
               {isAllergenesExpanded && (

--- a/app/fiches/[id]/page.js
+++ b/app/fiches/[id]/page.js
@@ -12,7 +12,7 @@ import FichePhoto, { FicheHeaderInfo, FicheHeaderInfoStyles } from '../../../com
 import { AllergenesBlock, FicheDetailNavbar } from '../../../components/FicheDetailShared'
 import ChefLoader from '../../../components/ChefLoader'
 import BackButton from '../../../components/BackButton'
-import { Card } from '../../../components/ui'
+import { Card , Badge } from '../../../components/ui'
 
 export default function FicheDetail() {
   const [fiche, setFiche] = useState(null)
@@ -225,8 +225,8 @@ export default function FicheDetail() {
           <h1 style={{ fontSize: isMobile ? '18px' : '22px', fontWeight: '500', marginBottom: '10px', color: c.texte, width: '100%' }}>{fiche.nom}</h1>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '14px', flexWrap: 'wrap', gap: '10px' }}>
             <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap', flex: '1 1 auto', minWidth: 0 }}>
-              {fiche.categorie && <span style={{ background: c.accentClair, color: c.accent, borderRadius: '20px', padding: '3px 12px', fontSize: '12px', fontWeight: '500' }}>{fiche.categorie}</span>}
-              {fiche.saison && <span style={{ background: c.fond, color: c.texteMuted, borderRadius: '20px', padding: '3px 12px', fontSize: '12px', border: `0.5px solid ${c.bordure}` }}>{fiche.saison}</span>}
+              {fiche.categorie && <Badge bg={c.accentClair} color={c.accent}>{fiche.categorie}</Badge>}
+              {fiche.saison && <Badge bg={c.fond} color={c.texteMuted} border={`0.5px solid ${c.bordure}`}>{fiche.saison}</Badge>}
             </div>
             <div style={{ background: c.principal, color: c.accent, borderRadius: '10px', padding: '8px 14px', textAlign: 'center', flexShrink: 0, minWidth: '70px' }}>
               <div style={{ fontSize: '10px', opacity: 0.7, textTransform: 'capitalize' }}>{uniteLabel}</div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -197,3 +197,18 @@ body {
   letter-spacing: 0.04em;
   margin-bottom: var(--sk-pad-xs);
 }
+
+/* ─── Badge ─── */
+.sk-badge {
+  border-radius: var(--sk-radius-pill);
+  padding: 3px 12px;
+  font-size: var(--sk-fs-sm);
+  font-weight: var(--sk-fw-med);
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  /* background + color injectés via style={} (dynamique) */
+}
+.sk-badge--sm { padding: 2px 8px; font-size: 11px; }
+.sk-badge--lg { padding: 4px 14px; }

--- a/app/ingredients/page.js
+++ b/app/ingredients/page.js
@@ -9,6 +9,7 @@ import { log } from '../../lib/useLog'
 import Navbar from '../../components/Navbar'
 import Pagination from '../../components/Pagination'
 import ChefLoader from '../../components/ChefLoader'
+import { Badge } from '../../components/ui'
 
 const PAGE_SIZE = 30
 
@@ -479,9 +480,9 @@ export default function IngredientsPage() {
                               {categories.map(cat => <option key={cat.id} value={cat.id}>{cat.emoji} {cat.nom}</option>)}
                             </select>
                           ) : ing.categories_ingredients ? (
-                            <span style={{ background: c.accentClair, color: c.accent, borderRadius: '20px', padding: '2px 10px', fontSize: '11px', fontWeight: '500' }}>
+                            <Badge bg={c.accentClair} color={c.accent} size="sm">
                               {ing.categories_ingredients.emoji} {ing.categories_ingredients.nom}
-                            </span>
+                            </Badge>
                           ) : (
                             <span style={{ color: c.texteMuted, fontSize: '12px' }}>—</span>
                           )}
@@ -642,11 +643,7 @@ export default function IngredientsPage() {
                         <td style={{ padding: '14px 16px', textAlign: 'right', color: '#16A34A' }}>{stat.prixMin.toFixed(2)} €</td>
                         <td style={{ padding: '14px 16px', textAlign: 'right', color: '#DC2626' }}>{stat.prixMax.toFixed(2)} €</td>
                         <td style={{ padding: '14px 16px', textAlign: 'right' }}>
-                          <span style={{
-                            background: ecartPct > 50 ? '#FEE2E2' : ecartPct > 20 ? '#FEF3C7' : '#DCFCE7',
-                            color: ecartPct > 50 ? '#DC2626' : ecartPct > 20 ? '#D97706' : '#16A34A',
-                            borderRadius: '20px', padding: '2px 10px', fontSize: '12px', fontWeight: '500'
-                          }}>{ecart.toFixed(2)} € ({ecartPct}%)</span>
+                          <Badge bg={ecartPct > 50 ? '#FEE2E2' : ecartPct > 20 ? '#FEF3C7' : '#DCFCE7'} color={ecartPct > 50 ? '#DC2626' : ecartPct > 20 ? '#D97706' : '#16A34A'} size="sm">{ecart.toFixed(2)} € ({ecartPct}%)</Badge>
                         </td>
                       </tr>
                     )

--- a/app/menus/[id]/page.js
+++ b/app/menus/[id]/page.js
@@ -8,6 +8,7 @@ import { useIsMobile } from '../../../lib/useIsMobile'
 import { log } from '../../../lib/useLog'
 import ChefLoader from '../../../components/ChefLoader'
 import BackButton from '../../../components/BackButton'
+import { Badge } from '../../../components/ui'
 
 export default function MenuDetail() {
   const { nomEtablissement } = useTheme()
@@ -290,9 +291,9 @@ useEffect(() => {
                   <h1 style={{ fontSize: '22px', fontWeight: '500', color: c.texte, marginBottom: '8px' }}>{menu.nom}</h1>
                   <div style={{ display: 'flex', gap: '8px' }}>
                     {menu.saison && (
-                      <span style={{ background: c.accentClair, color: c.principal, borderRadius: '20px', padding: '3px 12px', fontSize: '12px', fontWeight: '500' }}>
+                      <Badge bg={c.accentClair} color={c.principal}>
                         {menu.saison}
-                      </span>
+                      </Badge>
                     )}
                   </div>
                 </div>

--- a/app/sous-fiches/page.js
+++ b/app/sous-fiches/page.js
@@ -8,6 +8,7 @@ import { useRole } from '../../lib/useRole'
 import Navbar from '../../components/Navbar'
 import { ALLERGENES } from '../../lib/allergenes'
 import ChefLoader from '../../components/ChefLoader'
+import { Badge } from '../../components/ui'
 
 export default function SousFichesPage() {
   const [fiches, setFiches] = useState([])
@@ -108,9 +109,9 @@ export default function SousFichesPage() {
                       {fiche.allergenes.map(id => {
                         const a = ALLERGENES.find(al => al.id === id)
                         return a ? (
-                          <span key={id} title={a.label} style={{ background: '#FCEBEB', color: '#A32D2D', border: '0.5px solid #F09595', borderRadius: '20px', padding: '2px 8px', fontSize: '11px', fontWeight: '500' }}>
+                          <Badge key={id} title={a.label} bg={'#FCEBEB'} color={'#A32D2D'} border="0.5px solid #F09595" size="sm">
                             {a.emoji} {a.label}
-                          </span>
+                          </Badge>
                         ) : null
                       })}
                     </div>

--- a/components/FicheDetailShared.jsx
+++ b/components/FicheDetailShared.jsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ALLERGENES } from '../lib/allergenes'
-import { Alert } from './ui'
+import { Alert, Badge } from './ui'
 
 /**
  * Shared allergen display block for fiche detail pages.
@@ -20,9 +20,9 @@ export function AllergenesBlock({ allergenes = [], allergenesCascade = [], c }) 
           {directAllergens.map(id => {
             const a = ALLERGENES.find(al => al.id === id)
             return a ? (
-              <span key={id} style={{ background: 'white', color: '#A32D2D', border: '0.5px solid #F09595', borderRadius: '20px', padding: '4px 10px', fontSize: '12px', fontWeight: '500' }}>
+              <Badge key={id} bg={'white'} color={'#A32D2D'} border="0.5px solid #F09595">
                 {a.emoji} {a.label}
-              </span>
+              </Badge>
             ) : null
           })}
         </div>
@@ -34,9 +34,9 @@ export function AllergenesBlock({ allergenes = [], allergenesCascade = [], c }) 
             {cascadeOnly.map(id => {
               const a = ALLERGENES.find(al => al.id === id)
               return a ? (
-                <span key={id} style={{ background: 'white', color: '#A32D2D', border: '0.5px solid #F09595', borderRadius: '20px', padding: '4px 10px', fontSize: '12px', fontWeight: '500', opacity: 0.85 }}>
+                <Badge key={id} bg={'white'} color={'#A32D2D'} border="0.5px solid #F09595" style={{ opacity: 0.85 }}>
                   {a.emoji} {a.label}
-                </span>
+                </Badge>
               ) : null
             })}
           </div>
@@ -81,9 +81,9 @@ export function FicheFinancialRecap({ cout, fc, prixIndic, fiche, seuilVert, seu
             Food Cost {tvaLabel ? `(TVA ${tvaLabel})` : ''}
           </div>
           {fc ? (
-            <span style={{ background: fcBg, color: fcColor, borderRadius: '20px', padding: '4px 12px', fontSize: '16px', fontWeight: '600' }}>
+            <Badge bg={fcBg} color={fcColor} size="lg">
               {fc} %
-            </span>
+            </Badge>
           ) : (
             <div style={{ fontSize: '18px', fontWeight: '500', color: c.texteMuted }}>—</div>
           )}

--- a/components/FichesList.jsx
+++ b/components/FichesList.jsx
@@ -9,6 +9,7 @@ import { useRole } from '../lib/useRole'
 import { log } from '../lib/useLog'
 import Navbar from './Navbar'
 import Pagination from './Pagination'
+import { Badge } from './ui'
 
 const CATEGORIES_ALCOOL = ['Cocktails', 'Vins', 'Champagnes', 'Bières', 'Spiritueux']
 const PAGE_SIZE = 24
@@ -299,11 +300,11 @@ export default function FichesList({ section = 'cuisine' }) {
                       ) : null}
                     </div>
                     <div style={{ display: 'flex', gap: '6px', fontSize: '12px', color: c.texteMuted, flexWrap: 'wrap', alignItems: 'center' }}>
-                      {fiche.lieux && <span style={{ background: cfg.colors.lieuBg, color: cfg.colors.lieuColor, borderRadius: '20px', padding: '1px 7px', fontSize: '10px', fontWeight: '500' }}>{fiche.lieux.emoji} {fiche.lieux.nom}</span>}
+                      {fiche.lieux && <Badge bg={cfg.colors.lieuBg} color={cfg.colors.lieuColor}>{fiche.lieux.emoji} {fiche.lieux.nom}</Badge>}
                       {fiche.saison && <span style={{ fontSize: '11px' }}>{fiche.saison}</span>}
                       {fiche.nb_portions && <span>{fiche.nb_portions} portions</span>}
                       {fiche.prix_ttc && <span style={{ fontWeight: '500', color: c.texte }}>{Number(fiche.prix_ttc).toFixed(2)} €</span>}
-                      {fc && <span style={{ background: fcBgColor, color: fcColor, borderRadius: '20px', padding: '1px 7px', fontSize: '11px', fontWeight: '500' }}>{fc}%</span>}
+                      {fc && <Badge bg={fcBgColor} color={fcColor}>{fc}%</Badge>}
                     </div>
                   </div>
                 </div>

--- a/components/ImportView.jsx
+++ b/components/ImportView.jsx
@@ -8,6 +8,7 @@ import { log } from '../lib/useLog'
 import * as XLSX from 'xlsx'
 import Navbar from './Navbar'
 import ChefLoader from './ChefLoader'
+import { Badge } from './ui'
 
 const CONFIG = {
   cuisine: {
@@ -513,13 +514,9 @@ export default function ImportView({ section = 'cuisine' }) {
                         {cfg.showCategoryInPreview && (
                           <td style={{ padding: '8px 12px', border: `0.5px solid ${c.bordure}` }}>
                             {ing.categorieNom ? (
-                              <span style={{
-                                background: ing.categorieNonTrouvee ? '#FEF3C7' : accentBg,
-                                color: ing.categorieNonTrouvee ? '#92400E' : accent,
-                                borderRadius: '20px', padding: '2px 8px', fontSize: '11px', fontWeight: '500'
-                              }}>
+                              <Badge bg={ing.categorieNonTrouvee ? '#FEF3C7' : accentBg} color={ing.categorieNonTrouvee ? '#92400E' : accent} size="sm">
                                 {ing.categorieNonTrouvee ? '\u26a0\ufe0f ' : '\u2713 '}{ing.categorieNom}
-                              </span>
+                              </Badge>
                             ) : (
                               <span style={{ color: c.texteMuted, fontSize: '12px' }}>—</span>
                             )}

--- a/components/RecapView.jsx
+++ b/components/RecapView.jsx
@@ -9,6 +9,7 @@ import { useRole } from '../lib/useRole'
 import { log } from '../lib/useLog'
 import * as XLSX from 'xlsx'
 import Navbar from './Navbar'
+import { Badge } from './ui'
 
 const CATEGORIES_ALCOOL = ['Cocktails', 'Vins', 'Champagnes', 'Bières', 'Spiritueux']
 
@@ -207,7 +208,7 @@ export default function RecapView({ section = 'cuisine' }) {
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '6px' }}>
           <div style={{ fontSize: '14px', fontWeight: '500', color: c.texte, cursor: 'pointer', flex: 1 }} onClick={() => router.push(url)}>{item.nom}</div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            {fc && <span style={{ background: fcBg(fc), color: fcColor(fc), borderRadius: '20px', padding: '2px 8px', fontSize: '11px', fontWeight: '500' }}>{fc}%</span>}
+            {fc && <Badge bg={fcBg(fc)} color={fcColor(fc)} size="sm">{fc}%</Badge>}
             {peutModifier && <input type="checkbox" checked={aArchiver} onChange={() => toggleArchive(item.id)} style={{ width: '18px', height: '18px', cursor: 'pointer', accentColor: cfg.colors.accentCheckbox }} />}
           </div>
         </div>
@@ -215,7 +216,7 @@ export default function RecapView({ section = 'cuisine' }) {
           {cout ? <span>Coût : {Number(cout).toFixed(2)} €</span> : null}
           {prixTTC ? <span>Prix : {Number(prixTTC).toFixed(2)} €</span> : null}
           {item.saison ? <span>{item.saison}</span> : null}
-          {vue === 'categorie' && item.lieux && <span style={{ background: cfg.colors.lieuBg, color: cfg.colors.lieuColor, borderRadius: '20px', padding: '1px 8px', fontSize: '10px' }}>{item.lieux.emoji} {item.lieux.nom}</span>}
+          {vue === 'categorie' && item.lieux && <Badge bg={cfg.colors.lieuBg} color={cfg.colors.lieuColor}>{item.lieux.emoji} {item.lieux.nom}</Badge>}
         </div>
       </div>
     ) : (
@@ -223,7 +224,7 @@ export default function RecapView({ section = 'cuisine' }) {
         <td style={{ padding: '8px 10px', fontWeight: '500', color: c.texte, cursor: 'pointer' }} onClick={() => router.push(url)}>{item.nom}</td>
         {vue === 'categorie' && (
           <td style={{ padding: '8px 10px' }}>
-            {item.lieux && <span style={{ background: cfg.colors.lieuBg, color: cfg.colors.lieuColor, borderRadius: '20px', padding: '2px 8px', fontSize: '11px' }}>{item.lieux.emoji} {item.lieux.nom}</span>}
+            {item.lieux && <Badge bg={cfg.colors.lieuBg} color={cfg.colors.lieuColor} size="sm">{item.lieux.emoji} {item.lieux.nom}</Badge>}
           </td>
         )}
         <td style={{ padding: '8px 10px', textAlign: 'right', color: c.texteMuted }}>{item.saison || '—'}</td>
@@ -232,7 +233,7 @@ export default function RecapView({ section = 'cuisine' }) {
         <td style={{ padding: '8px 10px', textAlign: 'right' }}>{prixTTC ? `${Number(prixTTC).toFixed(2)} €` : '—'}</td>
         <td style={{ padding: '8px 10px', textAlign: 'right', fontWeight: '500', color: benefice ? (benefice > 0 ? '#3B6D11' : '#A32D2D') : c.texteMuted }}>{benefice ? `${benefice.toFixed(2)} €` : '—'}</td>
         <td style={{ padding: '8px 10px', textAlign: 'right' }}>
-          {fc ? <span style={{ background: fcBg(fc), color: fcColor(fc), borderRadius: '20px', padding: '2px 8px', fontSize: '11px', fontWeight: '500' }}>{fc} %</span> : '—'}
+          {fc ? <Badge bg={fcBg(fc)} color={fcColor(fc)} size="sm">{fc} %</Badge> : '—'}
         </td>
         {peutModifier && <td style={{ padding: '8px 10px', textAlign: 'right' }}><input type="checkbox" checked={aArchiver} onChange={() => toggleArchive(item.id)} style={{ width: '16px', height: '16px', cursor: 'pointer', accentColor: cfg.colors.accentCheckbox }} /></td>}
       </tr>
@@ -280,7 +281,7 @@ export default function RecapView({ section = 'cuisine' }) {
               <td style={{ padding: '14px 16px', textAlign: 'right' }}>{stats.prixTTCMoyen > 0 ? `${stats.prixTTCMoyen.toFixed(2)} €` : '—'}</td>
               <td style={{ padding: '14px 16px', textAlign: 'right', fontWeight: '500', color: stats.beneficeMoyen > 0 ? '#3B6D11' : c.texteMuted }}>{stats.beneficeMoyen !== 0 ? `${stats.beneficeMoyen.toFixed(2)} €` : '—'}</td>
               <td style={{ padding: '14px 16px', textAlign: 'right' }}>
-                {stats.ratioMoyen > 0 ? <span style={{ background: fcBg(stats.ratioMoyen), color: fcColor(stats.ratioMoyen), borderRadius: '20px', padding: '3px 10px', fontSize: '12px', fontWeight: '500' }}>{stats.ratioMoyen.toFixed(1)} %</span> : '—'}
+                {stats.ratioMoyen > 0 ? <Badge bg={fcBg(stats.ratioMoyen)} color={fcColor(stats.ratioMoyen)}>{stats.ratioMoyen.toFixed(1)} %</Badge> : '—'}
               </td>
             </tr></tbody></table>
           )}
@@ -334,9 +335,7 @@ export default function RecapView({ section = 'cuisine' }) {
                 display: 'flex', justifyContent: 'space-between', alignItems: 'center'
               }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-                  <div style={{ background: cfg.colors.lieuBg, color: cfg.colors.lieuColor, borderRadius: '20px', padding: '4px 14px', fontSize: '12px', fontWeight: '500' }}>
-                    {lieu.emoji} {lieu.nom}
-                  </div>
+                  <Badge bg={cfg.colors.lieuBg} color={cfg.colors.lieuColor} size="lg">{lieu.emoji} {lieu.nom}</Badge>
                   <span style={{ fontSize: '12px', color: c.texteMuted }}>{fichesLieu.length} fiche{fichesLieu.length > 1 ? 's' : ''}</span>
                 </div>
                 <div style={{ display: 'flex', gap: isMobile ? '12px' : '24px', alignItems: 'center' }}>
@@ -355,12 +354,12 @@ export default function RecapView({ section = 'cuisine' }) {
                 <div style={{ border: `0.5px solid ${c.bordure}`, borderTop: 'none', borderRadius: '0 0 12px 12px', background: c.fond, padding: '12px' }}>
                   {catsLieu.map(cat => {
                     const fichesCat = fichesLieu.filter(f => f.categorie_plat_id === cat.id)
-                    return <Accordeon key={cat.id} id={`${lieu.id}-${cat.id}`} badge={<span style={{ background: cfg.colors.catBg, color: cfg.colors.catColor, borderRadius: '20px', padding: '3px 12px', fontSize: '12px', fontWeight: '500' }}>{cat.emoji} {cat.nom}</span>} stats={statsListe(fichesCat)} fiches={fichesCat} />
+                    return <Accordeon key={cat.id} id={`${lieu.id}-${cat.id}`} badge={<Badge bg={cfg.colors.catBg} color={cfg.colors.catColor}>{cat.emoji} {cat.nom}</Badge>} stats={statsListe(fichesCat)} fiches={fichesCat} />
                   })}
                   {(() => {
                     const sansCat = fichesLieu.filter(f => !f.categorie_plat_id)
                     if (!sansCat.length) return null
-                    return <Accordeon id={`${lieu.id}-sans-cat`} badge={<span style={{ background: c.fond, color: c.texteMuted, borderRadius: '20px', padding: '3px 12px', fontSize: '12px', border: `0.5px solid ${c.bordure}` }}>Sans catégorie</span>} stats={statsListe(sansCat)} fiches={sansCat} />
+                    return <Accordeon id={`${lieu.id}-sans-cat`} badge={<Badge bg={c.fond} color={c.texteMuted} border={`0.5px solid ${c.bordure}`}>Sans catégorie</Badge>} stats={statsListe(sansCat)} fiches={sansCat} />
                   })()}
                 </div>
               )}
@@ -368,7 +367,7 @@ export default function RecapView({ section = 'cuisine' }) {
           )
         })}
         {sanslieu.length > 0 && (
-          <Accordeon id="sans-lieu" badge={<span style={{ background: c.fond, color: c.texteMuted, borderRadius: '20px', padding: '3px 12px', fontSize: '12px', border: `0.5px solid ${c.bordure}` }}>Sans lieu</span>} stats={statsListe(sanslieu)} fiches={sanslieu} />
+          <Accordeon id="sans-lieu" badge={<Badge bg={c.fond} color={c.texteMuted} border={`0.5px solid ${c.bordure}`}>Sans lieu</Badge>} stats={statsListe(sanslieu)} fiches={sanslieu} />
         )}
       </div>
     )
@@ -387,9 +386,9 @@ export default function RecapView({ section = 'cuisine' }) {
           <div>
             {catsAvecFiches.map(cat => {
               const fichesCat = fichesFiltrees.filter(f => f.categorie_plat_id === cat.id)
-              return <Accordeon key={cat.id} id={`cat-${cat.id}`} badge={<span style={{ background: cfg.colors.catBg, color: cfg.colors.catColor, borderRadius: '20px', padding: '3px 12px', fontSize: '12px', fontWeight: '500' }}>{cat.emoji} {cat.nom}</span>} stats={statsListe(fichesCat)} fiches={fichesCat} avecLieu={true} />
+              return <Accordeon key={cat.id} id={`cat-${cat.id}`} badge={<Badge bg={cfg.colors.catBg} color={cfg.colors.catColor}>{cat.emoji} {cat.nom}</Badge>} stats={statsListe(fichesCat)} fiches={fichesCat} avecLieu={true} />
             })}
-            {sansCat.length > 0 && <Accordeon id="cat-sans" badge={<span style={{ background: c.fond, color: c.texteMuted, borderRadius: '20px', padding: '3px 12px', fontSize: '12px', border: `0.5px solid ${c.bordure}` }}>Sans catégorie</span>} stats={statsListe(sansCat)} fiches={sansCat} avecLieu={true} />}
+            {sansCat.length > 0 && <Accordeon id="cat-sans" badge={<Badge bg={c.fond} color={c.texteMuted} border={`0.5px solid ${c.bordure}`}>Sans catégorie</Badge>} stats={statsListe(sansCat)} fiches={sansCat} avecLieu={true} />}
           </div>
         ) : (
           <div style={{ background: c.blanc, borderRadius: '12px', border: `0.5px solid ${c.bordure}`, overflow: 'hidden' }}>
@@ -409,7 +408,7 @@ export default function RecapView({ section = 'cuisine' }) {
                         onMouseLeave={e => { if (!isOpen) e.currentTarget.style.background = c.blanc }}>
                         <td style={{ padding: '14px 16px' }}>
                           <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                            <span style={{ background: cfg.colors.catBg, color: cfg.colors.catColor, borderRadius: '20px', padding: '3px 12px', fontSize: '12px', fontWeight: '500' }}>{cat.emoji} {cat.nom}</span>
+                            <Badge bg={cfg.colors.catBg} color={cfg.colors.catColor}>{cat.emoji} {cat.nom}</Badge>
                             <span style={{ fontSize: '11px', color: c.texteMuted }}>{stats.nb} fiche{stats.nb > 1 ? 's' : ''}</span>
                             <span style={{ fontSize: '11px', color: c.accent, marginLeft: 'auto' }}>{isOpen ? '▲' : '▼'}</span>
                           </div>
@@ -420,7 +419,7 @@ export default function RecapView({ section = 'cuisine' }) {
                         <td style={{ padding: '14px 16px', textAlign: 'right' }}>{stats.prixTTCMoyen > 0 ? `${stats.prixTTCMoyen.toFixed(2)} €` : '—'}</td>
                         <td style={{ padding: '14px 16px', textAlign: 'right', fontWeight: '500', color: stats.beneficeMoyen > 0 ? '#3B6D11' : c.texteMuted }}>{stats.beneficeMoyen !== 0 ? `${stats.beneficeMoyen.toFixed(2)} €` : '—'}</td>
                         <td style={{ padding: '14px 16px', textAlign: 'right' }}>
-                          {stats.ratioMoyen > 0 ? <span style={{ background: fcBg(stats.ratioMoyen), color: fcColor(stats.ratioMoyen), borderRadius: '20px', padding: '3px 10px', fontSize: '12px', fontWeight: '500' }}>{stats.ratioMoyen.toFixed(1)} %</span> : '—'}
+                          {stats.ratioMoyen > 0 ? <Badge bg={fcBg(stats.ratioMoyen)} color={fcColor(stats.ratioMoyen)}>{stats.ratioMoyen.toFixed(1)} %</Badge> : '—'}
                         </td>
                       </tr>
                       {isOpen && (
@@ -480,13 +479,13 @@ export default function RecapView({ section = 'cuisine' }) {
                 if (!stats) return null
                 return (
                   <tr key={lieu.id} style={{ borderBottom: `0.5px solid ${c.bordure}` }}>
-                    <td style={{ padding: '12px 16px' }}><span style={{ background: cfg.colors.lieuBg, color: cfg.colors.lieuColor, borderRadius: '20px', padding: '3px 12px', fontSize: '12px', fontWeight: '500' }}>{lieu.emoji} {lieu.nom}</span></td>
+                    <td style={{ padding: '12px 16px' }}><Badge bg={cfg.colors.lieuBg} color={cfg.colors.lieuColor}>{lieu.emoji} {lieu.nom}</Badge></td>
                     <td style={{ padding: '12px 16px', textAlign: 'right' }}>{stats.nb}</td>
                     <td style={{ padding: '12px 16px', textAlign: 'right' }}>{stats.coutMoyen > 0 ? `${stats.coutMoyen.toFixed(2)} €` : '—'}</td>
                     <td style={{ padding: '12px 16px', textAlign: 'right' }}>{stats.prixTTCMoyen > 0 ? `${stats.prixTTCMoyen.toFixed(2)} €` : '—'}</td>
                     <td style={{ padding: '12px 16px', textAlign: 'right', fontWeight: '500', color: stats.beneficeMoyen > 0 ? '#3B6D11' : c.texteMuted }}>{stats.beneficeMoyen > 0 ? `${stats.beneficeMoyen.toFixed(2)} €` : '—'}</td>
                     <td style={{ padding: '12px 16px', textAlign: 'right' }}>
-                      {stats.ratioMoyen > 0 ? <span style={{ background: fcBg(stats.ratioMoyen), color: fcColor(stats.ratioMoyen), borderRadius: '20px', padding: '3px 10px', fontSize: '12px', fontWeight: '500' }}>{stats.ratioMoyen.toFixed(1)} %</span> : '—'}
+                      {stats.ratioMoyen > 0 ? <Badge bg={fcBg(stats.ratioMoyen)} color={fcColor(stats.ratioMoyen)}>{stats.ratioMoyen.toFixed(1)} %</Badge> : '—'}
                     </td>
                   </tr>
                 )
@@ -499,7 +498,7 @@ export default function RecapView({ section = 'cuisine' }) {
                   <td style={{ padding: '12px 16px', textAlign: 'right', fontWeight: '500' }}>{statsTotal.prixTTCMoyen > 0 ? `${statsTotal.prixTTCMoyen.toFixed(2)} €` : '—'}</td>
                   <td style={{ padding: '12px 16px', textAlign: 'right', fontWeight: '500', color: statsTotal.beneficeMoyen > 0 ? '#3B6D11' : c.texteMuted }}>{statsTotal.beneficeMoyen > 0 ? `${statsTotal.beneficeMoyen.toFixed(2)} €` : '—'}</td>
                   <td style={{ padding: '12px 16px', textAlign: 'right' }}>
-                    {statsTotal.ratioMoyen > 0 ? <span style={{ background: fcBg(statsTotal.ratioMoyen), color: fcColor(statsTotal.ratioMoyen), borderRadius: '20px', padding: '3px 10px', fontSize: '12px', fontWeight: '500' }}>{statsTotal.ratioMoyen.toFixed(1)} %</span> : '—'}
+                    {statsTotal.ratioMoyen > 0 ? <Badge bg={fcBg(statsTotal.ratioMoyen)} color={fcColor(statsTotal.ratioMoyen)}>{statsTotal.ratioMoyen.toFixed(1)} %</Badge> : '—'}
                   </td>
                 </tr>
               )}

--- a/components/ui/Badge.jsx
+++ b/components/ui/Badge.jsx
@@ -1,0 +1,45 @@
+'use client'
+
+/**
+ * <Badge> — pill label (catégorie, lieu, allergène, ratio, …).
+ *
+ * Couleurs toujours dynamiques (catégorie, FC, branding) → passées en props.
+ *
+ * Props :
+ *   bg        : couleur de fond (string, requis)
+ *   color     : couleur texte (string, requis)
+ *   size      : 'sm' (11px, 2px 8px) | 'md' (défaut, 12px, 3px 12px) | 'lg' (12px, 4px 14px)
+ *   border    : bordure optionnelle (ex. '0.5px solid #F09595')
+ *   className : classes additionnelles
+ *   style     : style inline additionnel (échappatoire)
+ */
+export function Badge({
+  bg,
+  color,
+  size = 'md',
+  border,
+  className = '',
+  style,
+  children,
+  ...rest
+}) {
+  const sizeClass =
+    size === 'sm' ? 'sk-badge--sm' :
+    size === 'lg' ? 'sk-badge--lg' :
+    ''
+
+  return (
+    <span
+      className={`sk-badge ${sizeClass} ${className}`.trim()}
+      style={{
+        background: bg,
+        color,
+        ...(border && { border }),
+        ...style,
+      }}
+      {...rest}
+    >
+      {children}
+    </span>
+  )
+}

--- a/components/ui/index.js
+++ b/components/ui/index.js
@@ -1,3 +1,4 @@
 export { Card } from './Card'
 export { Button } from './Button'
 export { Alert } from './Alert'
+export { Badge } from './Badge'


### PR DESCRIPTION
## Summary
- Crée la primitive `<Badge>` (bg, color, size sm/md/lg, border) + classe CSS `.sk-badge`
- Migre **46 badges inline** sur 14 fichiers : catégories, lieux, ratios FC, allergènes
- Porte le total des primitives UI à **95** (Card 26 + Alert 16 + Button 7 + Badge 46)

## Test plan
- [ ] `/dashboard` + `/bar/dashboard` — badges FC ratio, catégories
- [ ] `/fiches/[id]` + `/bar/fiches/[id]` — badge catégorie + saison
- [ ] Allergènes sur une fiche (composant `FicheDetailShared`)
- [ ] `/admin/logs` — badges section + action
- [ ] `/ingredients` — badges catégorie
- [ ] `/sous-fiches` + `/bar/sous-fiches` — badges allergènes
- [ ] `RecapView` (récap cuisine + bar) — badges lieu/catégorie/FC

🤖 Generated with [Claude Code](https://claude.com/claude-code)