### PR TITLE
feat(crm): surface devis on CRM dashboard

### DIFF
--- a/app/crm/page.js
+++ b/app/crm/page.js
@@ -10,6 +10,7 @@ import Navbar from '../../components/Navbar'
 import { Card, Button, Badge, Alert } from '../../components/ui'
 import {
   STATUTS_MAP, STATUTS_ENGAGES, KANBAN_STATUTS,
+  STATUTS_DEVIS_MAP,
   formatMontant, formatDateFr, clientDisplayName, hexToRgba,
 } from '../../lib/crmConstants'
 
@@ -23,6 +24,7 @@ export default function CrmDashboardPage() {
   const [clientId, setClientId] = useState(null)
   const [clients, setClients] = useState([])
   const [evenements, setEvenements] = useState([])
+  const [devis, setDevis] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
@@ -50,18 +52,26 @@ export default function CrmDashboardPage() {
     if (!cid) { setLoading(false); return }
     setClientId(cid)
 
-    const [{ data: cData, error: cErr }, { data: eData, error: eErr }] = await Promise.all([
+    const [
+      { data: cData, error: cErr },
+      { data: eData, error: eErr },
+      { data: dData, error: dErr },
+    ] = await Promise.all([
       supabase.from('crm_clients')
         .select('id, type, nom, prenom, raison_sociale')
         .eq('client_id', cid),
       supabase.from('crm_evenements')
         .select('id, crm_client_id, titre, date_evenement, statut, type_prestation, nb_convives, montant_devis, montant_final, budget_estime, created_at')
         .eq('client_id', cid),
+      supabase.from('crm_devis')
+        .select('id, numero, crm_client_id, statut, total_ttc, date_emission, sent_at, created_at')
+        .eq('client_id', cid),
     ])
 
-    if (cErr || eErr) { setError((cErr || eErr).message); setLoading(false); return }
+    if (cErr || eErr || dErr) { setError((cErr || eErr || dErr).message); setLoading(false); return }
     setClients(cData || [])
     setEvenements(eData || [])
+    setDevis(dData || [])
     setLoading(false)
   }, [])
 
@@ -100,6 +110,32 @@ export default function CrmDashboardPage() {
     for (const s of KANBAN_STATUTS) parStatut[s.key] = 0
     for (const e of evenements) if (parStatut[e.statut] !== undefined) parStatut[e.statut] += 1
 
+    // ─── Stats devis ───────────────────────────────────────────
+    const SEPT_JOURS_MS = 7 * 24 * 60 * 60 * 1000
+
+    const devisEnvoyesMois = devis.filter((d) => {
+      if (!d.sent_at) return false
+      const s = new Date(d.sent_at)
+      return s >= debutMois && s <= finMois
+    })
+    const caDevisSigne = devis
+      .filter((d) => d.statut === 'accepte')
+      .reduce((sum, d) => sum + (Number(d.total_ttc) || 0), 0)
+    const devisEnAttente = devis.filter((d) => {
+      if (d.statut !== 'envoye' || !d.sent_at) return false
+      return now.getTime() - new Date(d.sent_at).getTime() > SEPT_JOURS_MS
+    })
+    const devisComptesTransfo = devis.filter((d) => ['envoye', 'accepte', 'refuse', 'expire'].includes(d.statut))
+    const devisAcceptes = devis.filter((d) => d.statut === 'accepte')
+    const tauxTransfo = devisComptesTransfo.length > 0
+      ? Math.round((devisAcceptes.length / devisComptesTransfo.length) * 100)
+      : null
+
+    const devisRecents = devis
+      .slice()
+      .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+      .slice(0, 5)
+
     return {
       totalClients: clients.length,
       evenementsMois: dansLeMois.length,
@@ -107,8 +143,14 @@ export default function CrmDashboardPage() {
       aVenir: aVenir.slice(0, 5),
       demandesRecentes,
       parStatut,
+      devisEnvoyesMoisCount: devisEnvoyesMois.length,
+      devisEnvoyesMoisCA: devisEnvoyesMois.reduce((s, d) => s + (Number(d.total_ttc) || 0), 0),
+      caDevisSigne,
+      devisEnAttenteCount: devisEnAttente.length,
+      tauxTransfo,
+      devisRecents,
     }
-  }, [evenements, clients])
+  }, [evenements, clients, devis])
 
   if (!authReady || roleLoading) {
     return (
@@ -135,12 +177,42 @@ export default function CrmDashboardPage() {
 
         {error && <Alert variant="error">{error}</Alert>}
 
-        {/* ─── KPI ─────────────────────────────────────────────── */}
+        {/* ─── KPI événements ──────────────────────────────────── */}
         <div className="crm-kpi-grid">
           <Kpi c={c} label="Clients" value={stats.totalClients} onClick={() => router.push('/crm/clients')} />
           <Kpi c={c} label="Événements ce mois-ci" value={stats.evenementsMois} onClick={() => router.push('/crm/evenements')} />
           <Kpi c={c} label="CA prévisionnel engagé" value={formatMontant(stats.caPrev)} />
           <Kpi c={c} label="Demandes en cours" value={stats.parStatut.demande + stats.parStatut.devis_envoye} onClick={() => router.push('/crm/evenements')} />
+        </div>
+
+        {/* ─── KPI devis ───────────────────────────────────────── */}
+        <div className="crm-kpi-grid" style={{ marginTop: 12 }}>
+          <Kpi
+            c={c}
+            label="Devis envoyés ce mois"
+            value={stats.devisEnvoyesMoisCount}
+            hint={stats.devisEnvoyesMoisCount > 0 ? `${formatMontant(stats.devisEnvoyesMoisCA)} TTC` : null}
+            onClick={() => router.push('/crm/devis')}
+          />
+          <Kpi
+            c={c}
+            label="CA devis signés"
+            value={formatMontant(stats.caDevisSigne)}
+            hint="Statut accepté"
+          />
+          <Kpi
+            c={c}
+            label="Devis en attente > 7 j"
+            value={stats.devisEnAttenteCount}
+            accent={stats.devisEnAttenteCount > 0 ? '#DC2626' : null}
+            onClick={stats.devisEnAttenteCount > 0 ? () => router.push('/crm/devis') : undefined}
+          />
+          <Kpi
+            c={c}
+            label="Taux de transformation"
+            value={stats.tauxTransfo != null ? `${stats.tauxTransfo} %` : '—'}
+            hint="Acceptés / envoyés + traités"
+          />
         </div>
 
         {/* ─── Prochains événements ───────────────────────────── */}
@@ -154,6 +226,22 @@ export default function CrmDashboardPage() {
             <div className="crm-list">
               {stats.aVenir.map((e) => (
                 <EventRow key={e.id} c={c} event={e} client={clientById[e.crm_client_id]} onClick={() => router.push(`/crm/evenements/${e.id}`)} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* ─── Derniers devis ─────────────────────────────────── */}
+        <div className="crm-section">
+          <h2 className="crm-section__title" style={{ color: c.texte }}>Derniers devis</h2>
+          {loading ? (
+            <div style={{ color: c.texteMuted, fontSize: 13, padding: 12 }}>Chargement…</div>
+          ) : stats.devisRecents.length === 0 ? (
+            <EmptyState c={c} title="Aucun devis" text="Composez vos devis depuis vos fiches techniques." onAction={() => router.push('/crm/devis/nouveau')} actionLabel="+ Nouveau devis" />
+          ) : (
+            <div className="crm-list">
+              {stats.devisRecents.map((d) => (
+                <DevisRow key={d.id} c={c} devis={d} client={clientById[d.crm_client_id]} onClick={() => router.push(`/crm/devis/${d.id}`)} />
               ))}
             </div>
           )}
@@ -181,11 +269,12 @@ export default function CrmDashboardPage() {
   )
 }
 
-function Kpi({ c, label, value, onClick }) {
+function Kpi({ c, label, value, hint, accent, onClick }) {
   return (
     <Card c={c} padding="md" as={onClick ? 'button' : 'div'} onClick={onClick} style={onClick ? { cursor: 'pointer', textAlign: 'left', width: '100%' } : undefined}>
       <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: 6 }}>{label}</div>
-      <div className="sk-stat-value" style={{ color: c.texte, fontSize: 26 }}>{value}</div>
+      <div className="sk-stat-value" style={{ color: accent || c.texte, fontSize: 26 }}>{value}</div>
+      {hint && <div style={{ color: c.texteMuted, fontSize: 11, marginTop: 4 }}>{hint}</div>}
     </Card>
   )
 }
@@ -207,6 +296,36 @@ function EventRow({ c, event, client, onClick }) {
       </div>
       <div className="crm-row__secondary" style={{ color: c.texteMuted }}>
         {formatDateFr(event.date_evenement)}
+      </div>
+      <div className="crm-row__meta">
+        {statut && (
+          <Badge bg={hexToRgba(statut.couleur, 0.12)} color={statut.couleur} size="sm">
+            {statut.label}
+          </Badge>
+        )}
+      </div>
+    </button>
+  )
+}
+
+function DevisRow({ c, devis, client, onClick }) {
+  const statut = STATUTS_DEVIS_MAP[devis.statut]
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="crm-row"
+      style={{ background: c.blanc, borderColor: c.bordure, color: c.texte }}
+    >
+      <div>
+        <div className="crm-row__primary" style={{ color: c.texte }}>{devis.numero}</div>
+        <div className="crm-row__secondary" style={{ color: c.texteMuted }}>
+          {clientDisplayName(client)}
+        </div>
+      </div>
+      <div className="crm-row__secondary" style={{ color: c.texteMuted }}>
+        <div>{formatDateFr(devis.date_emission)}</div>
+        <div>{formatMontant(devis.total_ttc)} TTC</div>
       </div>
       <div className="crm-row__meta">
         {statut && (


### PR DESCRIPTION
## Summary

Première partie du feedback post-dogfood sur le module Devis : il n'apparaissait nulle part sur `/crm` alors qu'on parle quand même d'une brique commerciale centrale. Ajout d'un bloc KPI + d'une liste des derniers devis.

## Changes

**KPI devis** (4 cartes sous les KPI événements existants)
- Devis envoyés ce mois (avec CA total en hint, ex: `1` + `492 € TTC`)
- CA devis signés (statut `accepte`)
- Devis en attente > 7 j (affiche en rouge + cliquable vers `/crm/devis` si > 0)
- Taux de transformation = acceptés / (envoyés + acceptés + refusés + expirés), affiche `—` si pas encore de devis traités

**Section "Derniers devis"** (entre "Prochains événements" et "Demandes récentes")
- 5 plus récents triés par `created_at` desc
- Empty state avec CTA vers `/crm/devis/nouveau`

## Test plan

- [x] Validé sur le preview — le devis `DEV-2026-001` (Antony Despaux, 492 € TTC, Envoyé) apparaît bien dans la liste et le compteur "Devis envoyés ce mois" passe à 1
- [x] Aucun nouveau call supabase bloquant — `crm_devis` rajouté dans le `Promise.all` existant avec les autres tables
- [ ] À vérifier après déploiement : que le bloc s'affiche pour tous les tenants qui ont le module CRM activé (le module devis fait partie du CRM, pas de gate séparé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)