### PR TITLE
feat(crm): devis PDF + email delivery (étape 3/3)

### DIFF
--- a/app/api/crm/devis/[id]/envoyer/route.js
+++ b/app/api/crm/devis/[id]/envoyer/route.js
@@ -1,0 +1,159 @@
+// POST /api/crm/devis/[id]/envoyer
+//
+// Génère le PDF → l'upload dans le bucket `devis` → envoie un email Resend
+// avec le PDF en pièce jointe → met à jour le devis (pdf_url, sent_at,
+// sent_to_email, statut: brouillon → envoye).
+
+import React from 'react'
+import { z } from 'zod'
+import { renderToBuffer } from '@react-pdf/renderer'
+import { Resend } from 'resend'
+import { apiHandler } from '../../../../../../lib/apiHandler'
+import { DevisPdf } from '../../../../../../lib/devisPdf'
+
+export const runtime = 'nodejs'
+
+const bodySchema = z.object({
+  client_id: z.string().uuid(),
+  to: z.string().email(),
+  subject: z.string().min(1).max(200),
+  message: z.string().max(5000).optional(),
+})
+
+const FROM = `Skalcook <${process.env.CONTACT_EMAIL || 'contact@skalcook.com'}>`
+
+export const POST = apiHandler({
+  schema: bodySchema,
+  guard: 'memberOfClient',
+  clientIdFrom: 'body.client_id',
+  handler: async ({ data, db, params, user }) => {
+    const devisId = params?.id
+    const clientId = data.client_id
+    if (!devisId) {
+      return Response.json({ error: 'devis id manquant' }, { status: 400 })
+    }
+
+    if (!process.env.RESEND_API_KEY) {
+      return Response.json({ error: 'RESEND_API_KEY absent — email désactivé.' }, { status: 500 })
+    }
+
+    // ─── 1. Charger devis + context ────────────────────────────────────
+    const [{ data: devis }, { data: tenant }] = await Promise.all([
+      db.from('crm_devis').select('*').eq('id', devisId).eq('client_id', clientId).maybeSingle(),
+      db.from('clients')
+        .select('nom, nom_etablissement, adresse_siege, siret, num_tva, email_contact, telephone_contact')
+        .eq('id', clientId).maybeSingle(),
+    ])
+    if (!devis) {
+      return Response.json({ error: 'Devis introuvable' }, { status: 404 })
+    }
+
+    const [{ data: lignes }, crmClientRes] = await Promise.all([
+      db.from('crm_devis_lignes').select('*').eq('devis_id', devisId).order('ordre', { ascending: true }),
+      devis.crm_client_id
+        ? db.from('crm_clients').select('*').eq('id', devis.crm_client_id).maybeSingle()
+        : Promise.resolve({ data: null }),
+    ])
+
+    // ─── 2. Générer le PDF ─────────────────────────────────────────────
+    const element = React.createElement(DevisPdf, {
+      tenant: tenant || {},
+      client: crmClientRes.data || null,
+      devis,
+      lignes: lignes || [],
+    })
+    const pdfBuffer = await renderToBuffer(element)
+
+    // ─── 3. Upload dans le bucket (upsert) ─────────────────────────────
+    const path = `${clientId}/${devis.id}.pdf`
+    const { error: upErr } = await db.storage
+      .from('devis')
+      .upload(path, pdfBuffer, {
+        contentType: 'application/pdf',
+        upsert: true,
+      })
+    if (upErr) {
+      return Response.json({ error: `Upload PDF échoué : ${upErr.message}` }, { status: 500 })
+    }
+
+    // ─── 4. Envoyer l'email Resend ─────────────────────────────────────
+    const resend = new Resend(process.env.RESEND_API_KEY)
+    const replyTo = tenant?.email_contact || undefined
+    const filename = `${devis.numero}.pdf`
+    const messageText = (data.message || '').trim()
+    const tenantNom = tenant?.nom_etablissement || tenant?.nom || 'Votre traiteur'
+    const htmlBody = `
+      <div style="font-family: -apple-system, Helvetica, Arial, sans-serif; font-size: 14px; color: #1f2937; line-height: 1.6;">
+        ${messageText ? `<p>${escapeHtml(messageText).replace(/\n/g, '<br/>')}</p>` : ''}
+        <p>Vous trouverez ci-joint le devis <strong>${escapeHtml(devis.numero)}</strong> pour un montant total de <strong>${formatEur(devis.total_ttc)} TTC</strong>.</p>
+        ${devis.date_validite ? `<p style="color:#6b7280">Ce devis est valable jusqu'au ${formatDateFr(devis.date_validite)}.</p>` : ''}
+        <p style="margin-top: 24px; color:#6b7280; font-size: 12px;">— ${escapeHtml(tenantNom)}</p>
+      </div>
+    `
+
+    const { error: emailErr } = await resend.emails.send({
+      from: FROM,
+      to: data.to,
+      replyTo,
+      subject: data.subject,
+      html: htmlBody,
+      attachments: [{
+        filename,
+        content: Buffer.from(pdfBuffer).toString('base64'),
+      }],
+    })
+    if (emailErr) {
+      return Response.json({ error: `Envoi email échoué : ${emailErr.message}` }, { status: 500 })
+    }
+
+    // ─── 5. Update devis (statut + tracking) ───────────────────────────
+    const nextStatut = devis.statut === 'brouillon' ? 'envoye' : devis.statut
+    const now = new Date().toISOString()
+    const { error: updErr } = await db
+      .from('crm_devis')
+      .update({
+        pdf_url: path,
+        pdf_generated_at: now,
+        sent_at: now,
+        sent_to_email: data.to,
+        statut: nextStatut,
+      })
+      .eq('id', devisId)
+      .eq('client_id', clientId)
+    if (updErr) {
+      return Response.json({ error: `Mise à jour du devis échouée : ${updErr.message}` }, { status: 500 })
+    }
+
+    return Response.json({
+      ok: true,
+      pdf_url: path,
+      sent_at: now,
+      sent_to_email: data.to,
+      statut: nextStatut,
+    })
+  },
+})
+
+function escapeHtml(s) {
+  return String(s || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function formatEur(n) {
+  const v = Number(n)
+  if (!Number.isFinite(v)) return '—'
+  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR', maximumFractionDigits: 2 }).format(v)
+}
+
+function formatDateFr(d) {
+  if (!d) return '—'
+  try {
+    return new Date(d).toLocaleDateString('fr-FR', { day: '2-digit', month: 'long', year: 'numeric' })
+  } catch {
+    return '—'
+  }
+}

--- a/app/api/crm/devis/[id]/pdf/route.js
+++ b/app/api/crm/devis/[id]/pdf/route.js
@@ -1,0 +1,66 @@
+// GET /api/crm/devis/[id]/pdf?client_id=<tenant>&download=0|1
+//
+// Rend le PDF du devis à la volée via @react-pdf/renderer.
+// Pas de persistence ici — c'est /envoyer qui uploade dans le bucket.
+
+import React from 'react'
+import { z } from 'zod'
+import { renderToBuffer } from '@react-pdf/renderer'
+import { apiHandler } from '../../../../../../lib/apiHandler'
+import { DevisPdf } from '../../../../../../lib/devisPdf'
+
+export const runtime = 'nodejs'
+
+const querySchema = z.object({
+  client_id: z.string().uuid(),
+  download: z.string().optional(),
+})
+
+export const GET = apiHandler({
+  schema: querySchema,
+  guard: 'memberOfClient',
+  clientIdFrom: 'body.client_id', // apiHandler strip le préfixe 'body.' → lit data.client_id
+  handler: async ({ data, db, params }) => {
+    const devisId = params?.id
+    const clientId = data.client_id
+    if (!devisId) {
+      return Response.json({ error: 'devis id manquant' }, { status: 400 })
+    }
+
+    const [{ data: devis }, { data: tenant }] = await Promise.all([
+      db.from('crm_devis').select('*').eq('id', devisId).eq('client_id', clientId).maybeSingle(),
+      db.from('clients')
+        .select('nom, nom_etablissement, adresse_siege, siret, num_tva, email_contact, telephone_contact')
+        .eq('id', clientId).maybeSingle(),
+    ])
+    if (!devis) {
+      return Response.json({ error: 'Devis introuvable' }, { status: 404 })
+    }
+
+    const [{ data: lignes }, crmClientRes] = await Promise.all([
+      db.from('crm_devis_lignes').select('*').eq('devis_id', devisId).order('ordre', { ascending: true }),
+      devis.crm_client_id
+        ? db.from('crm_clients').select('*').eq('id', devis.crm_client_id).maybeSingle()
+        : Promise.resolve({ data: null }),
+    ])
+
+    const element = React.createElement(DevisPdf, {
+      tenant: tenant || {},
+      client: crmClientRes.data || null,
+      devis,
+      lignes: lignes || [],
+    })
+    const pdfBuffer = await renderToBuffer(element)
+
+    const filename = `${devis.numero}.pdf`
+    const disposition = data.download === '1' ? 'attachment' : 'inline'
+    return new Response(pdfBuffer, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `${disposition}; filename="${filename}"`,
+        'Cache-Control': 'private, no-store',
+      },
+    })
+  },
+})

--- a/app/crm.css
+++ b/app/crm.css
@@ -610,3 +610,35 @@
   border-top-width: var(--sk-border-hair);
   border-top-style: solid;
 }
+
+/* ─── Devis send modal ─── */
+.crm-devis-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 16px;
+}
+.crm-devis-modal {
+  width: 100%;
+  max-width: 560px;
+  max-height: 90vh;
+  overflow-y: auto;
+  border-radius: var(--sk-radius-lg);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.crm-devis-modal__title {
+  font-size: 18px;
+  font-weight: var(--sk-fw-sb);
+  margin: 0;
+}
+.crm-devis-modal__subtitle {
+  font-size: var(--sk-fs-sm);
+  margin: 0;
+}

--- a/app/crm/devis/[id]/page.js
+++ b/app/crm/devis/[id]/page.js
@@ -36,6 +36,8 @@ export default function CrmDevisDetailPage() {
   const [mode, setMode] = useState('view')
   const [statutSaving, setStatutSaving] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
+  const [pdfLoading, setPdfLoading] = useState(false)
+  const [sendModalOpen, setSendModalOpen] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -172,6 +174,57 @@ export default function CrmDevisDetailPage() {
     router.push('/crm/devis')
   }
 
+  async function authHeaders() {
+    const { data: { session } } = await supabase.auth.getSession()
+    if (!session) throw new Error('Session expirée.')
+    return { Authorization: `Bearer ${session.access_token}` }
+  }
+
+  async function handleDownloadPdf({ download = true } = {}) {
+    if (!clientId) return
+    setPdfLoading(true)
+    setError('')
+    try {
+      const headers = await authHeaders()
+      const url = `/api/crm/devis/${id}/pdf?client_id=${clientId}${download ? '&download=1' : ''}`
+      const res = await fetch(url, { headers })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
+        throw new Error(j.error || 'Erreur PDF')
+      }
+      const blob = await res.blob()
+      const blobUrl = URL.createObjectURL(blob)
+      if (download) {
+        const a = document.createElement('a')
+        a.href = blobUrl
+        a.download = `${devis?.numero || 'devis'}.pdf`
+        document.body.appendChild(a)
+        a.click()
+        a.remove()
+      } else {
+        window.open(blobUrl, '_blank', 'noopener')
+      }
+      setTimeout(() => URL.revokeObjectURL(blobUrl), 60_000)
+    } catch (err) {
+      setError(err.message || 'Erreur PDF')
+    } finally {
+      setPdfLoading(false)
+    }
+  }
+
+  async function handleSend({ to, subject, message }) {
+    const headers = { ...(await authHeaders()), 'Content-Type': 'application/json' }
+    const res = await fetch(`/api/crm/devis/${id}/envoyer`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ client_id: clientId, to, subject, message }),
+    })
+    const j = await res.json().catch(() => ({}))
+    if (!res.ok) throw new Error(j.error || `HTTP ${res.status}`)
+    setSendModalOpen(false)
+    await load()
+  }
+
   const statut = useMemo(() => STATUTS_DEVIS_MAP[devis?.statut], [devis])
   const allergenesAgreges = useMemo(() => {
     const set = new Set()
@@ -251,9 +304,35 @@ export default function CrmDevisDetailPage() {
                 </p>
               </div>
               <div className="crm-actions">
+                <Button c={c} variant="ghost" onClick={() => handleDownloadPdf({ download: true })} disabled={pdfLoading}>
+                  {pdfLoading ? 'PDF…' : 'Télécharger PDF'}
+                </Button>
                 <Button c={c} variant="ghost" onClick={() => setMode('edit')}>Modifier</Button>
+                <Button c={c} onClick={() => setSendModalOpen(true)}>
+                  {devis.sent_at ? 'Renvoyer' : 'Envoyer par email'}
+                </Button>
               </div>
             </div>
+
+            {/* Envoi info (si déjà envoyé) */}
+            {devis.sent_at && (
+              <Card c={c} padding="md" style={{ marginBottom: 20, background: hexToRgba('#10B981', 0.06), borderColor: hexToRgba('#10B981', 0.3) }}>
+                <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap', fontSize: 13, color: c.texte }}>
+                  <span style={{ fontWeight: 500 }}>✓ Envoyé</span>
+                  <span style={{ color: c.texteMuted }}>
+                    le {formatDateFr(devis.sent_at)}{devis.sent_to_email ? ` à ${devis.sent_to_email}` : ''}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => handleDownloadPdf({ download: false })}
+                    disabled={pdfLoading}
+                    style={{ marginLeft: 'auto', background: 'transparent', border: 'none', color: c.accent, cursor: 'pointer', textDecoration: 'underline', fontSize: 13 }}
+                  >
+                    Voir le PDF
+                  </button>
+                </div>
+              </Card>
+            )}
 
             {/* Statut */}
             <Card c={c} padding="md" style={{ marginBottom: 20 }}>
@@ -374,6 +453,17 @@ export default function CrmDevisDetailPage() {
               </Card>
             )}
 
+            {/* Modal envoi */}
+            {sendModalOpen && (
+              <SendDevisModal
+                c={c}
+                devis={devis}
+                clientCrm={clientCrm}
+                onClose={() => setSendModalOpen(false)}
+                onSend={handleSend}
+              />
+            )}
+
             {/* Danger zone */}
             <div style={{ marginTop: 32, paddingTop: 16, borderTop: `0.5px solid ${c.bordure}` }}>
               {confirmDelete ? (
@@ -400,6 +490,83 @@ function Kv({ c, label, value }) {
     <div>
       <div className="crm-kv__key" style={{ color: c.texteMuted }}>{label}</div>
       <div className="crm-kv__value" style={{ color: c.texte }}>{value || '—'}</div>
+    </div>
+  )
+}
+
+function SendDevisModal({ c, devis, clientCrm, onClose, onSend }) {
+  const [to, setTo] = useState(clientCrm?.email || '')
+  const [subject, setSubject] = useState(`Devis ${devis.numero}`)
+  const [message, setMessage] = useState(
+    `Bonjour${clientCrm?.prenom ? ' ' + clientCrm.prenom : ''},\n\nVous trouverez ci-joint votre devis pour votre événement. N'hésitez pas à revenir vers moi pour toute question.\n\nBien cordialement,`
+  )
+  const [sending, setSending] = useState(false)
+  const [err, setErr] = useState('')
+
+  const inputStyle = { background: c.blanc, borderColor: c.bordure, color: c.texte }
+  const labelStyle = { color: c.texte }
+
+  async function submit(e) {
+    e.preventDefault()
+    setErr('')
+    if (!to.trim()) { setErr('Destinataire requis.'); return }
+    if (!subject.trim()) { setErr('Sujet requis.'); return }
+    setSending(true)
+    try {
+      await onSend({ to: to.trim(), subject: subject.trim(), message: message.trim() })
+    } catch (e2) {
+      setErr(e2.message || 'Envoi échoué.')
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <div className="crm-devis-modal-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose() }}>
+      <form className="crm-devis-modal" style={{ background: c.blanc, border: `0.5px solid ${c.bordure}` }} onSubmit={submit}>
+        <div>
+          <h3 className="crm-devis-modal__title" style={{ color: c.texte }}>Envoyer le devis par email</h3>
+          <p className="crm-devis-modal__subtitle" style={{ color: c.texteMuted }}>
+            Le PDF sera généré puis joint automatiquement au message.
+          </p>
+        </div>
+
+        <div className="crm-field">
+          <label className="crm-field__label crm-field__label--required" style={labelStyle}>Destinataire</label>
+          <input
+            type="email" required
+            className="crm-field__input" style={inputStyle}
+            value={to} onChange={(e) => setTo(e.target.value)}
+            placeholder="client@exemple.fr"
+          />
+        </div>
+
+        <div className="crm-field">
+          <label className="crm-field__label crm-field__label--required" style={labelStyle}>Sujet</label>
+          <input
+            type="text" required
+            className="crm-field__input" style={inputStyle}
+            value={subject} onChange={(e) => setSubject(e.target.value)}
+          />
+        </div>
+
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>Message</label>
+          <textarea
+            className="crm-field__textarea" style={{ ...inputStyle, minHeight: 140 }}
+            value={message} onChange={(e) => setMessage(e.target.value)}
+          />
+        </div>
+
+        {err && <div style={{ color: 'var(--sk-rouge-texte)', fontSize: 13 }}>{err}</div>}
+
+        <div className="crm-actions">
+          <Button c={c} variant="ghost" type="button" onClick={onClose} disabled={sending}>Annuler</Button>
+          <Button c={c} type="submit" disabled={sending}>
+            {sending ? 'Envoi…' : 'Envoyer'}
+          </Button>
+        </div>
+      </form>
     </div>
   )
 }

--- a/lib/devisPdf.jsx
+++ b/lib/devisPdf.jsx
@@ -1,0 +1,278 @@
+/* eslint-disable react/no-unknown-property */
+// Composant React-PDF pour la génération de devis.
+//
+// Rendu simple et sobre (imprimable N&B sans perte d'info). Pas de dépendance
+// à un logo tant que la colonne clients.logo_url n'existe pas.
+//
+// Tous les montants passés en props sont supposés déjà calculés côté serveur
+// (totaux cohérents avec la DB).
+
+import { Document, Page, View, Text, StyleSheet } from '@react-pdf/renderer'
+import {
+  formatMontant, formatDateFr, clientDisplayName, STATUTS_DEVIS_MAP,
+} from './crmConstants'
+
+const styles = StyleSheet.create({
+  page: {
+    padding: 40,
+    fontFamily: 'Helvetica',
+    fontSize: 9,
+    color: '#1f2937',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    borderBottom: '1 solid #e5e7eb',
+    paddingBottom: 12,
+    marginBottom: 18,
+  },
+  tenantBlock: { flexDirection: 'column', maxWidth: 260 },
+  tenantName: { fontSize: 13, fontFamily: 'Helvetica-Bold', marginBottom: 2 },
+  tenantLine: { color: '#6b7280', lineHeight: 1.4 },
+
+  title: { fontSize: 22, fontFamily: 'Helvetica-Bold', marginBottom: 2, textAlign: 'right' },
+  numeroLine: { fontSize: 11, textAlign: 'right', color: '#374151', marginBottom: 2 },
+  metaLine: { color: '#6b7280', textAlign: 'right' },
+
+  clientBox: {
+    border: '1 solid #e5e7eb',
+    backgroundColor: '#f9fafb',
+    padding: 10,
+    marginBottom: 18,
+    width: '55%',
+    alignSelf: 'flex-end',
+  },
+  clientLabel: { color: '#6b7280', fontSize: 8, textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 4 },
+  clientName: { fontFamily: 'Helvetica-Bold', fontSize: 11, marginBottom: 2 },
+  clientLine: { color: '#374151', lineHeight: 1.4 },
+
+  table: { marginBottom: 12 },
+  thead: {
+    flexDirection: 'row',
+    borderBottom: '1 solid #1f2937',
+    paddingBottom: 4,
+    marginBottom: 4,
+  },
+  th: { fontFamily: 'Helvetica-Bold', fontSize: 9 },
+  tr: {
+    flexDirection: 'row',
+    borderBottom: '0.5 solid #e5e7eb',
+    paddingVertical: 5,
+  },
+  td: { paddingRight: 4 },
+
+  colDesignation: { width: '46%' },
+  colQte:         { width: '8%',  textAlign: 'right' },
+  colPu:          { width: '14%', textAlign: 'right' },
+  colTva:         { width: '10%', textAlign: 'right' },
+  colRemise:      { width: '8%',  textAlign: 'right' },
+  colTotal:       { width: '14%', textAlign: 'right' },
+
+  description: { color: '#6b7280', fontSize: 8, marginTop: 2 },
+  allergene: { color: '#991b1b', fontSize: 7, marginTop: 2 },
+
+  totalsRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    marginTop: 2,
+  },
+  totalsLabel: { width: 120, textAlign: 'right', paddingRight: 10, color: '#6b7280' },
+  totalsValue: { width: 80, textAlign: 'right', color: '#1f2937' },
+  totalsTTC: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 11,
+    marginTop: 4,
+    paddingTop: 6,
+    borderTop: '1 solid #1f2937',
+  },
+
+  section: { marginTop: 18 },
+  sectionTitle: {
+    fontFamily: 'Helvetica-Bold',
+    fontSize: 10,
+    marginBottom: 4,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  paragraph: { color: '#374151', lineHeight: 1.5 },
+
+  signatureBox: {
+    marginTop: 24,
+    border: '1 solid #e5e7eb',
+    padding: 12,
+    width: '50%',
+    alignSelf: 'flex-end',
+  },
+  signatureTitle: { fontFamily: 'Helvetica-Bold', marginBottom: 4 },
+  signatureHint: { color: '#6b7280', fontSize: 8 },
+
+  footer: {
+    position: 'absolute',
+    bottom: 20,
+    left: 40,
+    right: 40,
+    borderTop: '0.5 solid #e5e7eb',
+    paddingTop: 6,
+    fontSize: 7,
+    color: '#9ca3af',
+    textAlign: 'center',
+  },
+})
+
+/**
+ * Props :
+ *   tenant    : { nom, nom_etablissement, adresse_siege, siret, num_tva, email_contact, telephone_contact }
+ *   client    : crm_client row (customer)
+ *   devis     : crm_devis row
+ *   lignes    : crm_devis_lignes rows (ordered)
+ */
+export function DevisPdf({ tenant, client, devis, lignes }) {
+  const statut = STATUTS_DEVIS_MAP[devis.statut]
+  const tvaByRate = regrouperTvaParTaux(lignes)
+  const tenantNom = tenant?.nom_etablissement || tenant?.nom || 'Établissement'
+
+  return (
+    <Document title={`Devis ${devis.numero}`} author={tenantNom} creator="Skalcook">
+      <Page size="A4" style={styles.page}>
+        {/* ─── Header ─── */}
+        <View style={styles.headerRow}>
+          <View style={styles.tenantBlock}>
+            <Text style={styles.tenantName}>{tenantNom}</Text>
+            {tenant?.adresse_siege && <Text style={styles.tenantLine}>{tenant.adresse_siege}</Text>}
+            {tenant?.telephone_contact && <Text style={styles.tenantLine}>Tél. {tenant.telephone_contact}</Text>}
+            {tenant?.email_contact && <Text style={styles.tenantLine}>{tenant.email_contact}</Text>}
+            {tenant?.siret && <Text style={styles.tenantLine}>SIRET {tenant.siret}</Text>}
+            {tenant?.num_tva && <Text style={styles.tenantLine}>TVA intracom. {tenant.num_tva}</Text>}
+          </View>
+          <View>
+            <Text style={styles.title}>DEVIS</Text>
+            <Text style={styles.numeroLine}>{devis.numero}</Text>
+            <Text style={styles.metaLine}>Émis le {formatDateFr(devis.date_emission)}</Text>
+            {devis.date_validite && <Text style={styles.metaLine}>Valable jusqu’au {formatDateFr(devis.date_validite)}</Text>}
+            {statut && statut.key !== 'brouillon' && (
+              <Text style={[styles.metaLine, { marginTop: 4, fontFamily: 'Helvetica-Bold', color: '#374151' }]}>
+                Statut : {statut.label}
+              </Text>
+            )}
+          </View>
+        </View>
+
+        {/* ─── Client ─── */}
+        {client && (
+          <View style={styles.clientBox}>
+            <Text style={styles.clientLabel}>Destinataire</Text>
+            <Text style={styles.clientName}>{clientDisplayName(client)}</Text>
+            {(client.adresse || client.code_postal || client.ville) && (
+              <Text style={styles.clientLine}>
+                {[client.adresse, [client.code_postal, client.ville].filter(Boolean).join(' ')].filter(Boolean).join(' · ')}
+              </Text>
+            )}
+            {client.email && <Text style={styles.clientLine}>{client.email}</Text>}
+            {client.telephone && <Text style={styles.clientLine}>{client.telephone}</Text>}
+            {client.siret && <Text style={styles.clientLine}>SIRET {client.siret}</Text>}
+          </View>
+        )}
+
+        {/* ─── Tableau lignes ─── */}
+        <View style={styles.table}>
+          <View style={styles.thead}>
+            <Text style={[styles.th, styles.colDesignation]}>Désignation</Text>
+            <Text style={[styles.th, styles.colQte]}>Qté</Text>
+            <Text style={[styles.th, styles.colPu]}>PU HT</Text>
+            <Text style={[styles.th, styles.colTva]}>TVA</Text>
+            <Text style={[styles.th, styles.colRemise]}>Remise</Text>
+            <Text style={[styles.th, styles.colTotal]}>Total HT</Text>
+          </View>
+          {lignes.map((l) => (
+            <View key={l.id || l.ordre} style={styles.tr} wrap={false}>
+              <View style={[styles.td, styles.colDesignation]}>
+                <Text>{l.designation}</Text>
+                {l.description && <Text style={styles.description}>{l.description}</Text>}
+                {Array.isArray(l.allergenes) && l.allergenes.length > 0 && (
+                  <Text style={styles.allergene}>Allergènes : {l.allergenes.join(', ')}</Text>
+                )}
+              </View>
+              <Text style={[styles.td, styles.colQte]}>{formatQte(l.quantite)}</Text>
+              <Text style={[styles.td, styles.colPu]}>{formatMontant(l.prix_unitaire_ht)}</Text>
+              <Text style={[styles.td, styles.colTva]}>{formatTvaLabel(l.tva_taux)}</Text>
+              <Text style={[styles.td, styles.colRemise]}>{l.remise_pct ? `${l.remise_pct} %` : '—'}</Text>
+              <Text style={[styles.td, styles.colTotal]}>{formatMontant(l.total_ht)}</Text>
+            </View>
+          ))}
+        </View>
+
+        {/* ─── Totaux ─── */}
+        <View>
+          <View style={styles.totalsRow}>
+            <Text style={styles.totalsLabel}>Total HT</Text>
+            <Text style={styles.totalsValue}>{formatMontant(devis.total_ht)}</Text>
+          </View>
+          {tvaByRate.map(({ taux, montant }) => (
+            <View key={taux} style={styles.totalsRow}>
+              <Text style={styles.totalsLabel}>TVA {formatTvaLabel(taux)}</Text>
+              <Text style={styles.totalsValue}>{formatMontant(montant)}</Text>
+            </View>
+          ))}
+          <View style={[styles.totalsRow, styles.totalsTTC]}>
+            <Text style={styles.totalsLabel}>Total TTC</Text>
+            <Text style={styles.totalsValue}>{formatMontant(devis.total_ttc)}</Text>
+          </View>
+        </View>
+
+        {/* ─── Conditions / acompte / notes ─── */}
+        {(devis.conditions_paiement || devis.acompte_pourcentage != null) && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Conditions</Text>
+            {devis.conditions_paiement && (
+              <Text style={styles.paragraph}>{devis.conditions_paiement}</Text>
+            )}
+            {devis.acompte_pourcentage != null && (
+              <Text style={styles.paragraph}>
+                Acompte de {devis.acompte_pourcentage} % à la commande, soit {formatMontant((Number(devis.total_ttc) * Number(devis.acompte_pourcentage)) / 100)}.
+              </Text>
+            )}
+          </View>
+        )}
+
+        {/* ─── Signature ─── */}
+        <View style={styles.signatureBox}>
+          <Text style={styles.signatureTitle}>Bon pour accord</Text>
+          <Text style={styles.signatureHint}>Date + signature précédée de « Bon pour accord »</Text>
+        </View>
+
+        {/* ─── Footer ─── */}
+        <Text
+          style={styles.footer}
+          render={({ pageNumber, totalPages }) => (
+            `${tenantNom}${tenant?.siret ? ` · SIRET ${tenant.siret}` : ''} — Devis ${devis.numero} — Page ${pageNumber}/${totalPages}`
+          )}
+          fixed
+        />
+      </Page>
+    </Document>
+  )
+}
+
+function formatQte(n) {
+  const v = Number(n)
+  if (!Number.isFinite(v)) return '—'
+  return v.toLocaleString('fr-FR', { maximumFractionDigits: 2 })
+}
+
+function formatTvaLabel(taux) {
+  const v = Number(taux)
+  if (!Number.isFinite(v)) return '—'
+  return `${v.toString().replace('.', ',')} %`
+}
+
+function regrouperTvaParTaux(lignes) {
+  const map = new Map()
+  for (const l of lignes) {
+    const t = Number(l.tva_taux) || 0
+    const m = Number(l.total_tva) || 0
+    map.set(t, (map.get(t) || 0) + m)
+  }
+  return Array.from(map.entries())
+    .sort((a, b) => a[0] - b[0])
+    .map(([taux, montant]) => ({ taux, montant: Math.round(montant * 100) / 100 }))
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
         "@lottiefiles/dotlottie-react": "^0.18.7",
+        "@react-pdf/renderer": "^4.5.1",
         "@supabase/auth-helpers-nextjs": "^0.15.0",
         "@supabase/supabase-js": "^2.99.1",
         "@upstash/ratelimit": "^2.0.8",
@@ -1465,6 +1466,30 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1537,6 +1562,183 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@react-pdf/fns": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.3.tgz",
+      "integrity": "sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.8.tgz",
+      "integrity": "sha512-deNd+emtZAJho1IlzKL9bRoLAGv/6oXOIKO2oZfs4RuXUrK1onLHbJO7e2YoVLPFP/sQxisRTnzdJFtd35iKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/types": "^2.11.1",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.1.0.tgz",
+      "integrity": "sha512-ks7Ry8v711r8NvKWSELehj0BXBNPRihSnWsM09nDD8Ur175zbWBCK217LLwQMKDNYDVpkZaipdoJPom1LGaE9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/svg": "^1.1.0",
+        "jay-peg": "^1.1.1",
+        "png-js": "^2.0.0"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.6.1.tgz",
+      "integrity": "sha512-gN6PmWoEffvlIkifLfEhMsVucRywVMyH3rnxdyOVOhGy0nWJKKGpHyPc4plbDdpP6EfZ0r8prHXujDSkIG2nSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/image": "^3.1.0",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "emoji-regex-xs": "^1.0.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/pdfkit": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-5.1.1.tgz",
+      "integrity": "sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "browserify-zlib": "^0.2.0",
+        "fontkit": "^2.0.2",
+        "jay-peg": "^1.1.1",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^2.0.0",
+        "vite-compatible-readable-stream": "^3.6.1"
+      }
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.3.0.tgz",
+      "integrity": "sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/reconciler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-2.0.0.tgz",
+      "integrity": "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.5.1.tgz",
+      "integrity": "sha512-IW/N4HWJWtioBXCf7n02IR24VJJ8gbdS3jGypf+vW/rSErEx3/URRzh9UK6Ma8Fpog9+T/W6GE2NHJ5AAKHhVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^2.1.4",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.5.1.tgz",
+      "integrity": "sha512-5r1VQrE6FRLXX5wWUxwZzM24E2BJMo6g8AQWuS8WyPs9ugu5yMnb2g8/RpPYka/Z6J+RUEWc32wty2NoUJF42Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/layout": "^4.6.1",
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/reconciler": "^2.0.0",
+        "@react-pdf/render": "^4.5.1",
+        "@react-pdf/types": "^2.11.1",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.2.1.tgz",
+      "integrity": "sha512-2+UEk+7e+z8baaWi2l5kPLWmwtJeOI+T5wW9GGeN3iDH7vd3kbTqOpN1yt9mmfNVZFxQsnDHpznFb5v5UF983A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/types": "^2.11.1",
+        "color-string": "^2.1.4",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/svg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/svg/-/svg-1.1.0.tgz",
+      "integrity": "sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/primitives": "^4.3.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.3.0.tgz",
+      "integrity": "sha512-v6+V8nAcVwm7s2s1jIG2MD3Iw//x/k+XrH1foWOELBE4b32pyDgKyPXN/6KJE0dnX7+fVy27uctLNCLNMvzKzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "bidi-js": "^1.0.2",
+        "hyphen": "^1.6.4",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.11.1.tgz",
+      "integrity": "sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -3155,6 +3357,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3486,6 +3694,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.7",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.7.tgz",
@@ -3529,6 +3757,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/browserslist": {
@@ -3691,6 +3937,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -3728,6 +3983,27 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -4081,6 +4357,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -4130,6 +4412,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
@@ -4822,6 +5110,15 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4836,7 +5133,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -4898,6 +5194,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -4962,6 +5264,23 @@
       "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -5308,6 +5627,21 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "license": "MIT",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "license": "ISC"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -5326,6 +5660,12 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/hyphen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.14.1.tgz",
