### PR TITLE
fix(superadmin): actually send invite email to new admins

### DIFF
--- a/lib/services/admin.service.ts
+++ b/lib/services/admin.service.ts
@@ -178,15 +178,17 @@ export async function createGlobalUser(db: SupabaseClient, input: CreateGlobalUs
 // ── Invite admin ───────────────────────────────────────────────────────────
 
 export async function inviteAdmin(db: SupabaseClient, email: string, nom: string, clientId: string) {
-  const tempPassword = generateTempPassword()
+  // On utilise inviteUserByEmail : Supabase crée l'utilisateur sans mot de
+  // passe et envoie un email d'invitation (template Auth → "Invite user")
+  // avec un lien qui ouvre une session authentifiée sur /nouveau-mot-de-passe
+  // où l'utilisateur définit son mot de passe.
+  const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL || '').replace(/\/$/, '')
+  const redirectTo = siteUrl ? `${siteUrl}/nouveau-mot-de-passe` : undefined
 
-  const { data: authData, error: authErr } = await db.auth.admin.createUser({
-    email,
-    password: tempPassword,
-    email_confirm: true,
-    user_metadata: { nom, client_id: clientId },
+  const { data: authData, error: authErr } = await db.auth.admin.inviteUserByEmail(email, {
+    redirectTo,
+    data: { nom, client_id: clientId },
   })
-
   if (authErr) throw new Error(authErr.message)
   const userId = authData.user.id
 
@@ -205,16 +207,10 @@ export async function inviteAdmin(db: SupabaseClient, email: string, nom: string
     }),
   ])
 
-  // Generate password reset link
-  const { data: linkData } = await db.auth.admin.generateLink({
-    type: 'recovery',
-    email,
-  })
-
   return {
     userId,
     email,
-    resetLink: linkData?.properties?.action_link ?? null,
+    invitationSent: true,
   }
 }
 


### PR DESCRIPTION
## Summary

Bug découvert en dogfood : le flow **"Inviter un admin par email"** du superadmin n'envoyait **aucun email**. Le compte auth était créé et un lien de recovery généré, mais le lien remontait jusqu'à la route API puis disparaissait. L'UI affichait un `alert('Invitation envoyée !')` mensonger.

## Root cause

`lib/services/admin.service.ts` → `inviteAdmin()` utilisait :
```ts
db.auth.admin.createUser({ email, password: tempPassword, ... })
db.auth.admin.generateLink({ type: 'recovery', email })
```
`generateLink()` **ne fait que retourner** une URL — il ne l'envoie nulle part.

## Fix

Remplacé par `supabase.auth.admin.inviteUserByEmail()`, qui fait les deux d'un coup :
- Crée le user auth sans mot de passe
- Envoie l'email d'invitation via le template Supabase Auth "Invite user" (configurable dans le dashboard Supabase)
- `redirectTo` pointe vers `/nouveau-mot-de-passe` (page existante déjà gérée pour les tokens de type recovery/invite — extrait `access_token` + `refresh_token` du hash URL, établit la session, laisse l'utilisateur définir son mot de passe)

Les lignes `profils` + `acces_clients` sont toujours créées après l'envoi, avec l'`id` du user retourné par `inviteUserByEmail`.

## Test plan

- [x] Compilation OK (endpoint renvoie 400 Zod sans body, pas de 500)
- [ ] À tester en prod : inviter un admin depuis `/superadmin`, vérifier que l'email arrive dans la boîte du destinataire, qu'il contient le bon lien (skalcook.com/nouveau-mot-de-passe#access_token=…), et que le user peut définir son mot de passe + se connecter
- [ ] Vérifier dans le dashboard Supabase → Authentication → Email Templates → "Invite user" que le template est correctement traduit (FR) et que le `{{ .ConfirmationURL }}` renvoie bien vers l'URL de prod

## Notes

- L'email est envoyé par Supabase Auth SMTP (pas via Resend) — le sender sera `noreply@mail.supabase.io` par défaut. Pour du branding custom, il faudra configurer un SMTP provider custom dans Supabase Auth settings (c'est une config dashboard, pas code).
- Pas de changement UI — le bouton et l'alert restent en place, mais l'alert dit maintenant la vérité.

🤖 Generated with [Claude Code](https://claude.com/claude-code)