### PR TITLE
feat(crm): personalize devis sender name with tenant name

### DIFF
--- a/app/api/crm/devis/[id]/envoyer/route.js
+++ b/app/api/crm/devis/[id]/envoyer/route.js
@@ -20,7 +20,24 @@ const bodySchema = z.object({
   message: z.string().max(5000).optional(),
 })
 
-const FROM = `Skalcook <${process.env.CONTACT_EMAIL || 'contact@skalcook.com'}>`
+const FROM_ADDRESS = process.env.CONTACT_EMAIL || 'contact@skalcook.com'
+const FALLBACK_FROM_NAME = 'Skalcook'
+
+// Construit l'en-tête From : "{Nom établissement} via Skalcook <contact@skalcook.com>"
+// L'adresse reste skalcook.com (domaine verifié chez Resend) mais le nom
+// affiché est celui du traiteur, pour que le client reconnaisse l'expéditeur.
+// Le replyTo pointe vers l'email du tenant, donc les réponses reviennent au
+// bon endroit.
+function buildFromHeader(tenantName) {
+  const base = (tenantName || '').trim()
+  // Caractères qui imposent d'entourer le display-name de guillemets (RFC 5322)
+  const needsQuoting = /[",<>@;:\\\[\]()]/.test(base)
+  const safe = base.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  const displayName = base
+    ? (needsQuoting ? `"${safe} via ${FALLBACK_FROM_NAME}"` : `${base} via ${FALLBACK_FROM_NAME}`)
+    : FALLBACK_FROM_NAME
+  return `${displayName} <${FROM_ADDRESS}>`
+}
 
 export const POST = apiHandler({
   schema: bodySchema,
@@ -101,8 +118,11 @@ export const POST = apiHandler({
       </div>
     `
 
+    // Pour le FROM on préfère null à "Votre traiteur" si aucun nom n'est
+    // renseigné — dans ce cas on retombe sur "Skalcook" tout court.
+    const fromHeader = buildFromHeader(tenant?.nom_etablissement || tenant?.nom || null)
     const { error: emailErr } = await resend.emails.send({
-      from: FROM,
+      from: fromHeader,
       to: data.to,
       replyTo,
       subject: data.subject,


### PR DESCRIPTION
## Summary

Option A du feedback post-dogfood sur l'envoi de devis : les devis partaient avec `Skalcook <contact@skalcook.com>` comme expéditeur, indiscernable d'un mail de la plateforme. Le client pouvait se demander pourquoi "Skalcook" lui envoie un devis plutôt que son traiteur.

## Change

Construit un header `From` dynamique par envoi :

```
"{Nom établissement} via Skalcook <contact@skalcook.com>"
```

Exemple pour l'Hôtel La Fantaisie : `Hôtel La Fantaisie via Skalcook <contact@skalcook.com>` — c'est le **display name** qui change, l'adresse reste sur `skalcook.com` (seul domaine vérifié chez Resend). Le `replyTo` reste sur `tenant.email_contact`, donc les réponses vont toujours au traiteur.

Gère l'escape RFC 5322 (guillemets, virgules, crochets…) pour les noms avec caractères spéciaux, et tombe proprement sur `Skalcook <contact@skalcook.com>` tout court si aucun nom n'est renseigné sur le tenant.

## Pourquoi pas Option B ou C

- **B** (sous-domaine Skalcook par tenant, `{slug}@mail.skalcook.com`) : demande un champ `mail_slug` par tenant + vérification sous-domaine chez Resend. ½ journée, aucune demande client pour l'instant.
- **C** (vrai domaine custom, `lafantaisie@lafantaisie.com`) : nécessite que chaque établissement verifie son domaine via DNS (SPF/DKIM), ajout UI onboarding + appels API Resend Domains + gestion d'états. 1-2 jours + support DNS. Attendre qu'un traiteur le demande explicitement.

## Test plan

- [x] Code compile (dev server tourne sans erreur)
- [x] Logique validée : `buildFromHeader('Hôtel La Fantaisie')` → `Hôtel La Fantaisie via Skalcook <contact@skalcook.com>` ; `buildFromHeader(null)` → `Skalcook <contact@skalcook.com>` ; `buildFromHeader('Café, Bar "Chic"')` → `"Café, Bar \"Chic\" via Skalcook" <contact@skalcook.com>` (RFC 5322 quoted-string)
- [ ] À tester en prod : envoyer un devis depuis `/crm/devis/[id]`, vérifier dans la boîte du destinataire que le sender affiche bien "Hôtel La Fantaisie via Skalcook" (Gmail / Apple Mail / Outlook)
- [ ] Vérifier que Resend accepte le header et ne renvoie pas de 422 (les logs Resend montreront l'en-tête From final)

🤖 Generated with [Claude Code](https://claude.com/claude-code)