### PR TITLE
feat(crm): bidirectional devis ↔ événement linking

### DIFF
--- a/app/crm/devis/[id]/page.js
+++ b/app/crm/devis/[id]/page.js
@@ -38,6 +38,8 @@ export default function CrmDevisDetailPage() {
   const [confirmDelete, setConfirmDelete] = useState(false)
   const [pdfLoading, setPdfLoading] = useState(false)
   const [sendModalOpen, setSendModalOpen] = useState(false)
+  const [linkSaving, setLinkSaving] = useState(false)
+  const [showEvenementPicker, setShowEvenementPicker] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -225,6 +227,48 @@ export default function CrmDevisDetailPage() {
     await load()
   }
 
+  async function handleLinkEvenement(evenementId) {
+    setLinkSaving(true)
+    setError('')
+    const { error: err } = await supabase
+      .from('crm_devis')
+      .update({ crm_evenement_id: evenementId || null })
+      .eq('id', id)
+      .eq('client_id', clientId)
+    setLinkSaving(false)
+    if (err) { setError(err.message); return }
+    setShowEvenementPicker(false)
+    await load()
+  }
+
+  async function handleCreateEvenementFromDevis() {
+    if (!devis?.crm_client_id) { setError('Aucun client lié à ce devis.'); return }
+    setLinkSaving(true)
+    setError('')
+    const { data: { user } } = await supabase.auth.getUser()
+    const { data: newEv, error: eErr } = await supabase
+      .from('crm_evenements')
+      .insert({
+        client_id: clientId,
+        crm_client_id: devis.crm_client_id,
+        titre: `Événement ${devis.numero}`,
+        statut: 'devis_envoye',
+        montant_devis: devis.total_ttc,
+        created_by: user?.id || null,
+      })
+      .select('id')
+      .single()
+    if (eErr) { setLinkSaving(false); setError(eErr.message); return }
+    const { error: uErr } = await supabase
+      .from('crm_devis')
+      .update({ crm_evenement_id: newEv.id })
+      .eq('id', id)
+      .eq('client_id', clientId)
+    setLinkSaving(false)
+    if (uErr) { setError(uErr.message); return }
+    router.push(`/crm/evenements/${newEv.id}`)
+  }
+
   const statut = useMemo(() => STATUTS_DEVIS_MAP[devis?.statut], [devis])
   const allergenesAgreges = useMemo(() => {
     const set = new Set()
@@ -232,6 +276,12 @@ export default function CrmDevisDetailPage() {
     return Array.from(set)
   }, [lignes])
   const tauxTvaMap = useMemo(() => Object.fromEntries(TAUX_TVA.map((t) => [t.key, t.label])), [])
+  const evenementsPourClient = useMemo(
+    () => (devis?.crm_client_id
+      ? evenementsDispo.filter((ev) => ev.crm_client_id === devis.crm_client_id)
+      : []),
+    [evenementsDispo, devis?.crm_client_id]
+  )
 
   if (!authReady || roleLoading) {
     return (
@@ -289,18 +339,6 @@ export default function CrmDevisDetailPage() {
                       {clientDisplayName(clientCrm)}
                     </button>
                   )}
-                  {evenement && (
-                    <>
-                      <span>·</span>
-                      <button
-                        type="button"
-                        onClick={() => router.push(`/crm/evenements/${evenement.id}`)}
-                        style={{ background: 'transparent', border: 'none', color: c.accent, cursor: 'pointer', padding: 0, fontSize: 13, textDecoration: 'underline' }}
-                      >
-                        {evenement.titre}
-                      </button>
-                    </>
-                  )}
                 </p>
               </div>
               <div className="crm-actions">
@@ -333,6 +371,81 @@ export default function CrmDevisDetailPage() {
                 </div>
               </Card>
             )}
+
+            {/* Événement lié */}
+            <Card c={c} padding="md" style={{ marginBottom: 20 }}>
+              <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 12 }}>
+                <div className="sk-label-muted" style={{ color: c.texteMuted }}>Événement lié</div>
+                {evenement ? (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => router.push(`/crm/evenements/${evenement.id}`)}
+                      style={{ background: 'transparent', border: 'none', color: c.accent, cursor: 'pointer', padding: 0, fontSize: 14, fontWeight: 500, textDecoration: 'underline' }}
+                    >
+                      {evenement.titre}
+                    </button>
+                    {evenement.date_evenement && (
+                      <span style={{ color: c.texteMuted, fontSize: 13 }}>
+                        · {formatDateFr(evenement.date_evenement)}
+                      </span>
+                    )}
+                    <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+                      <Button c={c} variant="ghost" size="sm" onClick={() => setShowEvenementPicker(true)} disabled={linkSaving}>
+                        Changer
+                      </Button>
+                      <Button c={c} variant="ghost" size="sm" onClick={() => handleLinkEvenement(null)} disabled={linkSaving}>
+                        Détacher
+                      </Button>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <span style={{ color: c.texteMuted, fontSize: 13 }}>Aucun événement lié</span>
+                    <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+                      <Button c={c} variant="ghost" size="sm" onClick={() => setShowEvenementPicker(true)} disabled={linkSaving || evenementsPourClient.length === 0}>
+                        Lier à un événement
+                      </Button>
+                      <Button c={c} variant="ghost" size="sm" onClick={handleCreateEvenementFromDevis} disabled={linkSaving}>
+                        + Créer un événement
+                      </Button>
+                    </div>
+                  </>
+                )}
+              </div>
+              {showEvenementPicker && (
+                <div style={{ marginTop: 12, paddingTop: 12, borderTop: `0.5px solid ${c.bordure}` }}>
+                  <select
+                    className="sk-select"
+                    style={{ background: c.blanc, border: `0.5px solid ${c.bordure}`, color: c.texte, width: '100%', maxWidth: 400 }}
+                    defaultValue=""
+                    onChange={(e) => { if (e.target.value) handleLinkEvenement(e.target.value) }}
+                    disabled={linkSaving}
+                  >
+                    <option value="">Choisir un événement…</option>
+                    {evenementsPourClient
+                      .filter((ev) => ev.id !== devis.crm_evenement_id)
+                      .map((ev) => (
+                        <option key={ev.id} value={ev.id}>
+                          {ev.titre}{ev.date_evenement ? ` — ${ev.date_evenement}` : ''}
+                        </option>
+                      ))}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={() => setShowEvenementPicker(false)}
+                    style={{ background: 'transparent', border: 'none', color: c.texteMuted, cursor: 'pointer', padding: '6px 0', fontSize: 12, marginLeft: 8 }}
+                  >
+                    Annuler
+                  </button>
+                  {evenementsPourClient.length === 0 && (
+                    <div style={{ color: c.texteMuted, fontSize: 12, marginTop: 6 }}>
+                      Aucun événement disponible pour ce client.
+                    </div>
+                  )}
+                </div>
+              )}
+            </Card>
 
             {/* Statut */}
             <Card c={c} padding="md" style={{ marginBottom: 20 }}>

