### PR TITLE
feat(crm): devis versioning with frozen snapshots

### DIFF
--- a/app/api/crm/devis/[id]/envoyer/route.js
+++ b/app/api/crm/devis/[id]/envoyer/route.js
@@ -64,8 +64,18 @@ export const POST = apiHandler({
     })
     const pdfBuffer = await renderToBuffer(element)
 
-    // ─── 3. Upload dans le bucket (upsert) ─────────────────────────────
-    const path = `${clientId}/${devis.id}.pdf`
+    // ─── 3. Calcul du prochain numéro de révision ─────────────────────
+    const { data: lastRev } = await db
+      .from('crm_devis_revisions')
+      .select('version')
+      .eq('devis_id', devisId)
+      .order('version', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+    const nextVersion = (lastRev?.version || 0) + 1
+
+    // ─── 4. Upload dans le bucket (path versionné) ────────────────────
+    const path = `${clientId}/${devis.id}/v${nextVersion}.pdf`
     const { error: upErr } = await db.storage
       .from('devis')
       .upload(path, pdfBuffer, {
@@ -76,7 +86,7 @@ export const POST = apiHandler({
       return Response.json({ error: `Upload PDF échoué : ${upErr.message}` }, { status: 500 })
     }
 
-    // ─── 4. Envoyer l'email Resend ─────────────────────────────────────
+    // ─── 5. Envoyer l'email Resend ─────────────────────────────────────
     const resend = new Resend(process.env.RESEND_API_KEY)
     const replyTo = tenant?.email_contact || undefined
     const filename = `${devis.numero}.pdf`
@@ -106,9 +116,34 @@ export const POST = apiHandler({
       return Response.json({ error: `Envoi email échoué : ${emailErr.message}` }, { status: 500 })
     }
 
-    // ─── 5. Update devis (statut + tracking) ───────────────────────────
-    const nextStatut = devis.statut === 'brouillon' ? 'envoye' : devis.statut
+    // ─── 6. Enregistrer la révision (snapshot figé) ────────────────────
     const now = new Date().toISOString()
+    const { error: revErr } = await db
+      .from('crm_devis_revisions')
+      .insert({
+        devis_id: devisId,
+        client_id: clientId,
+        version: nextVersion,
+        snapshot_header: devis,
+        snapshot_lignes: lignes || [],
+        snapshot_crm_client: crmClientRes.data || null,
+        snapshot_tenant: tenant || null,
+        sent_at: now,
+        sent_to_email: data.to,
+        sent_subject: data.subject,
+        sent_message: data.message || null,
+        pdf_url: path,
+        created_by: user?.id || null,
+      })
+    if (revErr) {
+      // La révision est l'historique — si l'insert échoue on n'empêche pas
+      // la mise à jour du devis (l'email est parti, le PDF est uploadé),
+      // mais on le log côté serveur.
+      console.error('[devis/envoyer] revision insert failed:', revErr.message)
+    }
+
+    // ─── 7. Update devis (statut + tracking = pointeur vers la dernière rev) ─
+    const nextStatut = devis.statut === 'brouillon' ? 'envoye' : devis.statut
     const { error: updErr } = await db
       .from('crm_devis')
       .update({
@@ -127,6 +162,7 @@ export const POST = apiHandler({
     return Response.json({
       ok: true,
       pdf_url: path,
+      version: nextVersion,
       sent_at: now,
       sent_to_email: data.to,
       statut: nextStatut,

--- a/app/api/crm/devis/[id]/revision/[revisionId]/pdf/route.js
+++ b/app/api/crm/devis/[id]/revision/[revisionId]/pdf/route.js
@@ -1,0 +1,58 @@
+// GET /api/crm/devis/[id]/revision/[revisionId]/pdf?client_id=<tenant>&download=0|1
+//
+// Sert le PDF stocké dans le bucket correspondant à une révision historique.
+// Ne régénère pas — renvoie le fichier figé au moment de l'envoi.
+
+import { z } from 'zod'
+import { apiHandler } from '../../../../../../../../lib/apiHandler'
+
+export const runtime = 'nodejs'
+
+const querySchema = z.object({
+  client_id: z.string().uuid(),
+  download: z.string().optional(),
+})
+
+export const GET = apiHandler({
+  schema: querySchema,
+  guard: 'memberOfClient',
+  clientIdFrom: 'body.client_id',
+  handler: async ({ data, db, params }) => {
+    const devisId = params?.id
+    const revisionId = params?.revisionId
+    const clientId = data.client_id
+    if (!devisId || !revisionId) {
+      return Response.json({ error: 'id ou revisionId manquant' }, { status: 400 })
+    }
+
+    const { data: rev, error: revErr } = await db
+      .from('crm_devis_revisions')
+      .select('id, devis_id, client_id, version, pdf_url, sent_at')
+      .eq('id', revisionId)
+      .eq('devis_id', devisId)
+      .eq('client_id', clientId)
+      .maybeSingle()
+    if (revErr || !rev) {
+      return Response.json({ error: 'Révision introuvable' }, { status: 404 })
+    }
+
+    const { data: fileData, error: dlErr } = await db.storage
+      .from('devis')
+      .download(rev.pdf_url)
+    if (dlErr || !fileData) {
+      return Response.json({ error: `PDF introuvable : ${dlErr?.message || 'download failed'}` }, { status: 404 })
+    }
+    const arrayBuffer = await fileData.arrayBuffer()
+
+    const filename = `devis-v${rev.version}.pdf`
+    const disposition = data.download === '1' ? 'attachment' : 'inline'
+    return new Response(Buffer.from(arrayBuffer), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `${disposition}; filename="${filename}"`,
+        'Cache-Control': 'private, no-store',
+      },
+    })
+  },
+})

--- a/app/crm/devis/[id]/page.js
+++ b/app/crm/devis/[id]/page.js
@@ -40,6 +40,8 @@ export default function CrmDevisDetailPage() {
   const [sendModalOpen, setSendModalOpen] = useState(false)
   const [linkSaving, setLinkSaving] = useState(false)
   const [showEvenementPicker, setShowEvenementPicker] = useState(false)
+  const [revisions, setRevisions] = useState([])
+  const [revisionLoadingId, setRevisionLoadingId] = useState(null)
 
   useEffect(() => {
     let cancelled = false
@@ -83,6 +85,7 @@ export default function CrmDevisDetailPage() {
       { data: clientsData },
       { data: evenementsData },
       { data: fichesData },
+      { data: revisionsData },
     ] = await Promise.all([
       supabase.from('crm_devis_lignes')
         .select('*')
@@ -110,6 +113,10 @@ export default function CrmDevisDetailPage() {
         .eq('archive', false)
         .eq('is_sub_fiche', false)
         .order('nom', { ascending: true }),
+      supabase.from('crm_devis_revisions')
+        .select('id, version, sent_at, sent_to_email, sent_subject, snapshot_header')
+        .eq('devis_id', id)
+        .order('version', { ascending: false }),
     ])
     if (lErr) { setError(lErr.message); setLoading(false); return }
     setLignes(lignesData || [])
@@ -118,6 +125,7 @@ export default function CrmDevisDetailPage() {
     setClientsDispo(clientsData || [])
     setEvenementsDispo(evenementsData || [])
     setFichesDispo(fichesData || [])
+    setRevisions(revisionsData || [])
     setLoading(false)
   }, [id])
 
@@ -225,6 +233,36 @@ export default function CrmDevisDetailPage() {
     if (!res.ok) throw new Error(j.error || `HTTP ${res.status}`)
     setSendModalOpen(false)
     await load()
+  }
+
+  async function handleDownloadRevisionPdf(revisionId, { download = false, version } = {}) {
+    if (!clientId) return
+    setRevisionLoadingId(revisionId)
+    setError('')
+    try {
+      const headers = await authHeaders()
+      const url = `/api/crm/devis/${id}/revision/${revisionId}/pdf?client_id=${clientId}${download ? '&download=1' : ''}`
+      const res = await fetch(url, { headers })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
+        throw new Error(j.error || 'Erreur PDF')
+      }
+      const blob = await res.blob()
+      const blobUrl = URL.createObjectURL(blob)
+      if (download) {
+        const a = document.createElement('a')
+        a.href = blobUrl
+        a.download = `${devis?.numero || 'devis'}-v${version || ''}.pdf`
+        document.body.appendChild(a); a.click(); a.remove()
+      } else {
+        window.open(blobUrl, '_blank', 'noopener')
+      }
+      setTimeout(() => URL.revokeObjectURL(blobUrl), 60_000)
+    } catch (err) {
+      setError(err.message || 'Erreur PDF')
+    } finally {
+      setRevisionLoadingId(null)
+    }
   }
 
   async function handleLinkEvenement(evenementId) {
@@ -356,17 +394,22 @@ export default function CrmDevisDetailPage() {
             {devis.sent_at && (
               <Card c={c} padding="md" style={{ marginBottom: 20, background: hexToRgba('#10B981', 0.06), borderColor: hexToRgba('#10B981', 0.3) }}>
                 <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap', fontSize: 13, color: c.texte }}>
-                  <span style={{ fontWeight: 500 }}>✓ Envoyé</span>
+                  <span style={{ fontWeight: 500 }}>
+                    ✓ Envoyé{revisions.length > 0 ? ` · V${revisions[0].version}` : ''}
+                  </span>
                   <span style={{ color: c.texteMuted }}>
                     le {formatDateFr(devis.sent_at)}{devis.sent_to_email ? ` à ${devis.sent_to_email}` : ''}
                   </span>
                   <button
                     type="button"
-                    onClick={() => handleDownloadPdf({ download: false })}
-                    disabled={pdfLoading}
+                    onClick={() => {
+                      if (revisions[0]) handleDownloadRevisionPdf(revisions[0].id, { version: revisions[0].version })
+                      else handleDownloadPdf({ download: false })
+                    }}
+                    disabled={pdfLoading || revisionLoadingId != null}
                     style={{ marginLeft: 'auto', background: 'transparent', border: 'none', color: c.accent, cursor: 'pointer', textDecoration: 'underline', fontSize: 13 }}
                   >
-                    Voir le PDF
+                    Voir le PDF envoyé
                   </button>
                 </div>
               </Card>
@@ -562,6 +605,70 @@ export default function CrmDevisDetailPage() {
                   {clientCrm.telephone && (
                     <a href={`tel:${clientCrm.telephone}`} style={{ color: c.accent }}>{clientCrm.telephone}</a>
                   )}
+                </div>
+              </Card>
+            )}
+
+            {/* Historique des envois */}
+            {revisions.length > 0 && (
+              <Card c={c} padding="md" style={{ marginBottom: 20 }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
+                  <div className="sk-panel-header" style={{ color: c.texte, margin: 0 }}>
+                    Historique des envois <span style={{ color: c.texteMuted, fontWeight: 400 }}>· {revisions.length}</span>
+                  </div>
+                </div>
+                <p style={{ color: c.texteMuted, fontSize: 12, margin: '0 0 12px 0' }}>
+                  Chaque envoi fige le devis dans son état d'alors. Utile pour tracer les évolutions demandées par le client.
+                </p>
+                <div className="crm-list">
+                  {revisions.map((r) => {
+                    const isLatest = r.version === revisions[0].version
+                    const totalTtc = r.snapshot_header?.total_ttc
+                    return (
+                      <div
+                        key={r.id}
+                        className="crm-row"
+                        style={{ background: c.blanc, borderColor: c.bordure, color: c.texte, cursor: 'default' }}
+                      >
+                        <div style={{ minWidth: 0, flex: 1 }}>
+                          <div className="crm-row__primary" style={{ color: c.texte, display: 'flex', gap: 8, alignItems: 'center' }}>
+                            <span>Version {r.version}</span>
+                            {isLatest && (
+                              <Badge bg={hexToRgba(c.accent, 0.12)} color={c.accent} size="sm">Actuelle</Badge>
+                            )}
+                          </div>
+                          <div className="crm-row__secondary" style={{ color: c.texteMuted }}>
+                            {formatDateFr(r.sent_at)} · {r.sent_to_email}
+                            {totalTtc != null && ` · ${formatMontant(totalTtc)} TTC`}
+                          </div>
+                          {r.sent_subject && (
+                            <div style={{ color: c.texteMuted, fontSize: 12, marginTop: 2 }}>
+                              Sujet : {r.sent_subject}
+                            </div>
+                          )}
+                        </div>
+                        <div className="crm-row__meta" style={{ display: 'flex', gap: 6 }}>
+                          <button
+                            type="button"
+                            onClick={() => handleDownloadRevisionPdf(r.id, { version: r.version, download: false })}
+                            disabled={revisionLoadingId != null}
+                            style={{ background: 'transparent', border: 'none', color: c.accent, cursor: 'pointer', textDecoration: 'underline', fontSize: 13, padding: 0 }}
+                          >
+                            {revisionLoadingId === r.id ? '…' : 'Voir'}
+                          </button>
+                          <span style={{ color: c.texteMuted, fontSize: 13 }}>·</span>
+                          <button
+                            type="button"
+                            onClick={() => handleDownloadRevisionPdf(r.id, { version: r.version, download: true })}
+                            disabled={revisionLoadingId != null}
+                            style={{ background: 'transparent', border: 'none', color: c.accent, cursor: 'pointer', textDecoration: 'underline', fontSize: 13, padding: 0 }}
+                          >
+                            Télécharger
+                          </button>
+                        </div>
+                      </div>
+                    )
+                  })}
                 </div>
               </Card>
             )}

--- a/supabase/migrations/20260418030000_crm_devis_revisions.sql
+++ b/supabase/migrations/20260418030000_crm_devis_revisions.sql
@@ -1,0 +1,58 @@
+-- ============================================================================
+-- CRM — Versioning des devis envoyés (crm_devis_revisions)
+--
+-- À chaque POST /envoyer, on snapshote :
+--   - l'état complet du header (crm_devis)
+--   - toutes les lignes (crm_devis_lignes)
+--   - l'état du crm_client destinataire
+--   - les métadonnées d'envoi (to, subject, message, pdf_url versionné)
+--
+-- Le numéro du devis reste stable ; les révisions permettent l'audit et
+-- de montrer au client l'évolution de la proposition (V1, V2, …).
+--
+-- Convention bucket pour les PDFs versionnés : {client_id}/{devis_id}/v{N}.pdf
+-- (l'ancien path plat {client_id}/{devis_id}.pdf n'est plus écrit, le
+-- crm_devis.pdf_url pointe désormais toujours vers la dernière révision).
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.crm_devis_revisions (
+  id             uuid         DEFAULT gen_random_uuid() PRIMARY KEY,
+  devis_id       uuid         NOT NULL REFERENCES public.crm_devis(id) ON DELETE CASCADE,
+  client_id      uuid         NOT NULL,
+  version        integer      NOT NULL,
+
+  -- Snapshots (figés au moment de l'envoi)
+  snapshot_header     jsonb   NOT NULL,
+  snapshot_lignes     jsonb   NOT NULL,
+  snapshot_crm_client jsonb,
+  snapshot_tenant     jsonb,
+
+  -- Métadonnées de l'envoi
+  sent_at          timestamptz NOT NULL DEFAULT now(),
+  sent_to_email    text        NOT NULL,
+  sent_subject     text,
+  sent_message     text,
+  pdf_url          text        NOT NULL, -- path bucket : {client_id}/{devis_id}/v{N}.pdf
+
+  created_by       uuid,
+  created_at       timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT crm_devis_revisions_version_unique UNIQUE (devis_id, version)
+);
+
+CREATE INDEX IF NOT EXISTS crm_devis_revisions_devis_id_idx
+  ON public.crm_devis_revisions (devis_id, version DESC);
+CREATE INDEX IF NOT EXISTS crm_devis_revisions_client_id_idx
+  ON public.crm_devis_revisions (client_id);
+
+-- ─── RLS ───────────────────────────────────────────────────────────────
+ALTER TABLE public.crm_devis_revisions ENABLE ROW LEVEL SECURITY;
+
+-- Lecture : n'importe quel membre de l'établissement
+CREATE POLICY crm_devis_revisions_select ON public.crm_devis_revisions
+  FOR SELECT TO authenticated
+  USING (public.user_has_client_access(client_id));
+
+-- Pas de policy INSERT/UPDATE/DELETE : les révisions ne sont écrites que
+-- par la route /api/crm/devis/[id]/envoyer qui passe en service-role.
+-- Empêche la falsification de l'historique depuis le client.


### PR DESCRIPTION
## Summary

Troisième retour post-dogfood : tracer les évolutions d'un devis suite aux demandes client. Chaque envoi crée maintenant une **révision immuable** (numéro de devis stable, version auto-incrémentée) avec son propre PDF figé dans le bucket.

## Changes

### Schéma
- **`crm_devis_revisions`** : `version` (unique par `devis_id`), 4 snapshots `jsonb` (header + lignes + crm_client + tenant), métadonnées d'envoi (`sent_at`, `sent_to_email`, `sent_subject`, `sent_message`, `pdf_url` versionné)
- **Path bucket** : passe de `{tenant}/{devis}.pdf` (écrasé à chaque envoi) à `{tenant}/{devis}/v{N}.pdf` — l'historique n'est plus perdu
- **RLS** : SELECT ouvert aux membres du tenant, **pas de policy** INSERT/UPDATE/DELETE — seule la route `/envoyer` en service-role peut écrire, impossible de falsifier l'historique

### Routes
- `POST /api/crm/devis/[id]/envoyer` : lit la version max existante → `nextVersion = max + 1` → upload versionné → **INSERT dans `crm_devis_revisions`** (après succès Resend) → UPDATE `crm_devis` (pointeur vers la dernière révision). Renvoie `version` dans la réponse.
- `GET /api/crm/devis/[id]/revision/[revisionId]/pdf` : sert le PDF **figé** stocké dans le bucket (pas de régénération) — préserve exactement ce qui a été envoyé à l'instant T.

### UI
- Card d'envoi : "✓ Envoyé **· V2**" + "Voir le PDF envoyé" récupère maintenant la dernière révision figée (avant = re-render de l'état courant, divergeait si le devis était modifié après envoi).
- Nouvelle section **"Historique des envois"** : liste version desc, avec date, destinataire, total TTC snapshoté, sujet de l'email, badge "Actuelle" sur la dernière, boutons **Voir** / **Télécharger** par version.

## Test plan

- [x] Migration appliquée via MCP sur le projet Supabase live
- [x] E2E : devis TEST-2026-REV envoyé une 1ère fois (total 110 €) → V1 créée → ligne ajoutée (+48 € TTC) → renvoi à 158 € → **V2 Actuelle + V1 préservée** en historique, totaux figés corrects
- [x] Bucket : `v1.pdf` et `v2.pdf` coexistent ; bytes distincts (server log: 200 OK sur la route `/revision/[rid]/pdf`)
- [x] Test data (devis + client + révisions + bucket objects) nettoyée
- [ ] À tester en prod : vérifier qu'un devis **déjà envoyé avant cette migration** (ex: DEV-2026-001) gère bien le cas "0 révision" et reste fonctionnel (la card continue de fonctionner via le fallback `handleDownloadPdf` qui re-render l'état courant)

## Design notes

- Pas de hook de cleanup bucket au DELETE devis (FK CASCADE supprime les `crm_devis_revisions` mais laisse les fichiers orphelins) — listé dans les follow-ups de la PR précédente.
- La **table de révisions n'est pas éditable** par le client même en cas de bug de RLS : c'est la SECURITY DEFINER / service role qui écrit. Intentionnel pour audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)