+      "integrity": "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==",
+      "license": "ISC"
     },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
@@ -5382,6 +5722,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -5782,6 +6128,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -5912,6 +6264,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "restructure": "^3.0.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -5922,11 +6283,16 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -6372,6 +6738,25 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -6399,7 +6784,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -6484,6 +6868,12 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
+    },
+    "node_modules/media-engine": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -6687,11 +7077,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "license": "MIT",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6889,6 +7287,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6901,6 +7305,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -7013,6 +7423,14 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/png-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-2.0.0.tgz",
+      "integrity": "sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -7058,6 +7476,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7072,7 +7496,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -7087,6 +7510,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -7326,6 +7758,12 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7414,6 +7852,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -7757,6 +8215,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -7942,6 +8409,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "license": "ISC"
+    },
     "node_modules/svix": {
       "version": "1.90.0",
       "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
@@ -7978,6 +8451,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -8336,6 +8815,32 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -8420,6 +8925,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "10.0.0",
@@ -8532,6 +9043,20 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-compatible-readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/vite/node_modules/lightningcss": {
@@ -9173,6 +9698,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
     "@lottiefiles/dotlottie-react": "^0.18.7",
+    "@react-pdf/renderer": "^4.5.1",
     "@supabase/auth-helpers-nextjs": "^0.15.0",
     "@supabase/supabase-js": "^2.99.1",
     "@upstash/ratelimit": "^2.0.8",

--- a/supabase/migrations/20260418020000_crm_devis_bucket.sql
+++ b/supabase/migrations/20260418020000_crm_devis_bucket.sql
@@ -1,0 +1,65 @@
+-- ============================================================================
+-- Bucket "devis" — stockage privé des PDFs de devis générés.
+--
+-- Convention de chemin : {client_id}/{devis_id}.pdf
+--   - client_id = tenant id (public.clients.id)
+--   - le 1er segment du path sert à la policy RLS
+--
+-- Bucket privé (public = false) : les PDFs ne sont accessibles que via
+-- signed URL générée côté serveur. Les policies storage.objects autorisent
+-- lecture/écriture uniquement aux users ayant accès au tenant.
+-- ============================================================================
+
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('devis', 'devis', false)
+ON CONFLICT (id) DO NOTHING;
+
+-- ─── Policies storage.objects (bucket = 'devis') ────────────────────────────
+-- Path format attendu : `{client_id}/...` — on check que le 1er segment est
+-- un tenant auquel l'utilisateur a accès.
+
+DROP POLICY IF EXISTS crm_devis_bucket_select ON storage.objects;
+CREATE POLICY crm_devis_bucket_select ON storage.objects
+  FOR SELECT TO authenticated
+  USING (
+    bucket_id = 'devis'
+    AND public.user_has_client_access(
+      ((storage.foldername(name))[1])::uuid
+    )
+  );
+
+DROP POLICY IF EXISTS crm_devis_bucket_insert ON storage.objects;
+CREATE POLICY crm_devis_bucket_insert ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'devis'
+    AND public.user_has_client_access(
+      ((storage.foldername(name))[1])::uuid
+    )
+  );
+
+DROP POLICY IF EXISTS crm_devis_bucket_update ON storage.objects;
+CREATE POLICY crm_devis_bucket_update ON storage.objects
+  FOR UPDATE TO authenticated
+  USING (
+    bucket_id = 'devis'
+    AND public.user_has_client_access(
+      ((storage.foldername(name))[1])::uuid
+    )
+  )
+  WITH CHECK (
+    bucket_id = 'devis'
+    AND public.user_has_client_access(
+      ((storage.foldername(name))[1])::uuid
+    )
+  );
+
+DROP POLICY IF EXISTS crm_devis_bucket_delete ON storage.objects;
+CREATE POLICY crm_devis_bucket_delete ON storage.objects
+  FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'devis'
+    AND public.user_has_client_access(
+      ((storage.foldername(name))[1])::uuid
+    )
+  );