--- a/app/crm/evenements/[id]/page.js
+++ b/app/crm/evenements/[id]/page.js
@@ -10,6 +10,7 @@ import { Card, Button, Badge, Alert } from '../../../../components/ui'
 import EvenementForm from '../../../../components/crm/EvenementForm'
 import {
   STATUTS, STATUTS_MAP, TYPES_PRESTATION_MAP, LIEUX_TYPES_MAP,
+  STATUTS_DEVIS_MAP,
   formatDateFr, formatMontant, clientDisplayName, hexToRgba,
 } from '../../../../lib/crmConstants'
 
@@ -30,6 +31,10 @@ export default function CrmEvenementDetailPage() {
   const [mode, setMode] = useState('view')
   const [statutSaving, setStatutSaving] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
+  const [devisLies, setDevisLies] = useState([])
+  const [devisDetachables, setDevisDetachables] = useState([])
+  const [linkSaving, setLinkSaving] = useState(false)
+  const [showDevisPicker, setShowDevisPicker] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -80,6 +85,17 @@ export default function CrmEvenementDetailPage() {
       .select('id, type, nom, prenom, raison_sociale')
       .eq('client_id', cid)
     setClientsDispo(allClients || [])
+
+    // Devis du tenant (filtrés après en mémoire : liés vs détachables du client courant)
+    const { data: allDevis } = await supabase
+      .from('crm_devis')
+      .select('id, numero, crm_client_id, crm_evenement_id, statut, total_ttc, date_emission, sent_at')
+      .eq('client_id', cid)
+      .order('date_emission', { ascending: false })
+    const devAll = allDevis || []
+    setDevisLies(devAll.filter((d) => d.crm_evenement_id === id))
+    setDevisDetachables(devAll.filter((d) => !d.crm_evenement_id && d.crm_client_id === ev?.crm_client_id))
+
     setLoading(false)
   }, [id])
 
