### PR TITLE
feat(crm): CRM par établissement — clients et événements traiteur

### DIFF
--- a/app/crm.css
+++ b/app/crm.css
@@ -1,0 +1,372 @@
+/* ──────────────────────────────────────────────────────────────
+ * CRM — styles dédiés au module
+ *
+ * Structure statique ici. Couleurs dynamiques (branding client +
+ * dark mode) passées via style={} dans le JSX (c.fond, c.blanc,
+ * c.bordure, c.texte, c.texteMuted, c.accent, c.accentClair).
+ * ────────────────────────────────────────────────────────────── */
+
+.crm-page {
+  min-height: 100vh;
+  padding: 16px;
+}
+@media (min-width: 768px) {
+  .crm-page { padding: 24px; }
+}
+
+/* ─── Header ─── */
+.crm-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+.crm-header__text { min-width: 0; }
+.crm-header__title {
+  font-size: 22px;
+  font-weight: 600;
+  margin-bottom: 2px;
+  letter-spacing: -0.01em;
+}
+.crm-header__subtitle {
+  font-size: var(--sk-fs-md);
+}
+@media (min-width: 768px) {
+  .crm-header__title { font-size: 26px; }
+}
+
+/* ─── Back link ─── */
+.crm-back {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 4px 0;
+  font-size: var(--sk-fs-md);
+  margin-bottom: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* ─── Toolbar ─── */
+.crm-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+  align-items: center;
+}
+.crm-toolbar__search {
+  flex: 1 1 220px;
+  min-width: 0;
+  padding: 9px 12px;
+  border-radius: var(--sk-radius-md);
+  font-size: var(--sk-fs-md);
+  outline: none;
+  font-family: inherit;
+}
+
+/* ─── Tabs (liste vs kanban) ─── */
+.crm-tabs {
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  border-radius: var(--sk-radius-md);
+}
+.crm-tabs__btn {
+  border: none;
+  background: transparent;
+  padding: 6px 14px;
+  border-radius: 6px;
+  font-size: var(--sk-fs-md);
+  cursor: pointer;
+  font-family: inherit;
+}
+
+/* ─── KPI grid (dashboard) ─── */
+.crm-kpi-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+@media (min-width: 640px) {
+  .crm-kpi-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 1024px) {
+  .crm-kpi-grid { grid-template-columns: repeat(4, 1fr); }
+}
+
+/* ─── Section stack ─── */
+.crm-section { margin-bottom: 24px; }
+.crm-section__title {
+  font-size: var(--sk-fs-lg);
+  font-weight: var(--sk-fw-bold);
+  margin-bottom: 10px;
+}
+
+/* ─── Liste responsive (clients / événements) ─── */
+.crm-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.crm-row {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 6px 12px;
+  padding: 12px 14px;
+  border-radius: var(--sk-radius-md);
+  cursor: pointer;
+  transition: transform 0.1s, box-shadow 0.1s;
+  text-align: left;
+  border-width: var(--sk-border-hair);
+  border-style: solid;
+}
+.crm-row:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 10px rgba(0,0,0,0.05);
+}
+.crm-row__primary {
+  font-weight: var(--sk-fw-med);
+  font-size: var(--sk-fs-lg);
+}
+.crm-row__secondary { font-size: var(--sk-fs-sm); }
+.crm-row__meta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  font-size: var(--sk-fs-sm);
+}
+@media (min-width: 768px) {
+  .crm-row { grid-template-columns: 1.4fr 1fr auto; align-items: center; }
+}
+
+/* ─── Kanban ─── */
+.crm-kanban {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  padding-bottom: 12px;
+  -webkit-overflow-scrolling: touch;
+}
+.crm-kanban__col {
+  flex: 0 0 280px;
+  min-width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border-radius: var(--sk-radius-lg);
+  border-width: var(--sk-border-hair);
+  border-style: solid;
+}
+.crm-kanban__col-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: var(--sk-fs-sm);
+  font-weight: var(--sk-fw-med);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 4px 10px;
+  border-bottom: var(--sk-border-hair) solid;
+}
+.crm-kanban__count {
+  font-size: 11px;
+  padding: 1px 8px;
+  border-radius: var(--sk-radius-pill);
+}
+.crm-kanban__cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow-y: auto;
+  max-height: 65vh;
+  padding-right: 2px;
+}
+.crm-kanban__card {
+  padding: 10px 12px;
+  border-radius: var(--sk-radius-md);
+  cursor: pointer;
+  text-align: left;
+  border-width: var(--sk-border-hair);
+  border-style: solid;
+  transition: transform 0.1s;
+}
+.crm-kanban__card:hover { transform: translateY(-1px); }
+.crm-kanban__card-title {
+  font-weight: var(--sk-fw-med);
+  margin-bottom: 4px;
+  font-size: var(--sk-fs-md);
+  line-height: 1.3;
+}
+.crm-kanban__card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: var(--sk-fs-sm);
+  margin-top: 4px;
+}
+
+/* ─── Form ─── */
+.crm-form {
+  display: grid;
+  gap: 14px;
+  max-width: 760px;
+}
+.crm-form__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 14px;
+}
+@media (min-width: 640px) {
+  .crm-form__grid--2 { grid-template-columns: 1fr 1fr; }
+  .crm-form__grid--3 { grid-template-columns: 1fr 1fr 1fr; }
+}
+
+.crm-field { display: flex; flex-direction: column; gap: 4px; }
+.crm-field__label {
+  font-size: var(--sk-fs-sm);
+  font-weight: var(--sk-fw-med);
+}
+.crm-field__label--required::after {
+  content: ' *';
+  color: var(--sk-rouge);
+}
+.crm-field__input,
+.crm-field__textarea,
+.crm-field__select {
+  padding: 9px 12px;
+  border-radius: var(--sk-radius-md);
+  font-size: var(--sk-fs-md);
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+  font-family: inherit;
+  border-width: var(--sk-border-hair);
+  border-style: solid;
+}
+.crm-field__textarea {
+  min-height: 84px;
+  resize: vertical;
+  line-height: 1.4;
+}
+.crm-field__hint {
+  font-size: 11px;
+  margin-top: 2px;
+}
+
+/* ─── Type toggle (particulier / entreprise) ─── */
+.crm-typetoggle {
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  border-radius: var(--sk-radius-md);
+  border-width: var(--sk-border-hair);
+  border-style: solid;
+}
+.crm-typetoggle__btn {
+  border: none;
+  background: transparent;
+  padding: 8px 18px;
+  border-radius: 6px;
+  font-size: var(--sk-fs-md);
+  cursor: pointer;
+  font-family: inherit;
+}
+
+/* ─── Tag pill + input ─── */
+.crm-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+.crm-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  border-radius: var(--sk-radius-pill);
+  font-size: 11px;
+  font-weight: var(--sk-fw-med);
+}
+.crm-tag__remove {
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  opacity: 0.7;
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+}
+.crm-tag__remove:hover { opacity: 1; }
+.crm-tag-input {
+  border: none;
+  background: transparent;
+  outline: none;
+  padding: 4px 8px;
+  font-size: var(--sk-fs-sm);
+  flex: 1 1 120px;
+  min-width: 80px;
+  font-family: inherit;
+}
+
+/* ─── Key-value grid (fiche détail) ─── */
+.crm-kv {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+@media (min-width: 640px) {
+  .crm-kv { grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 1024px) {
+  .crm-kv { grid-template-columns: repeat(3, 1fr); }
+}
+.crm-kv__key {
+  font-size: 11px;
+  font-weight: var(--sk-fw-med);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 2px;
+}
+.crm-kv__value {
+  font-size: var(--sk-fs-md);
+  word-break: break-word;
+}
+
+/* ─── Empty state ─── */
+.crm-empty {
+  padding: 40px 20px;
+  text-align: center;
+  border-radius: var(--sk-radius-lg);
+  border-width: var(--sk-border-hair);
+  border-style: dashed;
+}
+.crm-empty__title {
+  font-size: var(--sk-fs-lg);
+  font-weight: var(--sk-fw-med);
+  margin-bottom: 6px;
+}
+.crm-empty__text {
+  font-size: var(--sk-fs-md);
+  margin-bottom: 12px;
+}
+
+/* ─── Action bar (sticky mobile) ─── */
+.crm-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.crm-actions--left { justify-content: flex-start; }
+@media (max-width: 640px) {
+  .crm-actions .sk-btn { flex: 1 1 auto; justify-content: center; }
+}

--- a/app/crm/clients/[id]/page.js
+++ b/app/crm/clients/[id]/page.js
@@ -1,0 +1,262 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useRouter, useParams } from 'next/navigation'
+import { supabase, getClientId } from '../../../../lib/supabase'
+import { useTheme } from '../../../../lib/useTheme'
+import { useRole } from '../../../../lib/useRole'
+import Navbar from '../../../../components/Navbar'
+import { Card, Button, Badge, Alert } from '../../../../components/ui'
+import ClientForm from '../../../../components/crm/ClientForm'
+import {
+  STATUTS_MAP, formatDateFr, formatMontant, clientDisplayName, hexToRgba,
+} from '../../../../lib/crmConstants'
+
+export default function CrmClientDetailPage() {
+  const router = useRouter()
+  const params = useParams()
+  const id = params?.id
+  const { c } = useTheme()
+  const { role, loading: roleLoading } = useRole()
+
+  const [authReady, setAuthReady] = useState(false)
+  const [clientId, setClientId] = useState(null)
+  const [client, setClient] = useState(null)
+  const [evenements, setEvenements] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [mode, setMode] = useState('view') // view | edit
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const { data: { session } } = await supabase.auth.getSession()
+      if (cancelled) return
+      if (!session) { router.replace('/'); return }
+      setAuthReady(true)
+    })()
+    return () => { cancelled = true }
+  }, [router])
+
+  useEffect(() => {
+    if (!roleLoading && role && !['admin', 'directeur'].includes(role)) {
+      router.replace('/dashboard')
+    }
+  }, [role, roleLoading, router])
+
+  const load = useCallback(async () => {
+    if (!id) return
+    setLoading(true)
+    setError('')
+    const cid = await getClientId()
+    if (!cid) { setLoading(false); return }
+    setClientId(cid)
+
+    const [{ data: cli, error: cErr }, { data: evts, error: eErr }] = await Promise.all([
+      supabase.from('crm_clients').select('*').eq('id', id).eq('client_id', cid).maybeSingle(),
+      supabase.from('crm_evenements')
+        .select('id, titre, date_evenement, statut, type_prestation, nb_convives, montant_devis, montant_final, budget_estime, created_at')
+        .eq('crm_client_id', id).eq('client_id', cid)
+        .order('date_evenement', { ascending: false, nullsFirst: false }),
+    ])
+
+    if (cErr || eErr) { setError((cErr || eErr).message); setLoading(false); return }
+    setClient(cli)
+    setEvenements(evts || [])
+    setLoading(false)
+  }, [id])
+
+  useEffect(() => {
+    if (!authReady || !['admin', 'directeur'].includes(role || '')) return
+    load()
+  }, [authReady, role, load])
+
+  async function handleSave(values) {
+    const { error: err } = await supabase
+      .from('crm_clients')
+      .update(values)
+      .eq('id', id)
+      .eq('client_id', clientId)
+    if (err) throw err
+    setMode('view')
+    await load()
+  }
+
+  async function handleDelete() {
+    const { error: err } = await supabase
+      .from('crm_clients')
+      .delete()
+      .eq('id', id)
+      .eq('client_id', clientId)
+    if (err) { setError(err.message); return }
+    router.push('/crm/clients')
+  }
+
+  if (!authReady || roleLoading) {
+    return (
+      <div style={{ minHeight: '100vh', background: c.fond, display: 'flex', alignItems: 'center', justifyContent: 'center', color: c.texteMuted, fontSize: 14 }}>
+        Chargement…
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ background: c.fond, minHeight: '100vh' }}>
+      <Navbar section="cuisine" />
+      <div className="crm-page">
+        <button type="button" onClick={() => router.push('/crm/clients')} className="crm-back" style={{ color: c.texteMuted }}>
+          ← Clients
+        </button>
+
+        {error && <Alert variant="error">{error}</Alert>}
+
+        {loading ? (
+          <div style={{ color: c.texteMuted, fontSize: 13, padding: 12 }}>Chargement…</div>
+        ) : !client ? (
+          <Alert variant="warn">Client introuvable.</Alert>
+        ) : mode === 'edit' ? (
+          <>
+            <div className="crm-header">
+              <div className="crm-header__text">
+                <h1 className="crm-header__title" style={{ color: c.texte }}>Modifier le client</h1>
+              </div>
+            </div>
+            <ClientForm
+              c={c}
+              initial={client}
+              submitLabel="Enregistrer"
+              onSubmit={handleSave}
+              onCancel={() => setMode('view')}
+            />
+          </>
+        ) : (
+          <>
+            <div className="crm-header">
+              <div className="crm-header__text">
+                <h1 className="crm-header__title" style={{ color: c.texte }}>{clientDisplayName(client)}</h1>
+                <p className="crm-header__subtitle" style={{ color: c.texteMuted }}>
+                  <Badge
+                    bg={client.type === 'entreprise' ? hexToRgba('#6366F1', 0.12) : hexToRgba('#10B981', 0.12)}
+                    color={client.type === 'entreprise' ? '#6366F1' : '#10B981'}
+                    size="sm"
+                  >
+                    {client.type === 'entreprise' ? 'Entreprise' : 'Particulier'}
+                  </Badge>
+                  {client.source && (
+                    <span style={{ marginLeft: 8 }}>Source : {client.source}</span>
+                  )}
+                </p>
+              </div>
+              <div className="crm-actions">
+                <Button c={c} variant="ghost" onClick={() => setMode('edit')}>Modifier</Button>
+                <Button c={c} onClick={() => router.push(`/crm/evenements/nouveau?client_id=${client.id}`)}>+ Événement</Button>
+              </div>
+            </div>
+
+            {/* Infos client */}
+            <Card c={c} padding="responsive" style={{ marginBottom: 20 }}>
+              <div className="crm-kv">
+                {client.type === 'entreprise' && (
+                  <>
+                    <Kv c={c} label="Raison sociale" value={client.raison_sociale} />
+                    <Kv c={c} label="SIRET" value={client.siret} />
+                  </>
+                )}
+                <Kv c={c} label="Contact" value={[client.prenom, client.nom].filter(Boolean).join(' ') || '—'} />
+                <Kv c={c} label="E-mail" value={client.email ? <a href={`mailto:${client.email}`} style={{ color: c.accent }}>{client.email}</a> : '—'} />
+                <Kv c={c} label="Téléphone" value={client.telephone ? <a href={`tel:${client.telephone}`} style={{ color: c.accent }}>{client.telephone}</a> : '—'} />
+                <Kv c={c} label="Adresse" value={[client.adresse, [client.code_postal, client.ville].filter(Boolean).join(' ')].filter(Boolean).join(', ') || '—'} />
+                <Kv c={c} label="Créé le" value={formatDateFr(client.created_at)} />
+              </div>
+
+              {(client.tags || []).length > 0 && (
+                <div style={{ marginTop: 16 }}>
+                  <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: 6 }}>Tags</div>
+                  <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                    {client.tags.map((t) => (
+                      <Badge key={t} bg={hexToRgba(c.accent || '#6366F1', 0.12)} color={c.accent || '#6366F1'} size="sm">{t}</Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {client.notes && (
+                <div style={{ marginTop: 16 }}>
+                  <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: 6 }}>Notes</div>
+                  <div style={{ color: c.texte, fontSize: 14, whiteSpace: 'pre-wrap' }}>{client.notes}</div>
+                </div>
+              )}
+            </Card>
+
+            {/* Événements du client */}
+            <div className="crm-section">
+              <h2 className="crm-section__title" style={{ color: c.texte }}>
+                Événements {evenements.length > 0 && <span style={{ color: c.texteMuted, fontWeight: 400 }}>· {evenements.length}</span>}
+              </h2>
+              {evenements.length === 0 ? (
+                <div className="crm-empty" style={{ borderColor: c.bordure, background: c.blanc }}>
+                  <div className="crm-empty__title" style={{ color: c.texte }}>Aucun événement</div>
+                  <div className="crm-empty__text" style={{ color: c.texteMuted }}>Créez un premier événement pour ce client.</div>
+                  <Button c={c} onClick={() => router.push(`/crm/evenements/nouveau?client_id=${client.id}`)}>+ Nouvel événement</Button>
+                </div>
+              ) : (
+                <div className="crm-list">
+                  {evenements.map((e) => {
+                    const st = STATUTS_MAP[e.statut]
+                    return (
+                      <button
+                        key={e.id}
+                        type="button"
+                        onClick={() => router.push(`/crm/evenements/${e.id}`)}
+                        className="crm-row"
+                        style={{ background: c.blanc, borderColor: c.bordure, color: c.texte }}
+                      >
+                        <div>
+                          <div className="crm-row__primary" style={{ color: c.texte }}>{e.titre}</div>
+                          <div className="crm-row__secondary" style={{ color: c.texteMuted }}>
+                            {formatDateFr(e.date_evenement)}{e.nb_convives ? ` · ${e.nb_convives} convives` : ''}
+                          </div>
+                        </div>
+                        <div className="crm-row__secondary" style={{ color: c.texteMuted }}>
+                          {formatMontant(e.montant_final || e.montant_devis || e.budget_estime)}
+                        </div>
+                        <div className="crm-row__meta">
+                          {st && <Badge bg={hexToRgba(st.couleur, 0.12)} color={st.couleur} size="sm">{st.label}</Badge>}
+                        </div>
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+
+            {/* Zone danger */}
+            <div style={{ marginTop: 32, paddingTop: 16, borderTop: `0.5px solid ${c.bordure}` }}>
+              {confirmDelete ? (
+                <Alert variant="error" title="Confirmation">
+                  Supprimer ce client supprimera aussi {evenements.length > 0 ? `${evenements.length} événement(s) associé(s)` : 'ses données'}.
+                  <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>
+                    <Button c={c} variant="ghost" onClick={() => setConfirmDelete(false)}>Annuler</Button>
+                    <Button c={c} variant="danger-solid" onClick={handleDelete}>Supprimer définitivement</Button>
+                  </div>
+                </Alert>
+              ) : (
+                <Button c={c} variant="danger" onClick={() => setConfirmDelete(true)}>Supprimer ce client</Button>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Kv({ c, label, value }) {
+  return (
+    <div>
+      <div className="crm-kv__key" style={{ color: c.texteMuted }}>{label}</div>
+      <div className="crm-kv__value" style={{ color: c.texte }}>{value || '—'}</div>
+    </div>
+  )
+}

--- a/app/crm/clients/nouveau/page.js
+++ b/app/crm/clients/nouveau/page.js
@@ -1,0 +1,83 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase, getClientId } from '../../../../lib/supabase'
+import { useTheme } from '../../../../lib/useTheme'
+import { useRole } from '../../../../lib/useRole'
+import Navbar from '../../../../components/Navbar'
+import ClientForm from '../../../../components/crm/ClientForm'
+
+export default function NouveauClientPage() {
+  const router = useRouter()
+  const { c } = useTheme()
+  const { role, loading: roleLoading } = useRole()
+  const [authReady, setAuthReady] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const { data: { session } } = await supabase.auth.getSession()
+      if (cancelled) return
+      if (!session) { router.replace('/'); return }
+      setAuthReady(true)
+    })()
+    return () => { cancelled = true }
+  }, [router])
+
+  useEffect(() => {
+    if (!roleLoading && role && !['admin', 'directeur'].includes(role)) {
+      router.replace('/dashboard')
+    }
+  }, [role, roleLoading, router])
+
+  async function handleSubmit(values) {
+    const cid = await getClientId()
+    if (!cid) throw new Error('Établissement introuvable.')
+    const { data: { user } } = await supabase.auth.getUser()
+
+    const { data, error } = await supabase
+      .from('crm_clients')
+      .insert({ ...values, client_id: cid, created_by: user?.id || null })
+      .select('id')
+      .single()
+
+    if (error) throw error
+    router.push(`/crm/clients/${data.id}`)
+  }
+
+  if (!authReady || roleLoading) {
+    return (
+      <div style={{ minHeight: '100vh', background: c.fond, display: 'flex', alignItems: 'center', justifyContent: 'center', color: c.texteMuted, fontSize: 14 }}>
+        Chargement…
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ background: c.fond, minHeight: '100vh' }}>
+      <Navbar section="cuisine" />
+      <div className="crm-page">
+        <button
+          type="button"
+          onClick={() => router.push('/crm/clients')}
+          className="crm-back"
+          style={{ color: c.texteMuted }}
+        >← Clients</button>
+        <div className="crm-header">
+          <div className="crm-header__text">
+            <h1 className="crm-header__title" style={{ color: c.texte }}>Nouveau client</h1>
+            <p className="crm-header__subtitle" style={{ color: c.texteMuted }}>Particulier ou entreprise — les coordonnées peuvent être complétées plus tard.</p>
+          </div>
+        </div>
+
+        <ClientForm
+          c={c}
+          submitLabel="Créer le client"
+          onSubmit={handleSubmit}
+          onCancel={() => router.push('/crm/clients')}
+        />
+      </div>
+    </div>
+  )
+}

--- a/app/crm/clients/page.js
+++ b/app/crm/clients/page.js
@@ -1,0 +1,200 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase, getClientId } from '../../../lib/supabase'
+import { useTheme } from '../../../lib/useTheme'
+import { useRole } from '../../../lib/useRole'
+import { useIsMobile } from '../../../lib/useIsMobile'
+import Navbar from '../../../components/Navbar'
+import { Card, Button, Badge, Alert } from '../../../components/ui'
+import { clientDisplayName, hexToRgba, formatDateFr } from '../../../lib/crmConstants'
+
+export default function CrmClientsPage() {
+  const router = useRouter()
+  const { c } = useTheme()
+  const { role, loading: roleLoading } = useRole()
+  const isMobile = useIsMobile()
+
+  const [authReady, setAuthReady] = useState(false)
+  const [clients, setClients] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [recherche, setRecherche] = useState('')
+  const [filtreType, setFiltreType] = useState('tous')
+  const [filtreTag, setFiltreTag] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const { data: { session } } = await supabase.auth.getSession()
+      if (cancelled) return
+      if (!session) { router.replace('/'); return }
+      setAuthReady(true)
+    })()
+    return () => { cancelled = true }
+  }, [router])
+
+  useEffect(() => {
+    if (!roleLoading && role && !['admin', 'directeur'].includes(role)) {
+      router.replace('/dashboard')
+    }
+  }, [role, roleLoading, router])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    const cid = await getClientId()
+    if (!cid) { setLoading(false); return }
+
+    const { data, error: err } = await supabase
+      .from('crm_clients')
+      .select('id, type, nom, prenom, raison_sociale, email, telephone, ville, tags, created_at')
+      .eq('client_id', cid)
+      .order('created_at', { ascending: false })
+
+    if (err) { setError(err.message); setLoading(false); return }
+    setClients(data || [])
+    setLoading(false)
+  }, [])
+
+  useEffect(() => {
+    if (!authReady || !['admin', 'directeur'].includes(role || '')) return
+    load()
+  }, [authReady, role, load])
+
+  const tagsDispo = useMemo(() => {
+    const set = new Set()
+    for (const c of clients) (c.tags || []).forEach((t) => set.add(t))
+    return Array.from(set).sort()
+  }, [clients])
+
+  const filtres = useMemo(() => {
+    const q = recherche.trim().toLowerCase()
+    return clients.filter((cl) => {
+      if (filtreType !== 'tous' && cl.type !== filtreType) return false
+      if (filtreTag && !(cl.tags || []).includes(filtreTag)) return false
+      if (!q) return true
+      const hay = [clientDisplayName(cl), cl.email, cl.telephone, cl.ville, cl.raison_sociale].filter(Boolean).join(' ').toLowerCase()
+      return hay.includes(q)
+    })
+  }, [clients, recherche, filtreType, filtreTag])
+
+  if (!authReady || roleLoading) {
+    return (
+      <div style={{ minHeight: '100vh', background: c.fond, display: 'flex', alignItems: 'center', justifyContent: 'center', color: c.texteMuted, fontSize: 14 }}>
+        Chargement…
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ background: c.fond, minHeight: '100vh' }}>
+      <Navbar section="cuisine" />
+      <div className="crm-page">
+        <div className="crm-header">
+          <div className="crm-header__text">
+            <h1 className="crm-header__title" style={{ color: c.texte }}>Clients</h1>
+            <p className="crm-header__subtitle" style={{ color: c.texteMuted }}>
+              {clients.length} {clients.length > 1 ? 'clients' : 'client'} enregistré{clients.length > 1 ? 's' : ''}
+            </p>
+          </div>
+          <div className="crm-actions">
+            <Button c={c} onClick={() => router.push('/crm/clients/nouveau')}>+ Nouveau client</Button>
+          </div>
+        </div>
+
+        {error && <Alert variant="error">{error}</Alert>}
+
+        <div className="crm-toolbar">
+          <input
+            type="text"
+            placeholder="Rechercher un client…"
+            value={recherche}
+            onChange={(e) => setRecherche(e.target.value)}
+            className="crm-toolbar__search"
+            style={{ background: c.blanc, border: `0.5px solid ${c.bordure}`, color: c.texte }}
+          />
+          <select
+            value={filtreType}
+            onChange={(e) => setFiltreType(e.target.value)}
+            className="sk-select"
+            style={{ background: c.blanc, border: `0.5px solid ${c.bordure}`, color: c.texte }}
+          >
+            <option value="tous">Tous les types</option>
+            <option value="particulier">Particuliers</option>
+            <option value="entreprise">Entreprises</option>
+          </select>
+          {tagsDispo.length > 0 && (
+            <select
+              value={filtreTag}
+              onChange={(e) => setFiltreTag(e.target.value)}
+              className="sk-select"
+              style={{ background: c.blanc, border: `0.5px solid ${c.bordure}`, color: c.texte }}
+            >
+              <option value="">Tous les tags</option>
+              {tagsDispo.map((t) => <option key={t} value={t}>{t}</option>)}
+            </select>
+          )}
+        </div>
+
+        {loading ? (
+          <div style={{ color: c.texteMuted, fontSize: 13, padding: 12 }}>Chargement…</div>
+        ) : filtres.length === 0 ? (
+          <div className="crm-empty" style={{ borderColor: c.bordure, background: c.blanc }}>
+            <div className="crm-empty__title" style={{ color: c.texte }}>
+              {clients.length === 0 ? 'Aucun client pour le moment' : 'Aucun résultat'}
+            </div>
+            <div className="crm-empty__text" style={{ color: c.texteMuted }}>
+              {clients.length === 0
+                ? 'Ajoutez votre premier client pour commencer à suivre vos prospects.'
+                : 'Essayez d’ajuster vos filtres ou votre recherche.'}
+            </div>
+            {clients.length === 0 && (
+              <Button c={c} onClick={() => router.push('/crm/clients/nouveau')}>+ Nouveau client</Button>
+            )}
+          </div>
+        ) : (
+          <div className="crm-list">
+            {filtres.map((cl) => (
+              <button
+                key={cl.id}
+                type="button"
+                onClick={() => router.push(`/crm/clients/${cl.id}`)}
+                className="crm-row"
+                style={{ background: c.blanc, borderColor: c.bordure, color: c.texte }}
+              >
+                <div>
+                  <div className="crm-row__primary" style={{ color: c.texte }}>
+                    {clientDisplayName(cl)}
+                  </div>
+                  <div className="crm-row__secondary" style={{ color: c.texteMuted }}>
+                    {cl.email || cl.telephone || '—'}{cl.ville ? ` · ${cl.ville}` : ''}
+                  </div>
+                </div>
+                <div className="crm-row__meta">
+                  <Badge
+                    bg={cl.type === 'entreprise' ? hexToRgba('#6366F1', 0.12) : hexToRgba('#10B981', 0.12)}
+                    color={cl.type === 'entreprise' ? '#6366F1' : '#10B981'}
+                    size="sm"
+                  >
+                    {cl.type === 'entreprise' ? 'Entreprise' : 'Particulier'}
+                  </Badge>
+                  {(cl.tags || []).slice(0, 2).map((t) => (
+                    <Badge key={t} bg={hexToRgba(c.accent || '#6366F1', 0.10)} color={c.accent || '#6366F1'} size="sm">{t}</Badge>
+                  ))}
+                  {(cl.tags || []).length > 2 && (
+                    <span style={{ color: c.texteMuted, fontSize: 11 }}>+{cl.tags.length - 2}</span>
+                  )}
+                </div>
+                <div className="crm-row__secondary" style={{ color: c.texteMuted, fontSize: 11 }}>
+                  Créé {formatDateFr(cl.created_at)}
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/crm/evenements/[id]/page.js
+++ b/app/crm/evenements/[id]/page.js
@@ -1,0 +1,277 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter, useParams } from 'next/navigation'
+import { supabase, getClientId } from '../../../../lib/supabase'
+import { useTheme } from '../../../../lib/useTheme'
+import { useRole } from '../../../../lib/useRole'
+import Navbar from '../../../../components/Navbar'
+import { Card, Button, Badge, Alert } from '../../../../components/ui'
+import EvenementForm from '../../../../components/crm/EvenementForm'
+import {
+  STATUTS, STATUTS_MAP, TYPES_PRESTATION_MAP, LIEUX_TYPES_MAP,
+  formatDateFr, formatMontant, clientDisplayName, hexToRgba,
+} from '../../../../lib/crmConstants'
+
+export default function CrmEvenementDetailPage() {
+  const router = useRouter()
+  const params = useParams()
+  const id = params?.id
+  const { c } = useTheme()
+  const { role, loading: roleLoading } = useRole()
+
+  const [authReady, setAuthReady] = useState(false)
+  const [clientId, setClientId] = useState(null)
+  const [evenement, setEvenement] = useState(null)
+  const [clientCrm, setClientCrm] = useState(null)
+  const [clientsDispo, setClientsDispo] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [mode, setMode] = useState('view')
+  const [statutSaving, setStatutSaving] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const { data: { session } } = await supabase.auth.getSession()
+      if (cancelled) return
+      if (!session) { router.replace('/'); return }
+      setAuthReady(true)
+    })()
+    return () => { cancelled = true }
+  }, [router])
+
+  useEffect(() => {
+    if (!roleLoading && role && !['admin', 'directeur'].includes(role)) {
+      router.replace('/dashboard')
+    }
+  }, [role, roleLoading, router])
+
+  const load = useCallback(async () => {
+    if (!id) return
+    setLoading(true)
+    setError('')
+    const cid = await getClientId()
+    if (!cid) { setLoading(false); return }
+    setClientId(cid)
+
+    const { data: ev, error: eErr } = await supabase
+      .from('crm_evenements')
+      .select('*')
+      .eq('id', id).eq('client_id', cid)
+      .maybeSingle()
+
+    if (eErr) { setError(eErr.message); setLoading(false); return }
+    setEvenement(ev)
+
+    if (ev?.crm_client_id) {
+      const { data: cli } = await supabase
+        .from('crm_clients')
+        .select('id, type, nom, prenom, raison_sociale, email, telephone')
+        .eq('id', ev.crm_client_id).eq('client_id', cid)
+        .maybeSingle()
+      setClientCrm(cli)
+    }
+
+    // Pour le form d'édition
+    const { data: allClients } = await supabase
+      .from('crm_clients')
+      .select('id, type, nom, prenom, raison_sociale')
+      .eq('client_id', cid)
+    setClientsDispo(allClients || [])
+    setLoading(false)
+  }, [id])
+
+  useEffect(() => {
+    if (!authReady || !['admin', 'directeur'].includes(role || '')) return
+    load()
+  }, [authReady, role, load])
+
+  async function handleSave(values) {
+    const { error: err } = await supabase
+      .from('crm_evenements')
+      .update(values)
+      .eq('id', id)
+      .eq('client_id', clientId)
+    if (err) throw err
+    setMode('view')
+    await load()
+  }
+
+  async function handleStatutChange(newStatut) {
+    setStatutSaving(true)
+    const { error: err } = await supabase
+      .from('crm_evenements')
+      .update({ statut: newStatut })
+      .eq('id', id)
+      .eq('client_id', clientId)
+    if (!err) setEvenement((ev) => ({ ...ev, statut: newStatut }))
+    else setError(err.message)
+    setStatutSaving(false)
+  }
+
+  async function handleDelete() {
+    const { error: err } = await supabase
+      .from('crm_evenements')
+      .delete()
+      .eq('id', id)
+      .eq('client_id', clientId)
+    if (err) { setError(err.message); return }
+    router.push('/crm/evenements')
+  }
+
+  const statut = useMemo(() => STATUTS_MAP[evenement?.statut], [evenement])
+  const typePresta = useMemo(() => TYPES_PRESTATION_MAP[evenement?.type_prestation], [evenement])
+  const lieu = useMemo(() => LIEUX_TYPES_MAP[evenement?.lieu_type], [evenement])
+
+  if (!authReady || roleLoading) {
+    return (
+      <div style={{ minHeight: '100vh', background: c.fond, display: 'flex', alignItems: 'center', justifyContent: 'center', color: c.texteMuted, fontSize: 14 }}>
+        Chargement…
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ background: c.fond, minHeight: '100vh' }}>
+      <Navbar section="cuisine" />
+      <div className="crm-page">
+        <button type="button" onClick={() => router.push('/crm/evenements')} className="crm-back" style={{ color: c.texteMuted }}>
+          ← Événements
+        </button>
+
+        {error && <Alert variant="error">{error}</Alert>}
+
+        {loading ? (
+          <div style={{ color: c.texteMuted, fontSize: 13, padding: 12 }}>Chargement…</div>
+        ) : !evenement ? (
+          <Alert variant="warn">Événement introuvable.</Alert>
+        ) : mode === 'edit' ? (
+          <>
+            <div className="crm-header">
+              <div className="crm-header__text">
+                <h1 className="crm-header__title" style={{ color: c.texte }}>Modifier l’événement</h1>
+              </div>
+            </div>
+            <EvenementForm
+              c={c}
+              initial={evenement}
+              clientsDispo={clientsDispo}
+              submitLabel="Enregistrer"
+              onSubmit={handleSave}
+              onCancel={() => setMode('view')}
+            />
+          </>
+        ) : (
+          <>
+            <div className="crm-header">
+              <div className="crm-header__text">
+                <h1 className="crm-header__title" style={{ color: c.texte }}>{evenement.titre}</h1>
+                <p className="crm-header__subtitle" style={{ color: c.texteMuted, display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' }}>
+                  {clientCrm && (
+                    <button
+                      type="button"
+                      onClick={() => router.push(`/crm/clients/${clientCrm.id}`)}
+                      style={{ background: 'transparent', border: 'none', color: c.accent, cursor: 'pointer', padding: 0, fontSize: 13, textDecoration: 'underline' }}
+                    >
+                      {clientDisplayName(clientCrm)}
+                    </button>
+                  )}
+                  {typePresta && <span>· {typePresta.label}</span>}
+                  {evenement.nb_convives && <span>· {evenement.nb_convives} convives</span>}
+                </p>
+              </div>
+              <div className="crm-actions">
+                <Button c={c} variant="ghost" onClick={() => setMode('edit')}>Modifier</Button>
+              </div>
+            </div>
+
+            {/* Pipeline / statut */}
+            <Card c={c} padding="md" style={{ marginBottom: 20 }}>
+              <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 12 }}>
+                <div className="sk-label-muted" style={{ color: c.texteMuted }}>Statut</div>
+                {statut && (
+                  <Badge bg={hexToRgba(statut.couleur, 0.14)} color={statut.couleur} size="lg">
+                    {statut.label}
+                  </Badge>
+                )}
+                <select
+                  value={evenement.statut}
+                  onChange={(e) => handleStatutChange(e.target.value)}
+                  disabled={statutSaving}
+                  className="sk-select"
+                  style={{ background: c.blanc, border: `0.5px solid ${c.bordure}`, color: c.texte, marginLeft: 'auto' }}
+                >
+                  {STATUTS.map((s) => <option key={s.key} value={s.key}>{s.label}</option>)}
+                </select>
+              </div>
+            </Card>
+
+            {/* Détails */}
+            <Card c={c} padding="responsive" style={{ marginBottom: 20 }}>
+              <div className="crm-kv">
+                <Kv c={c} label="Date" value={formatDateFr(evenement.date_evenement)} />
+                <Kv c={c} label="Heure" value={evenement.heure_debut ? evenement.heure_debut.slice(0, 5) : '—'} />
+                <Kv c={c} label="Convives" value={evenement.nb_convives || '—'} />
+                <Kv c={c} label="Type" value={typePresta?.label || '—'} />
+                <Kv c={c} label="Lieu" value={lieu?.label || '—'} />
+                <Kv c={c} label="Adresse du lieu" value={evenement.lieu_adresse || '—'} />
+                <Kv c={c} label="Budget estimé" value={formatMontant(evenement.budget_estime)} />
+                <Kv c={c} label="Montant devis" value={formatMontant(evenement.montant_devis)} />
+                <Kv c={c} label="Montant final" value={formatMontant(evenement.montant_final)} />
+              </div>
+
+              {evenement.notes && (
+                <div style={{ marginTop: 16 }}>
+                  <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: 6 }}>Notes</div>
+                  <div style={{ color: c.texte, fontSize: 14, whiteSpace: 'pre-wrap' }}>{evenement.notes}</div>
+                </div>
+              )}
+            </Card>
+
+            {/* Contact client */}
+            {clientCrm && (
+              <Card c={c} padding="md" style={{ marginBottom: 20 }}>
+                <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: 8 }}>Contact client</div>
+                <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center', fontSize: 14 }}>
+                  <span style={{ color: c.texte, fontWeight: 500 }}>{clientDisplayName(clientCrm)}</span>
+                  {clientCrm.email && (
+                    <a href={`mailto:${clientCrm.email}`} style={{ color: c.accent }}>{clientCrm.email}</a>
+                  )}
+                  {clientCrm.telephone && (
+                    <a href={`tel:${clientCrm.telephone}`} style={{ color: c.accent }}>{clientCrm.telephone}</a>
+                  )}
+                </div>
+              </Card>
+            )}
+
+            {/* Zone danger */}
+            <div style={{ marginTop: 32, paddingTop: 16, borderTop: `0.5px solid ${c.bordure}` }}>
+              {confirmDelete ? (
+                <Alert variant="error" title="Confirmation">
+                  Supprimer définitivement cet événement ?
+                  <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>
+                    <Button c={c} variant="ghost" onClick={() => setConfirmDelete(false)}>Annuler</Button>
+                    <Button c={c} variant="danger-solid" onClick={handleDelete}>Supprimer</Button>
+                  </div>
+                </Alert>
+              ) : (
+                <Button c={c} variant="danger" onClick={() => setConfirmDelete(true)}>Supprimer cet événement</Button>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Kv({ c, label, value }) {
+  return (
+    <div>
+      <div className="crm-kv__key" style={{ color: c.texteMuted }}>{label}</div>
+      <div className="crm-kv__value" style={{ color: c.texte }}>{value || '—'}</div>
+    </div>
+  )
+}

--- a/app/crm/evenements/nouveau/page.js
+++ b/app/crm/evenements/nouveau/page.js
@@ -1,0 +1,114 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { supabase, getClientId } from '../../../../lib/supabase'
+import { useTheme } from '../../../../lib/useTheme'
+import { useRole } from '../../../../lib/useRole'
+import Navbar from '../../../../components/Navbar'
+import EvenementForm from '../../../../components/crm/EvenementForm'
+
+export default function NouvelEvenementPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const preselectedClientId = searchParams?.get('client_id') || ''
+  const { c } = useTheme()
+  const { role, loading: roleLoading } = useRole()
+
+  const [authReady, setAuthReady] = useState(false)
+  const [clients, setClients] = useState([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const { data: { session } } = await supabase.auth.getSession()
+      if (cancelled) return
+      if (!session) { router.replace('/'); return }
+      setAuthReady(true)
+    })()
+    return () => { cancelled = true }
+  }, [router])
+
+  useEffect(() => {
+    if (!roleLoading && role && !['admin', 'directeur'].includes(role)) {
+      router.replace('/dashboard')
+    }
+  }, [role, roleLoading, router])
+
+  const loadClients = useCallback(async () => {
+    const cid = await getClientId()
+    if (!cid) { setLoading(false); return }
+    const { data } = await supabase
+      .from('crm_clients')
+      .select('id, type, nom, prenom, raison_sociale')
+      .eq('client_id', cid)
+      .order('created_at', { ascending: false })
+    setClients(data || [])
+    setLoading(false)
+  }, [])
+
+  useEffect(() => {
+    if (!authReady || !['admin', 'directeur'].includes(role || '')) return
+    loadClients()
+  }, [authReady, role, loadClients])
+
+  async function handleSubmit(values) {
+    const cid = await getClientId()
+    if (!cid) throw new Error('Établissement introuvable.')
+    const { data: { user } } = await supabase.auth.getUser()
+
+    const { data, error } = await supabase
+      .from('crm_evenements')
+      .insert({ ...values, client_id: cid, created_by: user?.id || null })
+      .select('id')
+      .single()
+
+    if (error) throw error
+    router.push(`/crm/evenements/${data.id}`)
+  }
+
+  if (!authReady || roleLoading) {
+    return (
+      <div style={{ minHeight: '100vh', background: c.fond, display: 'flex', alignItems: 'center', justifyContent: 'center', color: c.texteMuted, fontSize: 14 }}>
+        Chargement…
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ background: c.fond, minHeight: '100vh' }}>
+      <Navbar section="cuisine" />
+      <div className="crm-page">
+        <button
+          type="button"
+          onClick={() => router.push('/crm/evenements')}
+          className="crm-back"
+          style={{ color: c.texteMuted }}
+        >← Événements</button>
+        <div className="crm-header">
+          <div className="crm-header__text">
+            <h1 className="crm-header__title" style={{ color: c.texte }}>Nouvel événement</h1>
+            <p className="crm-header__subtitle" style={{ color: c.texteMuted }}>
+              Rattachez l’événement à un client puis complétez les informations connues.
+            </p>
+          </div>
+        </div>
+
+        {loading ? (
+          <div style={{ color: c.texteMuted, fontSize: 13, padding: 12 }}>Chargement…</div>
+        ) : (
+          <EvenementForm
+            c={c}
+            clientsDispo={clients}
+            initial={preselectedClientId ? { crm_client_id: preselectedClientId } : {}}
+            lockClient={!!preselectedClientId}
+            submitLabel="Créer l’événement"
+            onSubmit={handleSubmit}
+            onCancel={() => router.push('/crm/evenements')}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/crm/evenements/page.js
+++ b/app/crm/evenements/page.js
@@ -1,0 +1,285 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase, getClientId } from '../../../lib/supabase'
+import { useTheme } from '../../../lib/useTheme'
+import { useRole } from '../../../lib/useRole'
+import { useIsMobile } from '../../../lib/useIsMobile'
+import Navbar from '../../../components/Navbar'
+import { Card, Button, Badge, Alert } from '../../../components/ui'
+import {
+  STATUTS_MAP, KANBAN_STATUTS, STATUTS, TYPES_PRESTATION_MAP,
+  formatDateFr, formatMontant, clientDisplayName, hexToRgba,
+} from '../../../lib/crmConstants'
+
+export default function CrmEvenementsPage() {
+  const router = useRouter()
+  const { c } = useTheme()
+  const { role, loading: roleLoading } = useRole()
+  const isMobile = useIsMobile()
+
+  const [authReady, setAuthReady] = useState(false)
+  const [evenements, setEvenements] = useState([])
+  const [clients, setClients] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  const [vue, setVue] = useState('kanban') // 'kanban' | 'liste'
+  const [recherche, setRecherche] = useState('')
+  const [filtreStatut, setFiltreStatut] = useState('tous')
+  const [filtreClos, setFiltreClos] = useState(false) // si true, montre annule/perdu en vue liste
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const { data: { session } } = await supabase.auth.getSession()
+      if (cancelled) return
+      if (!session) { router.replace('/'); return }
+      setAuthReady(true)
+    })()
+    return () => { cancelled = true }
+  }, [router])
+
+  useEffect(() => {
+    if (!roleLoading && role && !['admin', 'directeur'].includes(role)) {
+      router.replace('/dashboard')
+    }
+  }, [role, roleLoading, router])
+
+  useEffect(() => {
+    if (isMobile) setVue('liste')
+  }, [isMobile])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    const cid = await getClientId()
+    if (!cid) { setLoading(false); return }
+
+    const [{ data: eData, error: eErr }, { data: cData, error: cErr }] = await Promise.all([
+      supabase.from('crm_evenements')
+        .select('id, crm_client_id, titre, date_evenement, statut, type_prestation, nb_convives, montant_devis, montant_final, budget_estime, lieu_type, created_at')
+        .eq('client_id', cid)
+        .order('date_evenement', { ascending: true, nullsFirst: false }),
+      supabase.from('crm_clients')
+        .select('id, type, nom, prenom, raison_sociale')
+        .eq('client_id', cid),
+    ])
+    if (eErr || cErr) { setError((eErr || cErr).message); setLoading(false); return }
+    setEvenements(eData || [])
+    setClients(cData || [])
+    setLoading(false)
+  }, [])
+
+  useEffect(() => {
+    if (!authReady || !['admin', 'directeur'].includes(role || '')) return
+    load()
+  }, [authReady, role, load])
+
+  const clientById = useMemo(() => Object.fromEntries(clients.map((c) => [c.id, c])), [clients])
+
+  const filtres = useMemo(() => {
+    const q = recherche.trim().toLowerCase()
+    return evenements.filter((e) => {
+      if (filtreStatut !== 'tous' && e.statut !== filtreStatut) return false
+      if (!q) return true
+      const hay = [e.titre, clientDisplayName(clientById[e.crm_client_id])].filter(Boolean).join(' ').toLowerCase()
+      return hay.includes(q)
+    })
+  }, [evenements, recherche, filtreStatut, clientById])
+
+  const filtresListe = useMemo(() => {
+    if (filtreClos) return filtres
+    return filtres.filter((e) => !['annule', 'perdu'].includes(e.statut))
+  }, [filtres, filtreClos])
+
+  const parStatut = useMemo(() => {
+    const map = {}
+    for (const s of KANBAN_STATUTS) map[s.key] = []
+    for (const e of filtres) if (map[e.statut]) map[e.statut].push(e)
+    return map
+  }, [filtres])
+
+  if (!authReady || roleLoading) {
+    return (
+      <div style={{ minHeight: '100vh', background: c.fond, display: 'flex', alignItems: 'center', justifyContent: 'center', color: c.texteMuted, fontSize: 14 }}>
+        Chargement…
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ background: c.fond, minHeight: '100vh' }}>
+      <Navbar section="cuisine" />
+      <div className="crm-page">
+        <div className="crm-header">
+          <div className="crm-header__text">
+            <h1 className="crm-header__title" style={{ color: c.texte }}>Événements</h1>
+            <p className="crm-header__subtitle" style={{ color: c.texteMuted }}>
+              Pipeline traiteur · {evenements.length} événement{evenements.length > 1 ? 's' : ''}
+            </p>
+          </div>
+          <div className="crm-actions">
+            <Button c={c} onClick={() => router.push('/crm/evenements/nouveau')}>+ Nouvel événement</Button>
+          </div>
+        </div>
+
+        {error && <Alert variant="error">{error}</Alert>}
+
+        <div className="crm-toolbar">
+          <input
+            type="text"
+            placeholder="Rechercher…"
+            value={recherche}
+            onChange={(e) => setRecherche(e.target.value)}
+            className="crm-toolbar__search"
+            style={{ background: c.blanc, border: `0.5px solid ${c.bordure}`, color: c.texte }}
+          />
+          <select
+            value={filtreStatut}
+            onChange={(e) => setFiltreStatut(e.target.value)}
+            className="sk-select"
+            style={{ background: c.blanc, border: `0.5px solid ${c.bordure}`, color: c.texte }}
+          >
+            <option value="tous">Tous les statuts</option>
+            {STATUTS.map((s) => <option key={s.key} value={s.key}>{s.label}</option>)}
+          </select>
+
+          {!isMobile && (
+            <div className="crm-tabs" style={{ background: c.fond, border: `0.5px solid ${c.bordure}`, marginLeft: 'auto' }}>
+              <button
+                type="button"
+                className="crm-tabs__btn"
+                onClick={() => setVue('kanban')}
+                style={{
+                  background: vue === 'kanban' ? c.blanc : 'transparent',
+                  color: vue === 'kanban' ? c.texte : c.texteMuted,
+                  fontWeight: vue === 'kanban' ? 500 : 400,
+                  boxShadow: vue === 'kanban' ? '0 1px 2px rgba(0,0,0,0.04)' : 'none',
+                }}
+              >Kanban</button>
+              <button
+                type="button"
+                className="crm-tabs__btn"
+                onClick={() => setVue('liste')}
+                style={{
+                  background: vue === 'liste' ? c.blanc : 'transparent',
+                  color: vue === 'liste' ? c.texte : c.texteMuted,
+                  fontWeight: vue === 'liste' ? 500 : 400,
+                  boxShadow: vue === 'liste' ? '0 1px 2px rgba(0,0,0,0.04)' : 'none',
+                }}
+              >Liste</button>
+            </div>
+          )}
+        </div>
+
+        {loading ? (
+          <div style={{ color: c.texteMuted, fontSize: 13, padding: 12 }}>Chargement…</div>
+        ) : evenements.length === 0 ? (
+          <div className="crm-empty" style={{ borderColor: c.bordure, background: c.blanc }}>
+            <div className="crm-empty__title" style={{ color: c.texte }}>Aucun événement</div>
+            <div className="crm-empty__text" style={{ color: c.texteMuted }}>Commencez à construire votre pipeline traiteur.</div>
+            <Button c={c} onClick={() => router.push('/crm/evenements/nouveau')}>+ Nouvel événement</Button>
+          </div>
+        ) : vue === 'kanban' ? (
+          <div className="crm-kanban">
+            {KANBAN_STATUTS.map((s) => {
+              const items = parStatut[s.key] || []
+              return (
+                <div
+                  key={s.key}
+                  className="crm-kanban__col"
+                  style={{ background: c.blanc, borderColor: c.bordure }}
+                >
+                  <div
+                    className="crm-kanban__col-header"
+                    style={{ color: s.couleur, borderColor: c.bordure }}
+                  >
+                    <span>{s.label}</span>
+                    <span className="crm-kanban__count" style={{ background: hexToRgba(s.couleur, 0.12), color: s.couleur }}>
+                      {items.length}
+                    </span>
+                  </div>
+                  <div className="crm-kanban__cards">
+                    {items.length === 0 ? (
+                      <div style={{ color: c.texteMuted, fontSize: 12, padding: '8px 4px' }}>—</div>
+                    ) : items.map((e) => (
+                      <button
+                        key={e.id}
+                        type="button"
+                        className="crm-kanban__card"
+                        onClick={() => router.push(`/crm/evenements/${e.id}`)}
+                        style={{ background: c.fond, borderColor: c.bordure, color: c.texte }}
+                      >
+                        <div className="crm-kanban__card-title" style={{ color: c.texte }}>{e.titre}</div>
+                        <div style={{ color: c.texteMuted, fontSize: 12 }}>
+                          {clientDisplayName(clientById[e.crm_client_id])}
+                        </div>
+                        <div className="crm-kanban__card-meta" style={{ color: c.texteMuted }}>
+                          <span>{formatDateFr(e.date_evenement)}</span>
+                          {e.nb_convives && <span>· {e.nb_convives} pers.</span>}
+                          {(e.montant_devis || e.budget_estime) && (
+                            <span>· {formatMontant(e.montant_final || e.montant_devis || e.budget_estime)}</span>
+                          )}
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        ) : (
+          <>
+            <div style={{ marginBottom: 10, display: 'flex', alignItems: 'center', gap: 8 }}>
+              <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, color: c.texteMuted, cursor: 'pointer' }}>
+                <input type="checkbox" checked={filtreClos} onChange={(e) => setFiltreClos(e.target.checked)} />
+                Afficher annulés / perdus
+              </label>
+            </div>
+            {filtresListe.length === 0 ? (
+              <Card c={c} padding="md">
+                <span style={{ color: c.texteMuted, fontSize: 13 }}>Aucun résultat.</span>
+              </Card>
+            ) : (
+              <div className="crm-list">
+                {filtresListe.map((e) => {
+                  const st = STATUTS_MAP[e.statut]
+                  const type = TYPES_PRESTATION_MAP[e.type_prestation]
+                  return (
+                    <button
+                      key={e.id}
+                      type="button"
+                      onClick={() => router.push(`/crm/evenements/${e.id}`)}
+                      className="crm-row"
+                      style={{ background: c.blanc, borderColor: c.bordure, color: c.texte }}
+                    >
+                      <div>
+                        <div className="crm-row__primary" style={{ color: c.texte }}>{e.titre}</div>
+                        <div className="crm-row__secondary" style={{ color: c.texteMuted }}>
+                          {clientDisplayName(clientById[e.crm_client_id])}
+                          {type ? ` · ${type.label}` : ''}
+                          {e.nb_convives ? ` · ${e.nb_convives} convives` : ''}
+                        </div>
+                      </div>
+                      <div className="crm-row__secondary" style={{ color: c.texteMuted }}>
+                        {formatDateFr(e.date_evenement)}
+                        {(e.montant_final || e.montant_devis || e.budget_estime) && (
+                          <div>{formatMontant(e.montant_final || e.montant_devis || e.budget_estime)}</div>
+                        )}
+                      </div>
+                      <div className="crm-row__meta">
+                        {st && <Badge bg={hexToRgba(st.couleur, 0.12)} color={st.couleur} size="sm">{st.label}</Badge>}
+                      </div>
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/crm/page.js
+++ b/app/crm/page.js
@@ -1,0 +1,230 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase, getClientId } from '../../lib/supabase'
+import { useTheme } from '../../lib/useTheme'
+import { useRole } from '../../lib/useRole'
+import { useIsMobile } from '../../lib/useIsMobile'
+import Navbar from '../../components/Navbar'
+import { Card, Button, Badge, Alert } from '../../components/ui'
+import {
+  STATUTS_MAP, STATUTS_ENGAGES, KANBAN_STATUTS,
+  formatMontant, formatDateFr, clientDisplayName, hexToRgba,
+} from '../../lib/crmConstants'
+
+export default function CrmDashboardPage() {
+  const router = useRouter()
+  const { c } = useTheme()
+  const { role, loading: roleLoading } = useRole()
+  const isMobile = useIsMobile()
+
+  const [authReady, setAuthReady] = useState(false)
+  const [clientId, setClientId] = useState(null)
+  const [clients, setClients] = useState([])
+  const [evenements, setEvenements] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const { data: { session } } = await supabase.auth.getSession()
+      if (cancelled) return
+      if (!session) { router.replace('/'); return }
+      setAuthReady(true)
+    })()
+    return () => { cancelled = true }
+  }, [router])
+
+  useEffect(() => {
+    if (!roleLoading && role && !['admin', 'directeur'].includes(role)) {
+      router.replace('/dashboard')
+    }
+  }, [role, roleLoading, router])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    const cid = await getClientId()
+    if (!cid) { setLoading(false); return }
+    setClientId(cid)
+
+    const [{ data: cData, error: cErr }, { data: eData, error: eErr }] = await Promise.all([
+      supabase.from('crm_clients')
+        .select('id, type, nom, prenom, raison_sociale')
+        .eq('client_id', cid),
+      supabase.from('crm_evenements')
+        .select('id, crm_client_id, titre, date_evenement, statut, type_prestation, nb_convives, montant_devis, montant_final, budget_estime, created_at')
+        .eq('client_id', cid),
+    ])
+
+    if (cErr || eErr) { setError((cErr || eErr).message); setLoading(false); return }
+    setClients(cData || [])
+    setEvenements(eData || [])
+    setLoading(false)
+  }, [])
+
+  useEffect(() => {
+    if (!authReady || !['admin', 'directeur'].includes(role || '')) return
+    load()
+  }, [authReady, role, load])
+
+  const clientById = useMemo(() => Object.fromEntries(clients.map((c) => [c.id, c])), [clients])
+
+  const stats = useMemo(() => {
+    const now = new Date()
+    const debutMois = new Date(now.getFullYear(), now.getMonth(), 1)
+    const finMois = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+
+    const dansLeMois = evenements.filter((e) => {
+      if (!e.date_evenement) return false
+      const d = new Date(e.date_evenement)
+      return d >= debutMois && d <= finMois
+    })
+
+    const caPrev = evenements
+      .filter((e) => STATUTS_ENGAGES.includes(e.statut))
+      .reduce((sum, e) => sum + (Number(e.montant_final) || Number(e.montant_devis) || Number(e.budget_estime) || 0), 0)
+
+    const aVenir = evenements
+      .filter((e) => e.date_evenement && new Date(e.date_evenement) >= now && !['annule', 'perdu'].includes(e.statut))
+      .sort((a, b) => new Date(a.date_evenement) - new Date(b.date_evenement))
+
+    const demandesRecentes = evenements
+      .filter((e) => ['demande', 'devis_envoye'].includes(e.statut))
+      .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+      .slice(0, 5)
+
+    const parStatut = {}
+    for (const s of KANBAN_STATUTS) parStatut[s.key] = 0
+    for (const e of evenements) if (parStatut[e.statut] !== undefined) parStatut[e.statut] += 1
+
+    return {
+      totalClients: clients.length,
+      evenementsMois: dansLeMois.length,
+      caPrev,
+      aVenir: aVenir.slice(0, 5),
+      demandesRecentes,
+      parStatut,
+    }
+  }, [evenements, clients])
+
+  if (!authReady || roleLoading) {
+    return (
+      <div style={{ minHeight: '100vh', background: c.fond, display: 'flex', alignItems: 'center', justifyContent: 'center', color: c.texteMuted, fontSize: 14 }}>
+        Chargement…
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ background: c.fond, minHeight: '100vh' }}>
+      <Navbar section="cuisine" />
+      <div className="crm-page">
+        <div className="crm-header">
+          <div className="crm-header__text">
+            <h1 className="crm-header__title" style={{ color: c.texte }}>CRM</h1>
+            <p className="crm-header__subtitle" style={{ color: c.texteMuted }}>Clients, événements et pipeline traiteur</p>
+          </div>
+          <div className="crm-actions">
+            <Button c={c} variant="ghost" onClick={() => router.push('/crm/clients/nouveau')}>+ Client</Button>
+            <Button c={c} onClick={() => router.push('/crm/evenements/nouveau')}>+ Événement</Button>
+          </div>
+        </div>
+
+        {error && <Alert variant="error">{error}</Alert>}
+
+        {/* ─── KPI ─────────────────────────────────────────────── */}
+        <div className="crm-kpi-grid">
+          <Kpi c={c} label="Clients" value={stats.totalClients} onClick={() => router.push('/crm/clients')} />
+          <Kpi c={c} label="Événements ce mois-ci" value={stats.evenementsMois} onClick={() => router.push('/crm/evenements')} />
+          <Kpi c={c} label="CA prévisionnel engagé" value={formatMontant(stats.caPrev)} />
+          <Kpi c={c} label="Demandes en cours" value={stats.parStatut.demande + stats.parStatut.devis_envoye} onClick={() => router.push('/crm/evenements')} />
+        </div>
+
+        {/* ─── Prochains événements ───────────────────────────── */}
+        <div className="crm-section">
+          <h2 className="crm-section__title" style={{ color: c.texte }}>Prochains événements</h2>
+          {loading ? (
+            <div style={{ color: c.texteMuted, fontSize: 13, padding: 12 }}>Chargement…</div>
+          ) : stats.aVenir.length === 0 ? (
+            <EmptyState c={c} title="Aucun événement à venir" text="Créez votre premier événement pour suivre votre pipeline." onAction={() => router.push('/crm/evenements/nouveau')} actionLabel="+ Nouvel événement" />
+          ) : (
+            <div className="crm-list">
+              {stats.aVenir.map((e) => (
+                <EventRow key={e.id} c={c} event={e} client={clientById[e.crm_client_id]} onClick={() => router.push(`/crm/evenements/${e.id}`)} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* ─── Demandes récentes ──────────────────────────────── */}
+        <div className="crm-section">
+          <h2 className="crm-section__title" style={{ color: c.texte }}>Demandes récentes</h2>
+          {loading ? (
+            <div style={{ color: c.texteMuted, fontSize: 13, padding: 12 }}>Chargement…</div>
+          ) : stats.demandesRecentes.length === 0 ? (
+            <Card c={c} padding="md">
+              <span style={{ color: c.texteMuted, fontSize: 13 }}>Pas de demande en attente — tout est sous contrôle.</span>
+            </Card>
+          ) : (
+            <div className="crm-list">
+              {stats.demandesRecentes.map((e) => (
+                <EventRow key={e.id} c={c} event={e} client={clientById[e.crm_client_id]} onClick={() => router.push(`/crm/evenements/${e.id}`)} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Kpi({ c, label, value, onClick }) {
+  return (
+    <Card c={c} padding="md" as={onClick ? 'button' : 'div'} onClick={onClick} style={onClick ? { cursor: 'pointer', textAlign: 'left', width: '100%' } : undefined}>
+      <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: 6 }}>{label}</div>
+      <div className="sk-stat-value" style={{ color: c.texte, fontSize: 26 }}>{value}</div>
+    </Card>
+  )
+}
+
+function EventRow({ c, event, client, onClick }) {
+  const statut = STATUTS_MAP[event.statut]
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="crm-row"
+      style={{ background: c.blanc, borderColor: c.bordure, color: c.texte }}
+    >
+      <div>
+        <div className="crm-row__primary" style={{ color: c.texte }}>{event.titre}</div>
+        <div className="crm-row__secondary" style={{ color: c.texteMuted }}>
+          {clientDisplayName(client)}{event.nb_convives ? ` · ${event.nb_convives} convives` : ''}
+        </div>
+      </div>
+      <div className="crm-row__secondary" style={{ color: c.texteMuted }}>
+        {formatDateFr(event.date_evenement)}
+      </div>
+      <div className="crm-row__meta">
+        {statut && (
+          <Badge bg={hexToRgba(statut.couleur, 0.12)} color={statut.couleur} size="sm">
+            {statut.label}
+          </Badge>
+        )}
+      </div>
+    </button>
+  )
+}
+
+function EmptyState({ c, title, text, onAction, actionLabel }) {
+  return (
+    <div className="crm-empty" style={{ borderColor: c.bordure, background: c.blanc }}>
+      <div className="crm-empty__title" style={{ color: c.texte }}>{title}</div>
+      <div className="crm-empty__text" style={{ color: c.texteMuted }}>{text}</div>
+      {onAction && <Button c={c} onClick={onAction}>{actionLabel}</Button>}
+    </div>
+  )
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,5 +1,6 @@
 import './globals.css'
 import './landing.css'
+import './crm.css'
 import Script from 'next/script'
 import Providers from '../components/Providers'
 import AnalyticsWrapper from '../components/AnalyticsWrapper'

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -154,6 +154,15 @@ export default function Navbar({ section = 'cuisine' }) {
             ...(hasModule('avis')                      ? [{ label: 'Avis clients',    path: '/avis' }]         : []),
           ]
         },
+        ...((role === 'admin' || role === 'directeur') ? [{
+          label: 'CRM',
+          paths: ['/crm'],
+          items: [
+            { label: 'Dashboard',   path: '/crm' },
+            { label: 'Clients',     path: '/crm/clients' },
+            { label: 'Événements',  path: '/crm/evenements' },
+          ]
+        }] : []),
         ...(role === 'admin' ? [{
           label: 'Admin',
           paths: ['/parametres', '/admin', '/admin/logs', '/admin/ardoise'],

--- a/components/crm/ClientForm.jsx
+++ b/components/crm/ClientForm.jsx
@@ -1,0 +1,242 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '../ui'
+import { SOURCES } from '../../lib/crmConstants'
+
+/**
+ * Formulaire partagé pour création + édition d'un crm_client.
+ *
+ * Props:
+ *   c            : couleurs de useTheme()
+ *   initial      : valeurs initiales (création = {}, édition = row existante)
+ *   submitLabel  : texte du bouton principal
+ *   onSubmit(vals) : async (champ client_id + created_by ajoutés par le parent)
+ *   onCancel     : optionnel, affiche un bouton Annuler
+ */
+export default function ClientForm({ c, initial = {}, submitLabel = 'Enregistrer', onSubmit, onCancel }) {
+  const [form, setForm] = useState({
+    type:           initial.type || 'particulier',
+    nom:            initial.nom || '',
+    prenom:         initial.prenom || '',
+    raison_sociale: initial.raison_sociale || '',
+    siret:          initial.siret || '',
+    email:          initial.email || '',
+    telephone:      initial.telephone || '',
+    adresse:        initial.adresse || '',
+    code_postal:    initial.code_postal || '',
+    ville:          initial.ville || '',
+    source:         initial.source || '',
+    tags:           initial.tags || [],
+    notes:          initial.notes || '',
+  })
+  const [tagInput, setTagInput] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  const upd = (k) => (e) => setForm((f) => ({ ...f, [k]: e.target.value }))
+
+  function addTag(raw) {
+    const v = (raw || '').trim()
+    if (!v) return
+    setForm((f) => f.tags.includes(v) ? f : { ...f, tags: [...f.tags, v] })
+    setTagInput('')
+  }
+
+  function removeTag(t) {
+    setForm((f) => ({ ...f, tags: f.tags.filter((x) => x !== t) }))
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setError('')
+
+    // Validation minimale
+    if (form.type === 'particulier' && !form.nom.trim() && !form.prenom.trim()) {
+      setError('Renseignez au moins un nom ou un prénom.'); return
+    }
+    if (form.type === 'entreprise' && !form.raison_sociale.trim()) {
+      setError('La raison sociale est obligatoire pour une entreprise.'); return
+    }
+
+    const payload = {
+      type:           form.type,
+      nom:            form.nom.trim() || null,
+      prenom:         form.prenom.trim() || null,
+      raison_sociale: form.raison_sociale.trim() || null,
+      siret:          form.siret.trim() || null,
+      email:          form.email.trim() || null,
+      telephone:      form.telephone.trim() || null,
+      adresse:        form.adresse.trim() || null,
+      code_postal:    form.code_postal.trim() || null,
+      ville:          form.ville.trim() || null,
+      source:         form.source || null,
+      tags:           form.tags,
+      notes:          form.notes.trim() || null,
+    }
+
+    setSaving(true)
+    try {
+      await onSubmit(payload)
+    } catch (err) {
+      setError(err?.message || 'Erreur lors de l’enregistrement.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const inputStyle = { background: c.blanc, borderColor: c.bordure, color: c.texte }
+  const labelStyle = { color: c.texte }
+  const isEntreprise = form.type === 'entreprise'
+
+  return (
+    <form onSubmit={handleSubmit} className="crm-form">
+      {/* Type */}
+      <div className="crm-field">
+        <label className="crm-field__label" style={labelStyle}>Type</label>
+        <div className="crm-typetoggle" style={{ background: c.fond, borderColor: c.bordure }}>
+          <button
+            type="button"
+            onClick={() => setForm((f) => ({ ...f, type: 'particulier' }))}
+            className="crm-typetoggle__btn"
+            style={{
+              background: form.type === 'particulier' ? c.accent : 'transparent',
+              color: form.type === 'particulier' ? '#fff' : c.texteMuted,
+              fontWeight: form.type === 'particulier' ? 500 : 400,
+            }}
+          >Particulier</button>
+          <button
+            type="button"
+            onClick={() => setForm((f) => ({ ...f, type: 'entreprise' }))}
+            className="crm-typetoggle__btn"
+            style={{
+              background: form.type === 'entreprise' ? c.accent : 'transparent',
+              color: form.type === 'entreprise' ? '#fff' : c.texteMuted,
+              fontWeight: form.type === 'entreprise' ? 500 : 400,
+            }}
+          >Entreprise</button>
+        </div>
+      </div>
+
+      {/* Identité */}
+      {isEntreprise && (
+        <div className="crm-form__grid crm-form__grid--2">
+          <div className="crm-field">
+            <label className="crm-field__label crm-field__label--required" style={labelStyle}>Raison sociale</label>
+            <input className="crm-field__input" style={inputStyle} value={form.raison_sociale} onChange={upd('raison_sociale')} placeholder="SAS Martin & Co" />
+          </div>
+          <div className="crm-field">
+            <label className="crm-field__label" style={labelStyle}>SIRET</label>
+            <input className="crm-field__input" style={inputStyle} value={form.siret} onChange={upd('siret')} placeholder="123 456 789 00012" />
+          </div>
+        </div>
+      )}
+      <div className="crm-form__grid crm-form__grid--2">
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>Prénom{isEntreprise ? ' (contact)' : ''}</label>
+          <input className="crm-field__input" style={inputStyle} value={form.prenom} onChange={upd('prenom')} placeholder="Marie" />
+        </div>
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>Nom{isEntreprise ? ' (contact)' : ''}</label>
+          <input className="crm-field__input" style={inputStyle} value={form.nom} onChange={upd('nom')} placeholder="Dupont" />
+        </div>
+      </div>
+
+      {/* Contact */}
+      <div className="crm-form__grid crm-form__grid--2">
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>E-mail</label>
+          <input type="email" className="crm-field__input" style={inputStyle} value={form.email} onChange={upd('email')} placeholder="marie@exemple.fr" />
+        </div>
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>Téléphone</label>
+          <input className="crm-field__input" style={inputStyle} value={form.telephone} onChange={upd('telephone')} placeholder="06 12 34 56 78" />
+        </div>
+      </div>
+
+      {/* Adresse */}
+      <div className="crm-field">
+        <label className="crm-field__label" style={labelStyle}>Adresse</label>
+        <input className="crm-field__input" style={inputStyle} value={form.adresse} onChange={upd('adresse')} placeholder="12 rue de la Paix" />
+      </div>
+      <div className="crm-form__grid crm-form__grid--2">
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>Code postal</label>
+          <input className="crm-field__input" style={inputStyle} value={form.code_postal} onChange={upd('code_postal')} placeholder="75001" />
+        </div>
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>Ville</label>
+          <input className="crm-field__input" style={inputStyle} value={form.ville} onChange={upd('ville')} placeholder="Paris" />
+        </div>
+      </div>
+
+      {/* Source + tags */}
+      <div className="crm-field">
+        <label className="crm-field__label" style={labelStyle}>Source</label>
+        <select className="crm-field__select" style={inputStyle} value={form.source} onChange={upd('source')}>
+          <option value="">Non renseignée</option>
+          {SOURCES.map((s) => <option key={s} value={s}>{s}</option>)}
+        </select>
+      </div>
+
+      <div className="crm-field">
+        <label className="crm-field__label" style={labelStyle}>Tags</label>
+        <div
+          className="crm-tags"
+          style={{
+            background: c.blanc,
+            border: `0.5px solid ${c.bordure}`,
+            borderRadius: 8,
+            padding: '6px 8px',
+            minHeight: 40,
+          }}
+        >
+          {form.tags.map((t) => (
+            <span
+              key={t}
+              className="crm-tag"
+              style={{ background: c.accentClair || 'rgba(99,102,241,0.12)', color: c.accent || '#6366F1' }}
+            >
+              {t}
+              <button type="button" className="crm-tag__remove" onClick={() => removeTag(t)} aria-label={`Retirer ${t}`}>×</button>
+            </span>
+          ))}
+          <input
+            className="crm-tag-input"
+            style={{ color: c.texte }}
+            value={tagInput}
+            onChange={(e) => setTagInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ',') {
+                e.preventDefault()
+                addTag(tagInput)
+              } else if (e.key === 'Backspace' && !tagInput && form.tags.length) {
+                removeTag(form.tags[form.tags.length - 1])
+              }
+            }}
+            onBlur={() => addTag(tagInput)}
+            placeholder={form.tags.length ? '' : 'Entrée pour ajouter (VIP, Fidèle…)'}
+          />
+        </div>
+        <span className="crm-field__hint" style={{ color: c.texteMuted }}>
+          Appuyez sur Entrée ou virgule pour valider un tag.
+        </span>
+      </div>
+
+      {/* Notes */}
+      <div className="crm-field">
+        <label className="crm-field__label" style={labelStyle}>Notes</label>
+        <textarea className="crm-field__textarea" style={inputStyle} value={form.notes} onChange={upd('notes')} placeholder="Allergies, préférences, récurrence annuelle…" />
+      </div>
+
+      {error && (
+        <div style={{ color: 'var(--sk-rouge-texte)', fontSize: 13 }}>{error}</div>
+      )}
+
+      <div className="crm-actions">
+        {onCancel && <Button c={c} variant="ghost" type="button" onClick={onCancel}>Annuler</Button>}
+        <Button c={c} type="submit" disabled={saving}>{saving ? 'Enregistrement…' : submitLabel}</Button>
+      </div>
+    </form>
+  )
+}

--- a/components/crm/EvenementForm.jsx
+++ b/components/crm/EvenementForm.jsx
@@ -1,0 +1,188 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '../ui'
+import { TYPES_PRESTATION, LIEUX_TYPES, STATUTS, clientDisplayName } from '../../lib/crmConstants'
+
+/**
+ * Formulaire partagé pour création + édition d'un crm_evenement.
+ *
+ * Props:
+ *   c                 : couleurs de useTheme()
+ *   initial           : valeurs initiales ({} en création)
+ *   clientsDispo      : liste des clients CRM (pour le select)
+ *   lockClient        : si true, le select client est désactivé (pré-rempli)
+ *   submitLabel       : texte du bouton principal
+ *   onSubmit(vals)    : async handler
+ *   onCancel          : optionnel
+ */
+export default function EvenementForm({ c, initial = {}, clientsDispo = [], lockClient = false, submitLabel = 'Enregistrer', onSubmit, onCancel }) {
+  const [form, setForm] = useState({
+    crm_client_id:   initial.crm_client_id || '',
+    titre:           initial.titre || '',
+    type_prestation: initial.type_prestation || '',
+    date_evenement:  initial.date_evenement || '',
+    heure_debut:     initial.heure_debut || '',
+    nb_convives:     initial.nb_convives ?? '',
+    lieu_type:       initial.lieu_type || 'sur_place',
+    lieu_adresse:    initial.lieu_adresse || '',
+    statut:          initial.statut || 'demande',
+    budget_estime:   initial.budget_estime ?? '',
+    montant_devis:   initial.montant_devis ?? '',
+    montant_final:   initial.montant_final ?? '',
+    notes:           initial.notes || '',
+  })
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  const upd = (k) => (e) => setForm((f) => ({ ...f, [k]: e.target.value }))
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setError('')
+
+    if (!form.crm_client_id) { setError('Sélectionnez un client.'); return }
+    if (!form.titre.trim()) { setError('Donnez un titre à l’événement.'); return }
+
+    const payload = {
+      crm_client_id:   form.crm_client_id,
+      titre:           form.titre.trim(),
+      type_prestation: form.type_prestation || null,
+      date_evenement:  form.date_evenement || null,
+      heure_debut:     form.heure_debut || null,
+      nb_convives:     form.nb_convives === '' ? null : Number(form.nb_convives),
+      lieu_type:       form.lieu_type || 'sur_place',
+      lieu_adresse:    form.lieu_adresse.trim() || null,
+      statut:          form.statut || 'demande',
+      budget_estime:   form.budget_estime === '' ? null : Number(form.budget_estime),
+      montant_devis:   form.montant_devis === '' ? null : Number(form.montant_devis),
+      montant_final:   form.montant_final === '' ? null : Number(form.montant_final),
+      notes:           form.notes.trim() || null,
+    }
+
+    setSaving(true)
+    try {
+      await onSubmit(payload)
+    } catch (err) {
+      setError(err?.message || 'Erreur lors de l’enregistrement.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const inputStyle = { background: c.blanc, borderColor: c.bordure, color: c.texte }
+  const labelStyle = { color: c.texte }
+  const besoinAdresse = form.lieu_type === 'livraison' || form.lieu_type === 'externe'
+
+  return (
+    <form onSubmit={handleSubmit} className="crm-form">
+      {/* Client */}
+      <div className="crm-field">
+        <label className="crm-field__label crm-field__label--required" style={labelStyle}>Client</label>
+        <select
+          className="crm-field__select"
+          style={inputStyle}
+          value={form.crm_client_id}
+          onChange={upd('crm_client_id')}
+          disabled={lockClient}
+        >
+          <option value="">Sélectionner un client…</option>
+          {clientsDispo.map((cl) => (
+            <option key={cl.id} value={cl.id}>{clientDisplayName(cl)}</option>
+          ))}
+        </select>
+        {clientsDispo.length === 0 && (
+          <span className="crm-field__hint" style={{ color: c.texteMuted }}>
+            Créez d’abord un client avant d’ajouter un événement.
+          </span>
+        )}
+      </div>
+
+      {/* Titre */}
+      <div className="crm-field">
+        <label className="crm-field__label crm-field__label--required" style={labelStyle}>Titre</label>
+        <input className="crm-field__input" style={inputStyle} value={form.titre} onChange={upd('titre')} placeholder="Mariage Dupont / Cocktail Acme / Séminaire…" />
+      </div>
+
+      {/* Type + statut */}
+      <div className="crm-form__grid crm-form__grid--2">
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>Type de prestation</label>
+          <select className="crm-field__select" style={inputStyle} value={form.type_prestation} onChange={upd('type_prestation')}>
+            <option value="">Non précisé</option>
+            {TYPES_PRESTATION.map((t) => <option key={t.key} value={t.key}>{t.label}</option>)}
+          </select>
+        </div>
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>Statut</label>
+          <select className="crm-field__select" style={inputStyle} value={form.statut} onChange={upd('statut')}>
+            {STATUTS.map((s) => <option key={s.key} value={s.key}>{s.label}</option>)}
+          </select>
+        </div>
+      </div>
+
+      {/* Date / heure / convives */}
+      <div className="crm-form__grid crm-form__grid--3">
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>Date</label>
+          <input type="date" className="crm-field__input" style={inputStyle} value={form.date_evenement} onChange={upd('date_evenement')} />
+        </div>
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>Heure</label>
+          <input type="time" className="crm-field__input" style={inputStyle} value={form.heure_debut} onChange={upd('heure_debut')} />
+        </div>
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>Nb convives</label>
+          <input type="number" min="0" className="crm-field__input" style={inputStyle} value={form.nb_convives} onChange={upd('nb_convives')} placeholder="80" />
+        </div>
+      </div>
+
+      {/* Lieu */}
+      <div className="crm-form__grid crm-form__grid--2">
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>Lieu</label>
+          <select className="crm-field__select" style={inputStyle} value={form.lieu_type} onChange={upd('lieu_type')}>
+            {LIEUX_TYPES.map((l) => <option key={l.key} value={l.key}>{l.label}</option>)}
+          </select>
+        </div>
+        {besoinAdresse && (
+          <div className="crm-field">
+            <label className="crm-field__label" style={labelStyle}>Adresse du lieu</label>
+            <input className="crm-field__input" style={inputStyle} value={form.lieu_adresse} onChange={upd('lieu_adresse')} placeholder="Domaine de la Roche, 77…" />
+          </div>
+        )}
+      </div>
+
+      {/* Budget / devis / final */}
+      <div className="crm-form__grid crm-form__grid--3">
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>Budget estimé (€)</label>
+          <input type="number" min="0" step="50" className="crm-field__input" style={inputStyle} value={form.budget_estime} onChange={upd('budget_estime')} placeholder="3000" />
+        </div>
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>Montant devis (€)</label>
+          <input type="number" min="0" step="50" className="crm-field__input" style={inputStyle} value={form.montant_devis} onChange={upd('montant_devis')} placeholder="3200" />
+        </div>
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>Montant final (€)</label>
+          <input type="number" min="0" step="50" className="crm-field__input" style={inputStyle} value={form.montant_final} onChange={upd('montant_final')} placeholder="3450" />
+        </div>
+      </div>
+
+      {/* Notes */}
+      <div className="crm-field">
+        <label className="crm-field__label" style={labelStyle}>Notes</label>
+        <textarea className="crm-field__textarea" style={inputStyle} value={form.notes} onChange={upd('notes')} placeholder="Allergies, contraintes, prestations spéciales…" />
+      </div>
+
+      {error && <div style={{ color: 'var(--sk-rouge-texte)', fontSize: 13 }}>{error}</div>}
+
+      <div className="crm-actions">
+        {onCancel && <Button c={c} variant="ghost" type="button" onClick={onCancel}>Annuler</Button>}
+        <Button c={c} type="submit" disabled={saving || clientsDispo.length === 0}>
+          {saving ? 'Enregistrement…' : submitLabel}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/lib/crmConstants.js
+++ b/lib/crmConstants.js
@@ -1,0 +1,92 @@
+// Constantes partagées du module CRM.
+
+export const STATUTS = [
+  { key: 'demande',      label: 'Demande',       couleur: '#6366F1' }, // bleu
+  { key: 'devis_envoye', label: 'Devis envoyé',  couleur: '#8B5CF6' }, // violet
+  { key: 'degustation',  label: 'Dégustation',   couleur: '#EC4899' }, // rose
+  { key: 'negociation',  label: 'Négociation',   couleur: '#F59E0B' }, // amber
+  { key: 'acompte',      label: 'Acompte reçu',  couleur: '#F97316' }, // orange
+  { key: 'confirme',     label: 'Confirmé',      couleur: '#10B981' }, // emeraude
+  { key: 'realise',      label: 'Réalisé',       couleur: '#14B8A6' }, // teal
+  { key: 'facture',      label: 'Facturé',       couleur: '#0EA5E9' }, // sky
+  { key: 'paye',         label: 'Payé',          couleur: '#16A34A' }, // vert
+  { key: 'annule',       label: 'Annulé',        couleur: '#6B7280' }, // gris
+  { key: 'perdu',        label: 'Perdu',         couleur: '#DC2626' }, // rouge
+]
+
+export const STATUTS_MAP = Object.fromEntries(STATUTS.map((s) => [s.key, s]))
+
+// Statuts affichés dans le kanban principal (exclut clos négatifs par défaut).
+export const KANBAN_STATUTS = STATUTS.filter((s) => !['annule', 'perdu'].includes(s.key))
+
+// Statuts considérés comme "perdus / clos" pour les stats.
+export const STATUTS_PERDUS = ['annule', 'perdu']
+
+// Statuts considérés comme "gagnés / engagés" pour le CA prévisionnel.
+export const STATUTS_ENGAGES = ['acompte', 'confirme', 'realise', 'facture', 'paye']
+
+export const TYPES_PRESTATION = [
+  { key: 'mariage',    label: 'Mariage' },
+  { key: 'cocktail',   label: 'Cocktail dînatoire' },
+  { key: 'buffet',     label: 'Buffet' },
+  { key: 'livraison',  label: 'Livraison' },
+  { key: 'seminaire',  label: 'Séminaire' },
+  { key: 'anniversaire', label: 'Anniversaire' },
+  { key: 'autre',      label: 'Autre' },
+]
+
+export const TYPES_PRESTATION_MAP = Object.fromEntries(TYPES_PRESTATION.map((t) => [t.key, t]))
+
+export const LIEUX_TYPES = [
+  { key: 'sur_place', label: 'Sur place' },
+  { key: 'livraison', label: 'Livraison' },
+  { key: 'externe',   label: 'Prestation externe' },
+]
+
+export const LIEUX_TYPES_MAP = Object.fromEntries(LIEUX_TYPES.map((l) => [l.key, l]))
+
+export const SOURCES = [
+  'Site web',
+  'Instagram',
+  'Facebook',
+  'Bouche-à-oreille',
+  'Annuaire',
+  'Mariages.net',
+  'Salon professionnel',
+  'Ancien client',
+  'Autre',
+]
+
+export function formatMontant(n) {
+  if (n === null || n === undefined || n === '') return '—'
+  const v = Number(n)
+  if (Number.isNaN(v)) return '—'
+  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 }).format(v)
+}
+
+export function formatDateFr(d) {
+  if (!d) return '—'
+  try {
+    return new Date(d).toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric' })
+  } catch {
+    return '—'
+  }
+}
+
+export function clientDisplayName(client) {
+  if (!client) return '—'
+  if (client.type === 'entreprise') {
+    return client.raison_sociale || [client.prenom, client.nom].filter(Boolean).join(' ') || '—'
+  }
+  return [client.prenom, client.nom].filter(Boolean).join(' ') || '—'
+}
+
+export function hexToRgba(hex, alpha = 1) {
+  if (!hex) return `rgba(0,0,0,${alpha})`
+  const m = hex.replace('#', '')
+  const bigint = parseInt(m.length === 3 ? m.split('').map((c) => c + c).join('') : m, 16)
+  const r = (bigint >> 16) & 255
+  const g = (bigint >> 8) & 255
+  const b = bigint & 255
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}

--- a/supabase/migrations/20260418000000_crm_establishments.sql
+++ b/supabase/migrations/20260418000000_crm_establishments.sql
@@ -1,0 +1,124 @@
+-- ============================================================================
+-- CRM module — per-establishment clients (customers) and events (traiteur).
+--
+-- Naming note: in this codebase, "clients" (public.clients) refers to the
+-- *establishments* (tenants). The CRM tables therefore use the "crm_" prefix
+-- to avoid any ambiguity:
+--   - crm_clients    : customers / prospects of the establishment
+--   - crm_evenements : catering events linked to a crm_client
+--
+-- Scoped by client_id (= establishment id), RLS uses the existing helper
+-- public.user_has_client_access(client_id).
+-- ============================================================================
+
+-- ─── Table crm_clients ───────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.crm_clients (
+  id             uuid        DEFAULT gen_random_uuid() PRIMARY KEY,
+  client_id      uuid        NOT NULL,
+  type           text        NOT NULL DEFAULT 'particulier'
+                              CHECK (type IN ('particulier', 'entreprise')),
+  -- Identité
+  nom            text,
+  prenom         text,
+  raison_sociale text,
+  siret          text,
+  -- Contact
+  email          text,
+  telephone      text,
+  -- Adresse
+  adresse        text,
+  code_postal    text,
+  ville          text,
+  -- Meta
+  source         text,
+  tags           text[]      NOT NULL DEFAULT ARRAY[]::text[],
+  notes          text,
+  created_by     uuid,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS crm_clients_client_id_idx ON public.crm_clients (client_id);
+CREATE INDEX IF NOT EXISTS crm_clients_email_idx     ON public.crm_clients (client_id, email);
+CREATE INDEX IF NOT EXISTS crm_clients_nom_idx       ON public.crm_clients (client_id, nom);
+
+-- ─── Table crm_evenements ───────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.crm_evenements (
+  id              uuid        DEFAULT gen_random_uuid() PRIMARY KEY,
+  client_id       uuid        NOT NULL,
+  crm_client_id   uuid        NOT NULL REFERENCES public.crm_clients(id) ON DELETE CASCADE,
+  titre           text        NOT NULL,
+  type_prestation text, -- mariage, cocktail, buffet, livraison, seminaire, autre
+  date_evenement  date,
+  heure_debut     time,
+  nb_convives     integer,
+  lieu_type       text        DEFAULT 'sur_place'
+                               CHECK (lieu_type IN ('sur_place', 'livraison', 'externe')),
+  lieu_adresse    text,
+  statut          text        NOT NULL DEFAULT 'demande'
+                               CHECK (statut IN (
+                                 'demande', 'devis_envoye', 'degustation', 'negociation',
+                                 'acompte', 'confirme', 'realise', 'facture', 'paye',
+                                 'annule', 'perdu'
+                               )),
+  budget_estime   numeric,
+  montant_devis   numeric,
+  montant_final   numeric,
+  notes           text,
+  created_by      uuid,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS crm_evenements_client_id_idx     ON public.crm_evenements (client_id);
+CREATE INDEX IF NOT EXISTS crm_evenements_crm_client_id_idx ON public.crm_evenements (crm_client_id);
+CREATE INDEX IF NOT EXISTS crm_evenements_date_idx          ON public.crm_evenements (client_id, date_evenement);
+CREATE INDEX IF NOT EXISTS crm_evenements_statut_idx        ON public.crm_evenements (client_id, statut);
+
+-- ─── Trigger updated_at ─────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.set_updated_at_timestamp()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS crm_clients_set_updated_at ON public.crm_clients;
+CREATE TRIGGER crm_clients_set_updated_at
+  BEFORE UPDATE ON public.crm_clients
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at_timestamp();
+
+DROP TRIGGER IF EXISTS crm_evenements_set_updated_at ON public.crm_evenements;
+CREATE TRIGGER crm_evenements_set_updated_at
+  BEFORE UPDATE ON public.crm_evenements
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at_timestamp();
+
+-- ─── RLS: crm_clients ───────────────────────────────────────────────────────
+ALTER TABLE public.crm_clients ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY crm_clients_select ON public.crm_clients FOR SELECT TO authenticated
+  USING (public.user_has_client_access(client_id));
+CREATE POLICY crm_clients_insert ON public.crm_clients FOR INSERT TO authenticated
+  WITH CHECK (public.user_has_client_access(client_id));
+CREATE POLICY crm_clients_update ON public.crm_clients FOR UPDATE TO authenticated
+  USING (public.user_has_client_access(client_id))
+  WITH CHECK (public.user_has_client_access(client_id));
+CREATE POLICY crm_clients_delete ON public.crm_clients FOR DELETE TO authenticated
+  USING (public.user_has_client_access(client_id));
+
+-- ─── RLS: crm_evenements ────────────────────────────────────────────────────
+ALTER TABLE public.crm_evenements ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY crm_evenements_select ON public.crm_evenements FOR SELECT TO authenticated
+  USING (public.user_has_client_access(client_id));
+CREATE POLICY crm_evenements_insert ON public.crm_evenements FOR INSERT TO authenticated
+  WITH CHECK (public.user_has_client_access(client_id));
+CREATE POLICY crm_evenements_update ON public.crm_evenements FOR UPDATE TO authenticated
+  USING (public.user_has_client_access(client_id))
+  WITH CHECK (public.user_has_client_access(client_id));
+CREATE POLICY crm_evenements_delete ON public.crm_evenements FOR DELETE TO authenticated
+  USING (public.user_has_client_access(client_id));


### PR DESCRIPTION
## Summary
- Nouveau module CRM scopé par établissement pour gérer clients et événements traiteur
- Pipeline à 9 statuts (demande → devis envoyé → dégustation → négociation → acompte → confirmé → réalisé → facturé → payé, + annulé / perdu)
- Vue liste **et** kanban (toggle desktop, liste uniquement mobile)
- Accès restreint aux rôles `admin` et `directeur`

## Contenu
**Migration Supabase** — déjà appliquée sur le projet :
- `crm_clients` (particulier / entreprise, tags libres, source, contact, adresse, notes)
- `crm_evenements` lié par `crm_client_id` (titre, date, nb convives, type prestation, lieu, statut, budget / devis / final, notes)
- RLS via `user_has_client_access(client_id)`
- Trigger `updated_at` automatique (search_path fixé `public`)

**Pages** (7 routes) :
- `/crm` — dashboard : 4 KPI, prochains événements, demandes récentes
- `/crm/clients` + `/nouveau` + `/[id]` — liste + filtres type/tag, détail + édition inline + historique événements
- `/crm/evenements` + `/nouveau` + `/[id]` — liste, kanban 9 colonnes, détail + changement rapide de statut

**Composants partagés** :
- `components/crm/ClientForm.jsx` — création + édition client
- `components/crm/EvenementForm.jsx` — création + édition événement
- `lib/crmConstants.js` — statuts, types prestation, helpers de format

**Navbar** : nouveau groupe "CRM" visible pour admin / directeur uniquement.

**Styles** : CSS statique dans `app/crm.css` (pattern `.crm-*`), couleurs dynamiques via `c` de `useTheme()`. Primitives existantes réutilisées (`Card`, `Button`, `Badge`, `Alert`) et classes `sk-*`.

## Test plan
- [ ] Navigation : menu CRM visible pour admin, pas pour cuisine/bar
- [ ] Créer un client particulier avec tags
- [ ] Créer un client entreprise (raison sociale obligatoire)
- [ ] Créer un événement depuis le dashboard (+ Événement)
- [ ] Créer un événement depuis une fiche client (bouton + Événement)
- [ ] Basculer liste / kanban sur `/crm/evenements` en desktop
- [ ] Changer le statut d'un événement depuis sa fiche → vérifier la colonne kanban
- [ ] Supprimer un client avec événements associés → vérifier cascade
- [ ] Vérifier le responsive mobile (liste forcée, menu hamburger, form stacking)

## Suite prévue
- Itération 2 : composition devis depuis fiches techniques + génération PDF + envoi Resend

🤖 Generated with [Claude Code](https://claude.com/claude-code)