### PR DESCRIPTION
## Summary

Closing out the CRM **Devis** module: a brouillon becomes a traceable sent quote with a PDF attachment.

- **Bucket Supabase privé `devis`** + policies `storage.objects` scopées par `user_has_client_access` sur le 1er segment du path (`{tenant_id}/{devis_id}.pdf`, upsert à chaque envoi)
- **PDF via `@react-pdf/renderer`** ([lib/devisPdf.jsx](lib/devisPdf.jsx)) : header tenant (SIRET, TVA intracom., contact), bloc destinataire, tableau lignes avec snapshot allergènes, **totaux TVA regroupés par taux**, conditions + acompte calculé, cartouche "Bon pour accord", footer paginé
- **Routes API** (runtime `nodejs`, guard `memberOfClient`) :
  - `GET /api/crm/devis/[id]/pdf?client_id=…&download=0|1` — rend à la volée (inline ou download)
  - `POST /api/crm/devis/[id]/envoyer` — génère + upload bucket + Resend (attachment base64) + UPDATE `crm_devis` (`pdf_url`, `pdf_generated_at`, `sent_at`, `sent_to_email`, statut `brouillon → envoye`)
- **UI** : bouton "Télécharger PDF" (fetch blob), bouton "Envoyer par email" ouvrant une modale pré-remplie (destinataire = `crm_client.email`, sujet = "Devis {numero}", message avec `Bonjour {prénom}`), card verte "✓ Envoyé le… à…" + lien "Voir le PDF" une fois envoyé. Bouton devient "Renvoyer" après le 1er envoi, pas de nouvelle transition de statut au renvoi.