@@ -109,6 +125,34 @@ export default function CrmEvenementDetailPage() {
     if (!err) setEvenement((ev) => ({ ...ev, statut: newStatut }))
     else setError(err.message)
     setStatutSaving(false)
+  }
+
+  async function handleAttachDevis(devisId) {
+    if (!devisId) return
+    setLinkSaving(true)
+    setError('')
+    const { error: err } = await supabase
+      .from('crm_devis')
+      .update({ crm_evenement_id: id })
+      .eq('id', devisId)
+      .eq('client_id', clientId)
+    setLinkSaving(false)
+    if (err) { setError(err.message); return }
+    setShowDevisPicker(false)
+    await load()
+  }
+
+  async function handleDetachDevis(devisId) {
+    setLinkSaving(true)
+    setError('')
+    const { error: err } = await supabase
+      .from('crm_devis')
+      .update({ crm_evenement_id: null })
+      .eq('id', devisId)
+      .eq('client_id', clientId)
+    setLinkSaving(false)
+    if (err) { setError(err.message); return }
+    await load()
   }
 
   async function handleDelete() {
@@ -246,6 +290,87 @@ export default function CrmEvenementDetailPage() {
                 </div>
               </Card>
             )}
+
+            {/* Devis liés */}
+            <Card c={c} padding="md" style={{ marginBottom: 20 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 10 }}>
+                <div className="sk-panel-header" style={{ color: c.texte, margin: 0 }}>
+                  Devis {devisLies.length > 0 && <span style={{ color: c.texteMuted, fontWeight: 400 }}>· {devisLies.length}</span>}
+                </div>
+                <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                  {devisDetachables.length > 0 && (
+                    <Button c={c} variant="ghost" size="sm" onClick={() => setShowDevisPicker((v) => !v)} disabled={linkSaving}>
+                      {showDevisPicker ? 'Fermer' : 'Lier un devis existant'}
+                    </Button>
+                  )}
+                  <Button c={c} variant="ghost" size="sm" onClick={() => router.push(`/crm/devis/nouveau?evenement=${id}`)}>
+                    + Nouveau devis
+                  </Button>
+                </div>
+              </div>
+
+              {showDevisPicker && devisDetachables.length > 0 && (
+                <div style={{ marginBottom: 12, paddingBottom: 12, borderBottom: `0.5px solid ${c.bordure}` }}>
+                  <select
+                    className="sk-select"
+                    style={{ background: c.blanc, border: `0.5px solid ${c.bordure}`, color: c.texte, width: '100%', maxWidth: 400 }}
+                    defaultValue=""
+                    onChange={(e) => { if (e.target.value) handleAttachDevis(e.target.value) }}
+                    disabled={linkSaving}
+                  >
+                    <option value="">Choisir un devis non lié…</option>
+                    {devisDetachables.map((d) => (
+                      <option key={d.id} value={d.id}>
+                        {d.numero} — {formatMontant(d.total_ttc)} TTC ({STATUTS_DEVIS_MAP[d.statut]?.label || d.statut})
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
+
+              {devisLies.length === 0 ? (
+                <div style={{ color: c.texteMuted, fontSize: 13, padding: '4px 0' }}>
+                  Aucun devis lié à cet événement.
+                </div>
+              ) : (
+                <div className="crm-list">
+                  {devisLies.map((d) => {
+                    const st = STATUTS_DEVIS_MAP[d.statut]
+                    return (
+                      <div
+                        key={d.id}
+                        className="crm-row"
+                        style={{ background: c.blanc, borderColor: c.bordure, color: c.texte, cursor: 'default' }}
+                      >
+                        <button
+                          type="button"
+                          onClick={() => router.push(`/crm/devis/${d.id}`)}
+                          style={{ background: 'transparent', border: 'none', padding: 0, textAlign: 'left', cursor: 'pointer', flex: 1, minWidth: 0 }}
+                        >
+                          <div className="crm-row__primary" style={{ color: c.texte }}>{d.numero}</div>
+                          <div className="crm-row__secondary" style={{ color: c.texteMuted }}>
+                            {formatDateFr(d.date_emission)} · {formatMontant(d.total_ttc)} TTC
+                            {d.sent_at && ` · Envoyé le ${formatDateFr(d.sent_at)}`}
+                          </div>
+                        </button>
+                        <div className="crm-row__meta" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                          {st && <Badge bg={hexToRgba(st.couleur, 0.12)} color={st.couleur} size="sm">{st.label}</Badge>}
+                          <button
+                            type="button"
+                            onClick={() => handleDetachDevis(d.id)}
+                            disabled={linkSaving}
+                            title="Détacher ce devis de l'événement"
+                            style={{ background: 'transparent', border: 'none', color: c.texteMuted, cursor: 'pointer', padding: 4, fontSize: 16, lineHeight: 1 }}
+                          >
+                            ×
+                          </button>
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+            </Card>
 
             {/* Zone danger */}
             <div style={{ marginTop: 32, paddingTop: 16, borderTop: `0.5px solid ${c.bordure}` }}>


### PR DESCRIPTION
## Summary

Deuxième retour post-dogfood : la FK `crm_devis.crm_evenement_id` existait déjà mais la liaison était quasi-invisible — seulement accessible au moment "créer un devis depuis un événement". Exposition de la capacité dans les deux sens, à tout moment.

## Changes

### Devis detail — nouveau bloc "Événement lié"
- Si lié : titre + date cliquables, boutons **Changer** (ré-ouvre le picker) et **Détacher**
- Si non lié : **Lier à un événement** (select des événements du même client) et **+ Créer un événement** (crée l'événement à partir des données du devis : `titre = "Événement DEV-2026-XXX"`, `statut = 'devis_envoye'`, `montant_devis = total_ttc`, puis UPDATE la FK et redirige vers le détail de l'événement)

### Event detail — nouvelle section "Devis"
- Liste des devis liés (numéro, date d'émission, total TTC, date d'envoi si envoyé, badge statut, × pour détacher)
- **Lier un devis existant** : select des devis non-liés du même client
- **+ Nouveau devis** : utilise le flow existant `/crm/devis/nouveau?evenement=…`

## Design notes

- Pas de nouvelle migration — on exploite la FK existante `crm_devis.crm_evenement_id`
- Les actions de liaison utilisent un simple UPDATE avec RLS, pas d'API route dédiée
- "Créer un événement depuis ce devis" force le statut événement à `devis_envoye` (cohérent avec le fait que le devis existe déjà), l'utilisateur pourra affiner les détails (date, convives…) dans la page événement

## Test plan

- [x] Devis detail : card "Aucun événement lié" + 2 boutons rendus correctement sur le vrai devis `DEV-2026-001`
- [x] Event detail : section "Devis" rendue avec bouton "Lier un devis existant" + picker fonctionnel
- [x] Attach OK : sélection d'un devis non-lié → UPDATE immédiat → liste "Devis · 1" avec toutes les infos (numéro, total, statut envoyé, ×)
- [x] Test data (événement de test + liaison) nettoyée
- [ ] À tester en prod : "Créer un événement depuis ce devis" (flow de redirection)
- [ ] À tester en prod : "Changer" (picker avec événement existant déjà rattaché)

🤖 Generated with [Claude Code](https://claude.com/claude-code)