### PR TITLE
fix(auth): rattraper les liens invitation / recovery qui atterrissent sur la landing

### DIFF
--- a/app/LandingPage.jsx
+++ b/app/LandingPage.jsx
@@ -4,6 +4,30 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { Logo } from '../lib/theme.jsx'
 import './landing.css'
 
+/* ── Safety net : si Supabase renvoie l'utilisateur sur la landing ──
+ *
+ * Le lien d'invitation / recovery devrait arriver sur /nouveau-mot-de-passe.
+ * Mais si la config Supabase (Site URL / Redirect URLs allow-list)
+ * n'autorise pas cette cible, Supabase rewrite silencieusement vers le
+ * Site URL — souvent la racine. On rattrape ici en détectant les params
+ * d'auth dans le hash ou la query, et on renvoie sur la bonne page en
+ * préservant les tokens. */
+function usePasswordLinkRedirect() {
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const hash = window.location.hash || ''
+    const search = window.location.search || ''
+    const hasHashToken = /(^|[#&])access_token=/.test(hash)
+    const hasHashType = /(^|[#&])type=(recovery|invite|signup|magiclink)/.test(hash)
+    const hasCode = /(^|[?&])code=/.test(search)
+    if (hasHashToken && hasHashType) {
+      window.location.replace(`/nouveau-mot-de-passe${hash}`)
+    } else if (hasCode) {
+      window.location.replace(`/nouveau-mot-de-passe${search}`)
+    }
+  }, [])
+}
+
 /* ── Scroll reveal hook ── */
 function useReveal() {
   const ref = useRef(null)
@@ -208,6 +232,7 @@ function DemoForm() {
  * Landing Page Component
  * ════════════════════════════════════════════════════════════════ */
 export default function LandingPage() {
+  usePasswordLinkRedirect()
   const [menuOpen, setMenuOpen] = useState(false)
 
   const scrollTo = useCallback((id) => {

--- a/app/api/invite-admin/route.ts
+++ b/app/api/invite-admin/route.ts
@@ -6,8 +6,15 @@ export const POST = apiHandler({
   schema: inviteAdminSchema,
   guard: 'adminOrSuperadmin',
   clientIdFrom: 'body.client_id',
-  handler: async ({ data, db }) => {
-    const result = await inviteAdmin(db, data.email, data.nom_complet, data.client_id)
+  handler: async ({ data, db, request }) => {
+    // Pour le redirectTo : priorité NEXT_PUBLIC_SITE_URL (config explicite),
+    // sinon on utilise l'origin de la requête entrante (couvre preview + prod
+    // sans avoir à tenir l'env var à jour partout).
+    const envOrigin = (process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL || '').replace(/\/$/, '')
+    const reqOrigin = new URL(request.url).origin
+    const siteOrigin = envOrigin || reqOrigin
+
+    const result = await inviteAdmin(db, data.email, data.nom_complet, data.client_id, siteOrigin)
     return Response.json(result, { status: 201 })
   },
 })

--- a/app/nouveau-mot-de-passe/page.js
+++ b/app/nouveau-mot-de-passe/page.js
@@ -15,22 +15,49 @@ export default function NouveauMotDePassePage() {
   const router = useRouter()
 
   useEffect(() => {
-    // Récupérer le token depuis l'URL et établir la session
-    const hashParams = new URLSearchParams(window.location.hash.substring(1))
-    const accessToken = hashParams.get('access_token')
-    const refreshToken = hashParams.get('refresh_token')
+    let cancelled = false
+    ;(async () => {
+      // Supabase envoie les tokens soit dans le hash (#access_token=…), soit
+      // dans la query (?code=…) selon le flow configuré côté projet.
+      // On gère les deux + une session déjà établie (au cas où un autre
+      // composant aurait déjà consommé les tokens).
+      const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''))
+      const searchParams = new URLSearchParams(window.location.search)
 
-    if (accessToken && refreshToken) {
-      supabase.auth.setSession({
-        access_token: accessToken,
-        refresh_token: refreshToken
-      }).then(({ error }) => {
-        if (!error) setSessionReady(true)
-        else setError('Lien invalide ou expiré. Demandez un nouveau lien.')
-      })
-    } else {
-      setError('Lien invalide ou expiré. Demandez un nouveau lien.')
-    }
+      const hashError = hashParams.get('error_description') || searchParams.get('error_description')
+      if (hashError) {
+        if (!cancelled) setError(decodeURIComponent(hashError).replace(/\+/g, ' '))
+        return
+      }
+
+      const accessToken = hashParams.get('access_token')
+      const refreshToken = hashParams.get('refresh_token')
+      const code = searchParams.get('code')
+
+      try {
+        if (accessToken && refreshToken) {
+          const { error } = await supabase.auth.setSession({
+            access_token: accessToken,
+            refresh_token: refreshToken,
+          })
+          if (error) throw error
+        } else if (code) {
+          const { error } = await supabase.auth.exchangeCodeForSession(code)
+          if (error) throw error
+        } else {
+          // Pas de token dans l'URL — peut-être session déjà en cours ?
+          const { data } = await supabase.auth.getSession()
+          if (!data.session) {
+            if (!cancelled) setError('Lien invalide ou expiré. Demandez un nouveau lien.')
+            return
+          }
+        }
+        if (!cancelled) setSessionReady(true)
+      } catch (e) {
+        if (!cancelled) setError(e?.message || 'Lien invalide ou expiré. Demandez un nouveau lien.')
+      }
+    })()
+    return () => { cancelled = true }
   }, [])
 
   const handleSubmit = async (e) => {

--- a/lib/services/admin.service.ts
+++ b/lib/services/admin.service.ts
@@ -177,13 +177,16 @@ export async function createGlobalUser(db: SupabaseClient, input: CreateGlobalUs
 
 // ── Invite admin ───────────────────────────────────────────────────────────
 
-export async function inviteAdmin(db: SupabaseClient, email: string, nom: string, clientId: string) {
+export async function inviteAdmin(db: SupabaseClient, email: string, nom: string, clientId: string, siteOrigin?: string) {
   // On utilise inviteUserByEmail : Supabase crée l'utilisateur sans mot de
   // passe et envoie un email d'invitation (template Auth → "Invite user")
   // avec un lien qui ouvre une session authentifiée sur /nouveau-mot-de-passe
   // où l'utilisateur définit son mot de passe.
-  const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL || '').replace(/\/$/, '')
-  const redirectTo = siteUrl ? `${siteUrl}/nouveau-mot-de-passe` : undefined
+  // siteOrigin est passé par la route handler (fallback sur l'origin de la
+  // requête si l'env var n'est pas configurée — voir app/api/invite-admin).
+  const envOrigin = (process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL || '').replace(/\/$/, '')
+  const origin = siteOrigin || envOrigin
+  const redirectTo = origin ? `${origin.replace(/\/$/, '')}/nouveau-mot-de-passe` : undefined
 
   const { data: authData, error: authErr } = await db.auth.admin.inviteUserByEmail(email, {
     redirectTo,


### PR DESCRIPTION
## Problème

Rapporté en dogfood : le lien dans les emails **d'invitation admin** et **de reset mot de passe** faisait atterrir l'utilisateur sur la landing (`/`), sans aucun moyen de définir un mot de passe ni de se connecter.

## Cause racine probable

Config Supabase Auth incomplète. Quand le `Site URL` est `https://skalcook.com` mais que `https://skalcook.com/nouveau-mot-de-passe` **n'est pas dans la liste des Redirect URLs autorisés**, Supabase rewrite silencieusement le `redirectTo` vers le Site URL — souvent la racine — tout en conservant les tokens dans le hash. L'utilisateur voit donc la landing avec `#access_token=…` dans l'URL mais aucun code ne consomme ce hash.

## Fixes côté code

1. **Landing page** ([LandingPage.jsx](app/LandingPage.jsx)) : détecte les params d'auth dans le hash (`#access_token=…&type=recovery|invite|…`) ou en query (`?code=…`) et redirige vers `/nouveau-mot-de-passe` en préservant les tokens. C'est le **safety net** contre une mauvaise config Supabase — ça rattrape le scénario sans attendre que la config soit corrigée.

2. **/nouveau-mot-de-passe** ([page.js](app/nouveau-mot-de-passe/page.js)) : supporte maintenant les deux flows Supabase (hash legacy `#access_token` + PKCE `?code=`) via `exchangeCodeForSession`, et retombe sur la session courante si un autre composant a déjà consommé les tokens. Affiche aussi les `error_description` Supabase lisiblement (ex: "Email link is invalid or has expired").

3. **invite-admin** ([route.ts](app/api/invite-admin/route.ts), [admin.service.ts](lib/services/admin.service.ts)) : récupère l'`origin` de la requête en fallback si `NEXT_PUBLIC_SITE_URL` n'est pas défini (ex: pas encore set sur Vercel). Évite un `redirectTo: undefined` silencieux.

## Action config à faire côté Supabase (non-code)

Dans le dashboard Supabase → **Authentication** → **URL Configuration** :

- **Site URL** : `https://skalcook.com`
- **Redirect URLs** (allow-list) : ajouter
  - `https://skalcook.com/nouveau-mot-de-passe`
  - `https://skalcook.vercel.app/nouveau-mot-de-passe` (ou le domaine Vercel utilisé pour previews, si nécessaire)

Tant que ce n'est pas fait, le safety net (#1) rattrape le scénario.

## Test plan

- [x] Simulé : `https://localhost:3000/#access_token=fake&refresh_token=fake2&type=recovery` → redirige bien sur `/nouveau-mot-de-passe` avec hash préservé
- [x] `/nouveau-mot-de-passe` sans token affiche "Lien invalide ou expiré" avec CTA vers /reset-password
- [ ] À tester en prod après merge :
  - Inviter un admin → clic sur le lien dans l'email → atterrissage sur `/nouveau-mot-de-passe` (via safety net ou direct), définition du mot de passe OK, connexion après
  - Reset mot de passe depuis `/reset-password` → même flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)