## Design notes

- **Pas de logo** sur le PDF : `clients.logo_url` n'existe pas encore, à ajouter dans un PR dédié quand on voudra brander le PDF.
- **From** email hardcodé à `Skalcook <contact@skalcook.com>` (surchargeable via `CONTACT_EMAIL`). `replyTo` = `clients.email_contact` pour que la réponse aille bien au traiteur. Permettre un `from` par tenant nécessitera d'abord vérifier le domaine chez Resend — hors scope.
- **Bucket privé** : pas d'URL publique, le PDF n'est jamais listable. Les re-consultations passent par l'API route qui re-génère à la volée (plus simple que de servir le blob stocké via signed URL, garde la source de vérité en DB).
- **Guard `memberOfClient`** : comme les autres routes CRM, n'importe quel rôle (admin ou directeur) peut télécharger/envoyer — cohérent avec l'UI qui gate déjà le module sur ces deux rôles.

## Test plan

- [x] Migration bucket appliquée via MCP sur le projet Supabase live
- [x] E2E : création devis de test (DEV-2026-001, 2 lignes, totaux 150 HT / 165 TTC) → `GET /pdf` 200 en 640ms, magic bytes `%PDF-1.3`, 4748 B → `POST /envoyer` 200 en 3.5s avec destinataire `delivered@resend.dev` (sandbox Resend) → PDF bien stocké dans le bucket au path `{client_id}/{devis_id}.pdf` → statut basculé `brouillon → envoye` → UI rafraîchie (card verte, bouton "Renvoyer", "Voir le PDF")
- [x] 401 sans Bearer token (guard actif)
- [x] DB de test nettoyée (devis + client + counter reseté)
- [ ] À tester en prod après déploiement Vercel : envoi vers un vrai email, vérification visuelle du PDF reçu, rendu sur un devis multi-pages

## Follow-ups

- Un PDF orphelin reste dans le bucket (de la session de test) — sera écrasé au prochain envoi avec le même `devis_id`, ou à nettoyer via le dashboard Supabase
- Ajouter `logo_url` sur `clients` pour brander le PDF
- Hook de cleanup côté API `DELETE /crm_devis/[id]` pour supprimer le PDF du bucket quand le devis est supprimé (actuellement il reste orphelin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)