### PR TITLE
fix(crm): active state + tenant module toggle

### DIFF
--- a/app/superadmin/components/ClientsList.jsx
+++ b/app/superadmin/components/ClientsList.jsx
@@ -11,6 +11,7 @@ const MODULES_DISPONIBLES = [
   { id: 'ardoise', label: 'Ardoise', emoji: '🖊️' },
   { id: 'cartes', label: 'Cartes', emoji: '🍽️' },
   { id: 'gestion', label: 'Gestion', emoji: '📦' },
+  { id: 'crm', label: 'CRM traiteur', emoji: '👥' },
 ]
 
 export default function ClientsList({

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -107,7 +107,7 @@ export default function Navbar({ section = 'cuisine' }) {
   const isActive = (paths) => {
     const arr = Array.isArray(paths) ? paths : [paths]
     return arr.some(p => {
-      if (p === DASHBOARD_PATH) return pathname === DASHBOARD_PATH
+      if (p === DASHBOARD_PATH || p === '/crm') return pathname === p
       return pathname.startsWith(p)
     })
   }
@@ -154,7 +154,7 @@ export default function Navbar({ section = 'cuisine' }) {
             ...(hasModule('avis')                      ? [{ label: 'Avis clients',    path: '/avis' }]         : []),
           ]
         },
-        ...((role === 'admin' || role === 'directeur') ? [{
+        ...(hasModule('crm') && (role === 'admin' || role === 'directeur') ? [{
           label: 'CRM',
           paths: ['/crm'],
           items: [


### PR DESCRIPTION
## Summary
Deux fix rapides suite au merge du module CRM (#34) :

1. **Dashboard CRM surlignait à tort** quand on naviguait vers /crm/clients ou /crm/evenements (le \`isActive\` faisait un startsWith sur /crm). Fix : exact-match pour /crm comme pour /dashboard.

2. **Module CRM togglable depuis le superadmin** — ajouté à \`MODULES_DISPONIBLES\` avec emoji 👥 et label "CRM traiteur". Le groupe CRM dans la navbar est maintenant gated par \`hasModule('crm')\` + role admin/directeur, pour pouvoir vendre le module séparément.

**Note DB** : le tenant "Hôtel La Fantaisie" a été mis à jour directement (ajout de 'crm' dans \`modules_actifs\`) pour conserver l'accès le temps du déploiement.

## Test plan
- [ ] Naviguer /crm → Dashboard CRM surligné
- [ ] Naviguer /crm/clients → Clients surligné, Dashboard non
- [ ] Naviguer /crm/evenements → Événements surligné, Dashboard non
- [ ] Dans /superadmin, modifier un établissement → carte "CRM traiteur 👥" visible dans MODULES ACTIFS
- [ ] Désactiver le module CRM sur un tenant test → le groupe CRM disparaît de la navbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)