### PR TITLE
feat(crm): activity timeline on CRM client page

### DIFF
--- a/app/api/crm/devis/[id]/envoyer/route.js
+++ b/app/api/crm/devis/[id]/envoyer/route.js
@@ -138,7 +138,7 @@ export const POST = apiHandler({
 
     // ─── 6. Enregistrer la révision (snapshot figé) ────────────────────
     const now = new Date().toISOString()
-    const { error: revErr } = await db
+    const { data: revRow, error: revErr } = await db
       .from('crm_devis_revisions')
       .insert({
         devis_id: devisId,
@@ -155,11 +155,33 @@ export const POST = apiHandler({
         pdf_url: path,
         created_by: user?.id || null,
       })
+      .select('id')
+      .single()
     if (revErr) {
       // La révision est l'historique — si l'insert échoue on n'empêche pas
       // la mise à jour du devis (l'email est parti, le PDF est uploadé),
       // mais on le log côté serveur.
       console.error('[devis/envoyer] revision insert failed:', revErr.message)
+    }
+
+    // ─── 6bis. Log activité client (timeline page client) ─────────────
+    if (devis.crm_client_id) {
+      const { error: actErr } = await db
+        .from('crm_client_activities')
+        .insert({
+          client_id: clientId,
+          crm_client_id: devis.crm_client_id,
+          type: 'devis_envoye',
+          titre: `Devis ${devis.numero} envoyé${nextVersion > 1 ? ` (V${nextVersion})` : ''}`,
+          description: `Montant ${Number(devis.total_ttc || 0).toLocaleString('fr-FR', { style: 'currency', currency: 'EUR' })} TTC → ${data.to}`,
+          occurred_at: now,
+          crm_devis_id: devisId,
+          crm_devis_revision_id: revRow?.id || null,
+          created_by: user?.id || null,
+        })
+      if (actErr) {
+        console.error('[devis/envoyer] activity insert failed:', actErr.message)
+      }
     }
 
     // ─── 7. Update devis (statut + tracking = pointeur vers la dernière rev) ─

--- a/app/crm/clients/[id]/page.js
+++ b/app/crm/clients/[id]/page.js
@@ -9,7 +9,8 @@ import Navbar from '../../../../components/Navbar'
 import { Card, Button, Badge, Alert } from '../../../../components/ui'
 import ClientForm from '../../../../components/crm/ClientForm'
 import {
-  STATUTS_MAP, formatDateFr, formatMontant, clientDisplayName, hexToRgba,
+  STATUTS_MAP, ACTIVITY_TYPES_MAP, ACTIVITY_TYPES_MANUELS,
+  formatDateFr, formatDateTimeFr, formatMontant, clientDisplayName, hexToRgba,
 } from '../../../../lib/crmConstants'
 
 export default function CrmClientDetailPage() {
@@ -23,10 +24,14 @@ export default function CrmClientDetailPage() {
   const [clientId, setClientId] = useState(null)
   const [client, setClient] = useState(null)
   const [evenements, setEvenements] = useState([])
+  const [activities, setActivities] = useState([])
+  const [currentUserId, setCurrentUserId] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [mode, setMode] = useState('view') // view | edit
   const [confirmDelete, setConfirmDelete] = useState(false)
+  const [showActivityForm, setShowActivityForm] = useState(false)
+  const [activitySaving, setActivitySaving] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -53,17 +58,29 @@ export default function CrmClientDetailPage() {
     if (!cid) { setLoading(false); return }
     setClientId(cid)
 
-    const [{ data: cli, error: cErr }, { data: evts, error: eErr }] = await Promise.all([
+    const { data: { user } } = await supabase.auth.getUser()
+    setCurrentUserId(user?.id || null)
+
+    const [
+      { data: cli, error: cErr },
+      { data: evts, error: eErr },
+      { data: acts, error: aErr },
+    ] = await Promise.all([
       supabase.from('crm_clients').select('*').eq('id', id).eq('client_id', cid).maybeSingle(),
       supabase.from('crm_evenements')
         .select('id, titre, date_evenement, statut, type_prestation, nb_convives, montant_devis, montant_final, budget_estime, created_at')
         .eq('crm_client_id', id).eq('client_id', cid)
         .order('date_evenement', { ascending: false, nullsFirst: false }),
+      supabase.from('crm_client_activities')
+        .select('id, type, titre, description, occurred_at, crm_devis_id, crm_evenement_id, created_by, created_at')
+        .eq('crm_client_id', id)
+        .order('occurred_at', { ascending: false }),
     ])
 
-    if (cErr || eErr) { setError((cErr || eErr).message); setLoading(false); return }
+    if (cErr || eErr || aErr) { setError((cErr || eErr || aErr).message); setLoading(false); return }
     setClient(cli)
     setEvenements(evts || [])
+    setActivities(acts || [])
     setLoading(false)
   }, [id])
 
@@ -91,6 +108,35 @@ export default function CrmClientDetailPage() {
       .eq('client_id', clientId)
     if (err) { setError(err.message); return }
     router.push('/crm/clients')
+  }
+
+  async function handleAddActivity(values) {
+    setActivitySaving(true)
+    setError('')
+    const { error: err } = await supabase
+      .from('crm_client_activities')
+      .insert({
+        client_id: clientId,
+        crm_client_id: id,
+        type: values.type,
+        titre: values.titre.trim() || null,
+        description: values.description.trim() || null,
+        occurred_at: values.occurred_at ? new Date(values.occurred_at).toISOString() : new Date().toISOString(),
+        created_by: currentUserId,
+      })
+    setActivitySaving(false)
+    if (err) { setError(err.message); return }
+    setShowActivityForm(false)
+    await load()
+  }
+
+  async function handleDeleteActivity(activityId) {
+    const { error: err } = await supabase
+      .from('crm_client_activities')
+      .delete()
+      .eq('id', activityId)
+    if (err) { setError(err.message); return }
+    await load()
   }
 
   if (!authReady || roleLoading) {
@@ -189,6 +235,55 @@ export default function CrmClientDetailPage() {
               )}
             </Card>
 
+            {/* Historique des activités */}
+            <div className="crm-section">
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 8, marginBottom: 10 }}>
+                <h2 className="crm-section__title" style={{ color: c.texte, margin: 0 }}>
+                  Historique {activities.length > 0 && <span style={{ color: c.texteMuted, fontWeight: 400 }}>· {activities.length}</span>}
+                </h2>
+                {!showActivityForm && (
+                  <Button c={c} variant="ghost" size="sm" onClick={() => setShowActivityForm(true)}>
+                    + Ajouter une activité
+                  </Button>
+                )}
+              </div>
+
+              {showActivityForm && (
+                <ActivityForm
+                  c={c}
+                  saving={activitySaving}
+                  onSubmit={handleAddActivity}
+                  onCancel={() => setShowActivityForm(false)}
+                />
+              )}
+
+              {activities.length === 0 && !showActivityForm ? (
+                <div className="crm-empty" style={{ borderColor: c.bordure, background: c.blanc }}>
+                  <div className="crm-empty__title" style={{ color: c.texte }}>Aucune activité</div>
+                  <div className="crm-empty__text" style={{ color: c.texteMuted }}>
+                    Loguez vos appels, relances, rendez-vous — les envois de devis apparaissent automatiquement.
+                  </div>
+                  <Button c={c} onClick={() => setShowActivityForm(true)}>+ Ajouter une activité</Button>
+                </div>
+              ) : activities.length > 0 && (
+                <div className="crm-list">
+                  {activities.map((a) => (
+                    <ActivityRow
+                      key={a.id}
+                      c={c}
+                      activity={a}
+                      canDelete={a.created_by && a.created_by === currentUserId}
+                      onOpen={(act) => {
+                        if (act.crm_devis_id) router.push(`/crm/devis/${act.crm_devis_id}`)
+                        else if (act.crm_evenement_id) router.push(`/crm/evenements/${act.crm_evenement_id}`)
+                      }}
+                      onDelete={() => handleDeleteActivity(a.id)}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+
             {/* Événements du client */}
             <div className="crm-section">
               <h2 className="crm-section__title" style={{ color: c.texte }}>
@@ -258,5 +353,127 @@ function Kv({ c, label, value }) {
       <div className="crm-kv__key" style={{ color: c.texteMuted }}>{label}</div>
       <div className="crm-kv__value" style={{ color: c.texte }}>{value || '—'}</div>
     </div>
+  )
+}
+
+function ActivityRow({ c, activity, canDelete, onOpen, onDelete }) {
+  const meta = ACTIVITY_TYPES_MAP[activity.type] || { label: activity.type, couleur: c.texteMuted, icon: '•' }
+  const clickable = !!(activity.crm_devis_id || activity.crm_evenement_id)
+  const handleClick = clickable ? () => onOpen(activity) : undefined
+
+  return (
+    <div
+      className="crm-row"
+      style={{ background: c.blanc, borderColor: c.bordure, color: c.texte, cursor: clickable ? 'pointer' : 'default', alignItems: 'flex-start' }}
+      onClick={handleClick}
+      role={clickable ? 'button' : undefined}
+      tabIndex={clickable ? 0 : undefined}
+      onKeyDown={clickable ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleClick() } } : undefined}
+    >
+      <div style={{ display: 'flex', gap: 10, flex: 1, minWidth: 0 }}>
+        <div style={{
+          width: 32, height: 32, borderRadius: 8, flexShrink: 0,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          background: hexToRgba(meta.couleur, 0.12), fontSize: 16,
+        }}>
+          {meta.icon}
+        </div>
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div className="crm-row__primary" style={{ color: c.texte, display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+            <span>{activity.titre || meta.label}</span>
+            <Badge bg={hexToRgba(meta.couleur, 0.12)} color={meta.couleur} size="sm">
+              {meta.label}
+            </Badge>
+          </div>
+          {activity.description && (
+            <div className="crm-row__secondary" style={{ color: c.texteMuted, whiteSpace: 'pre-wrap' }}>
+              {activity.description}
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="crm-row__meta" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ color: c.texteMuted, fontSize: 12, whiteSpace: 'nowrap' }}>
+          {formatDateTimeFr(activity.occurred_at)}
+        </span>
+        {canDelete && (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); onDelete() }}
+            title="Supprimer cette activité"
+            style={{ background: 'transparent', border: 'none', color: c.texteMuted, cursor: 'pointer', padding: 4, fontSize: 16, lineHeight: 1 }}
+          >
+            ×
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ActivityForm({ c, saving, onSubmit, onCancel }) {
+  const now = new Date()
+  const pad = (n) => String(n).padStart(2, '0')
+  const localInput = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}`
+
+  const [type, setType] = useState(ACTIVITY_TYPES_MANUELS[0]?.key || 'note')
+  const [titre, setTitre] = useState('')
+  const [description, setDescription] = useState('')
+  const [occurredAt, setOccurredAt] = useState(localInput)
+
+  const inputStyle = { background: c.blanc, borderColor: c.bordure, color: c.texte }
+  const labelStyle = { color: c.texte }
+
+  function submit(e) {
+    e.preventDefault()
+    onSubmit({ type, titre, description, occurred_at: occurredAt })
+  }
+
+  return (
+    <Card c={c} padding="md" style={{ marginBottom: 12 }}>
+      <form onSubmit={submit} className="crm-form" style={{ gap: 12 }}>
+        <div className="crm-form__grid crm-form__grid--2">
+          <div className="crm-field">
+            <label className="crm-field__label" style={labelStyle}>Type</label>
+            <select className="crm-field__select" style={inputStyle} value={type} onChange={(e) => setType(e.target.value)}>
+              {ACTIVITY_TYPES_MANUELS.map((t) => (
+                <option key={t.key} value={t.key}>{t.icon} {t.label}</option>
+              ))}
+            </select>
+          </div>
+          <div className="crm-field">
+            <label className="crm-field__label" style={labelStyle}>Date & heure</label>
+            <input
+              type="datetime-local"
+              className="crm-field__input" style={inputStyle}
+              value={occurredAt}
+              onChange={(e) => setOccurredAt(e.target.value)}
+            />
+          </div>
+        </div>
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>Titre (optionnel)</label>
+          <input
+            type="text" className="crm-field__input" style={inputStyle}
+            value={titre} onChange={(e) => setTitre(e.target.value)}
+            placeholder="Rappelé pour confirmer menu"
+          />
+        </div>
+        <div className="crm-field">
+          <label className="crm-field__label" style={labelStyle}>Description</label>
+          <textarea
+            className="crm-field__textarea" style={inputStyle}
+            value={description} onChange={(e) => setDescription(e.target.value)}
+            placeholder="Points discutés, engagements pris…"
+          />
+        </div>
+        <div className="crm-actions">
+          <Button c={c} variant="ghost" type="button" onClick={onCancel} disabled={saving}>Annuler</Button>
+          <Button c={c} type="submit" disabled={saving}>
+            {saving ? 'Enregistrement…' : 'Enregistrer'}
+          </Button>
+        </div>
+      </form>
+    </Card>
   )
 }

--- a/lib/crmConstants.js
+++ b/lib/crmConstants.js
@@ -108,6 +108,38 @@ export const CONDITIONS_PAIEMENT = [
   'Paiement à 30 jours fin de mois',
 ]
 
+// ─── Activités / timeline client ─────────────────────────────────────────
+// Types triés en 2 groupes : manuels (l'utilisateur les saisit depuis la page
+// client) et système (auto-insérés par les routes API). Ordre = ordre
+// d'affichage dans le select "Ajouter une activité".
+export const ACTIVITY_TYPES = [
+  // ─ Manuels ─
+  { key: 'appel',         label: 'Appel',           couleur: '#0EA5E9', icon: '📞', manual: true },
+  { key: 'email',         label: 'Email',           couleur: '#8B5CF6', icon: '✉️', manual: true },
+  { key: 'relance',       label: 'Relance',         couleur: '#F59E0B', icon: '🔔', manual: true },
+  { key: 'rendez_vous',   label: 'Rendez-vous',     couleur: '#EC4899', icon: '📅', manual: true },
+  { key: 'note',          label: 'Note',            couleur: '#6B7280', icon: '📝', manual: true },
+  // ─ Système ─
+  { key: 'devis_envoye',  label: 'Devis envoyé',    couleur: '#10B981', icon: '📨', manual: false },
+  { key: 'devis_modifie', label: 'Devis modifié',   couleur: '#14B8A6', icon: '✏️', manual: false },
+  { key: 'evenement_cree',label: 'Événement créé',  couleur: '#6366F1', icon: '🎉', manual: false },
+]
+
+export const ACTIVITY_TYPES_MAP = Object.fromEntries(ACTIVITY_TYPES.map((t) => [t.key, t]))
+export const ACTIVITY_TYPES_MANUELS = ACTIVITY_TYPES.filter((t) => t.manual)
+
+export function formatDateTimeFr(d) {
+  if (!d) return '—'
+  try {
+    return new Date(d).toLocaleString('fr-FR', {
+      day: '2-digit', month: 'short', year: 'numeric',
+      hour: '2-digit', minute: '2-digit',
+    })
+  } catch {
+    return '—'
+  }
+}
+
 // Formate un numéro de devis : DEV-2026-042
 export function formatDevisNumero(prefix, annee, sequence) {
   if (!prefix || !annee || !sequence) return '—'

--- a/supabase/migrations/20260419000000_crm_client_activities.sql
+++ b/supabase/migrations/20260419000000_crm_client_activities.sql
@@ -1,0 +1,63 @@
+-- ============================================================================
+-- CRM — crm_client_activities : timeline d'activités par client CRM.
+--
+-- Deux sources d'alimentation :
+--   - Système : auto-insert depuis /api/crm/devis/[id]/envoyer (type
+--     'devis_envoye'), lié via crm_devis_id / crm_devis_revision_id.
+--   - Manuel : bouton "+ Ajouter une activité" sur la page client, pour
+--     loguer un appel, une relance, une note, un rendez-vous, etc.
+--
+-- occurred_at est distinct de created_at : permet de loguer un événement
+-- passé (ex. "appel du 10 avril" saisi le 15).
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.crm_client_activities (
+  id                     uuid        DEFAULT gen_random_uuid() PRIMARY KEY,
+  client_id              uuid        NOT NULL,
+  crm_client_id          uuid        NOT NULL REFERENCES public.crm_clients(id) ON DELETE CASCADE,
+
+  type                   text        NOT NULL
+                                     CHECK (type IN (
+                                       'appel', 'email', 'relance', 'note',
+                                       'rendez_vous',
+                                       'devis_envoye', 'devis_modifie',
+                                       'evenement_cree'
+                                     )),
+
+  titre                  text,
+  description            text,
+  occurred_at            timestamptz NOT NULL DEFAULT now(),
+
+  -- Soft-links vers les entités liées (pour les entrées système)
+  crm_evenement_id       uuid        REFERENCES public.crm_evenements(id)      ON DELETE SET NULL,
+  crm_devis_id           uuid        REFERENCES public.crm_devis(id)           ON DELETE SET NULL,
+  crm_devis_revision_id  uuid        REFERENCES public.crm_devis_revisions(id) ON DELETE SET NULL,
+
+  created_by             uuid,
+  created_at             timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS crm_client_activities_crm_client_idx
+  ON public.crm_client_activities (crm_client_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS crm_client_activities_client_idx
+  ON public.crm_client_activities (client_id, occurred_at DESC);
+
+-- ─── RLS ───────────────────────────────────────────────────────────────
+ALTER TABLE public.crm_client_activities ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY crm_client_activities_select ON public.crm_client_activities
+  FOR SELECT TO authenticated
+  USING (public.user_has_client_access(client_id));
+
+CREATE POLICY crm_client_activities_insert ON public.crm_client_activities
+  FOR INSERT TO authenticated
+  WITH CHECK (public.user_has_client_access(client_id));
+
+CREATE POLICY crm_client_activities_update ON public.crm_client_activities
+  FOR UPDATE TO authenticated
+  USING (public.user_has_client_access(client_id) AND created_by = auth.uid())
+  WITH CHECK (public.user_has_client_access(client_id));
+
+CREATE POLICY crm_client_activities_delete ON public.crm_client_activities
+  FOR DELETE TO authenticated
+  USING (public.user_has_client_access(client_id) AND created_by = auth.uid());


### PR DESCRIPTION
## Summary

Retour post-dogfood : depuis la page d'un client CRM il faut voir tout ce qui s'est passé avec lui — **devis envoyés, appels, relances, rendez-vous, notes, etc.** — pour avoir le fil complet de la relation en un coup d'œil.

## Schéma

Nouvelle table **`crm_client_activities`** avec :
- `type` contraint sur 8 valeurs, 2 groupes :
  - **Manuels** : `appel`, `email`, `relance`, `note`, `rendez_vous`
  - **Système** : `devis_envoye`, `devis_modifie`, `evenement_cree`
- `occurred_at` distinct de `created_at` : permet de loguer un appel passé à reculons ("appel du 10 avril" saisi le 15)
- Soft-links nullable vers `crm_devis` / `crm_devis_revisions` / `crm_evenements` pour les entrées système (ON DELETE SET NULL — l'historique survit à la suppression du devis/événement)
- **RLS** : SELECT/INSERT ouverts aux membres du tenant, UPDATE/DELETE restreints à `created_by = auth.uid()` — empêche un collègue de modifier ou supprimer les notes d'un autre

## Auto-insert côté API

- `POST /api/crm/devis/[id]/envoyer` crée une entrée `devis_envoye` à chaque envoi, liée à la révision créée (`crm_devis_revision_id`). Titre inclut `V{N}` si > 1, description avec le montant TTC + destinataire.
- Insert best-effort : si ça plante (ex: RLS config mauvaise), on log côté serveur mais on ne bloque pas la réponse — l'email est parti, le PDF est sauvé, c'est le plus important.

## UI `/crm/clients/[id]`

- Nouvelle section **"Historique"** placée **avant** les événements (c'est la première chose qu'un traiteur veut voir en ouvrant une fiche client : c'était quand, la dernière interaction ?)
- Tri `occurred_at` desc, icône (emoji) + badge couleur par type
- Cliquable vers le devis / événement lié quand applicable
- Bouton **+ Ajouter une activité** : form inline avec type (select parmi les manuels), date/heure (préremplie), titre optionnel, description
- Entrées manuelles supprimables par leur créateur uniquement (× visible si `created_by === currentUserId`) ; les entrées système restent immuables depuis l'UI

## Test plan

- [x] Migration appliquée via MCP sur le projet Supabase live
- [x] Compilation OK (pas d'erreur dev server, imports résolus)
- [ ] À tester en prod après merge :
  - Sur la page d'un client avec un devis déjà envoyé : rien n'apparaît (l'activité `devis_envoye` existante n'a pas été backfillée ; les prochains envois en créeront)
  - Renvoyer un devis → vérifier qu'une nouvelle entrée "Devis DEV-XXX envoyé (V2)" apparaît dans l'historique
  - Ajouter une activité manuelle (appel, note…) → vérifier affichage + suppression
  - Un autre utilisateur du même tenant ne peut pas supprimer les activités d'un collègue (UPDATE/DELETE RLS)

## Follow-ups (non inclus MVP)

- Backfill des entrées `devis_envoye` à partir de `crm_devis_revisions` existantes (si tu veux voir ton envoi manuel d'hier dans la timeline)
- Auto-insert `evenement_cree` quand on crée un événement depuis un devis
- Édition inline d'une activité (pour corriger un typo) — pour l'instant faut delete + re-add
- Export PDF de l'historique (utile pour justifier auprès du client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)