### PR TITLE
fix(auth): expired links + pre-existing users on invite

### DIFF
--- a/app/LandingPage.jsx
+++ b/app/LandingPage.jsx
@@ -20,9 +20,18 @@ function usePasswordLinkRedirect() {
     const hasHashToken = /(^|[#&])access_token=/.test(hash)
     const hasHashType = /(^|[#&])type=(recovery|invite|signup|magiclink)/.test(hash)
     const hasCode = /(^|[?&])code=/.test(search)
+    // Supabase renvoie aussi les erreurs (otp_expired, access_denied…) dans
+    // le hash. On redirige pareil pour afficher un message propre au lieu
+    // de laisser l'utilisateur bloqué sur la landing.
+    const hasHashError = /(^|[#&])error(_code|_description)?=/.test(hash)
+    const hasQueryError = /(^|[?&])error(_code|_description)?=/.test(search)
     if (hasHashToken && hasHashType) {
       window.location.replace(`/nouveau-mot-de-passe${hash}`)
     } else if (hasCode) {
+      window.location.replace(`/nouveau-mot-de-passe${search}`)
+    } else if (hasHashError) {
+      window.location.replace(`/nouveau-mot-de-passe${hash}`)
+    } else if (hasQueryError) {
       window.location.replace(`/nouveau-mot-de-passe${search}`)
     }
   }, [])

--- a/app/nouveau-mot-de-passe/page.js
+++ b/app/nouveau-mot-de-passe/page.js
@@ -24,9 +24,21 @@ export default function NouveauMotDePassePage() {
       const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''))
       const searchParams = new URLSearchParams(window.location.search)
 
-      const hashError = hashParams.get('error_description') || searchParams.get('error_description')
-      if (hashError) {
-        if (!cancelled) setError(decodeURIComponent(hashError).replace(/\+/g, ' '))
+      const rawErr = hashParams.get('error_description') || searchParams.get('error_description')
+        || hashParams.get('error') || searchParams.get('error')
+      if (rawErr) {
+        const decoded = decodeURIComponent(rawErr).replace(/\+/g, ' ').toLowerCase()
+        // Traduction des erreurs Supabase courantes pour déclencher le CTA
+        // "Demander un nouveau lien" (le composant le cherche via le mot "expiré")
+        let msg = 'Lien invalide ou expiré. Demandez un nouveau lien.'
+        if (decoded.includes('expired') || decoded.includes('expir')) {
+          msg = 'Lien invalide ou expiré. Demandez un nouveau lien.'
+        } else if (decoded.includes('access_denied') || decoded.includes('access denied')) {
+          msg = 'Accès refusé. Ce lien n\'est plus valide, demandez-en un nouveau.'
+        } else {
+          msg = decodeURIComponent(rawErr).replace(/\+/g, ' ')
+        }
+        if (!cancelled) setError(msg)
         return
       }
 
@@ -111,7 +123,7 @@ export default function NouveauMotDePassePage() {
               {error && (
                 <Alert variant="error" style={{ marginBottom: '16px' }}>
                   {error}
-                  {error.includes('expiré') && (
+                  {(/(expir|refus|invalid|nouveau)/i.test(error)) && (
                     <div style={{ marginTop: '8px' }}>
                       <span onClick={() => router.push('/reset-password')} style={{ color: '#A32D2D', cursor: 'pointer', fontWeight: '600', textDecoration: 'underline' }}>
                         Demander un nouveau lien →

--- a/lib/services/admin.service.ts
+++ b/lib/services/admin.service.ts
@@ -192,22 +192,31 @@ export async function inviteAdmin(db: SupabaseClient, email: string, nom: string
     redirectTo,
     data: { nom, client_id: clientId },
   })
-  if (authErr) throw new Error(authErr.message)
+  if (authErr) {
+    const msg = authErr.message || ''
+    if (/already|exist|registered/i.test(msg)) {
+      throw new ConflictError('Un compte existe déjà avec cet email. Demandez à l\'utilisateur de se connecter, ou utilisez une autre adresse.')
+    }
+    throw new Error(msg)
+  }
   const userId = authData.user.id
 
+  // On upsert les lignes profils + acces_clients pour être tolérant à un
+  // re-invite partiel (ex: auth user créé mais rows applicatives manquantes
+  // suite à un crash précédent).
   await Promise.all([
-    db.from('profils').insert({
+    db.from('profils').upsert({
       id: userId,
       email,
       nom,
       role: 'admin',
       client_id: clientId,
-    }),
-    db.from('acces_clients').insert({
+    }, { onConflict: 'id' }),
+    db.from('acces_clients').upsert({
       user_id: userId,
       client_id: clientId,
       role: 'admin',
-    }),
+    }, { onConflict: 'user_id,client_id' }),
   ])
 
   return {


### PR DESCRIPTION
## Bugs rapportés en prod

**#1 Reset password → landing silencieuse.** Le lien du mail d'hier était expiré (TTL Supabase = 1h). Le retour contenait `#error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired`. Mon safety net précédent ne regardait que `access_token` et `code` → il laissait passer les `error=` → landing vide sans feedback.

**#2 Invite admin → 500 "Erreur serveur interne".** `antony@skalcook.com` existe déjà en base (Antony teste en s'invitant lui-même). `supabase.auth.admin.inviteUserByEmail()` refuse de créer un user dupliqué, l'erreur remonte en 500 générique côté API, la modale ne se ferme pas et l'utilisateur n'a aucun message.

## Fixes

### Landing safety net ([LandingPage.jsx](app/LandingPage.jsx))
Détection élargie : hashes et query strings contenant `error=`, `error_code=`, ou `error_description=` → redirect sur `/nouveau-mot-de-passe` avec le hash/search préservés.

### /nouveau-mot-de-passe ([page.js](app/nouveau-mot-de-passe/page.js))
- Lit aussi `error=` (pas que `error_description=`)
- Traduit les erreurs Supabase courantes en FR (`expired` → "Lien invalide ou expiré. Demandez un nouveau lien." / `access_denied` → "Accès refusé. Ce lien n'est plus valide...")
- CTA "Demander un nouveau lien" déclenché par regex élargie (`expir|refus|invalid|nouveau`), plus seulement le mot `expiré`

### Invite-admin ([admin.service.ts](lib/services/admin.service.ts))
- Attrape les erreurs Supabase `already|exist|registered` → renvoie **409 ConflictError** avec message clair : _"Un compte existe déjà avec cet email. Demandez à l'utilisateur de se connecter, ou utilisez une autre adresse."_
- L'UI `/superadmin` affiche déjà `data.error` dans l'alert → pas de changement UI nécessaire
- Bonus : `profils` + `acces_clients` passent en **upsert** (`onConflict: id` et `user_id,client_id`) pour être tolérants au cas d'un user existant mais sans lignes applicatives (ancien flow partiel)

## Test plan

- [x] Preview : `/#error=access_denied&error_code=otp_expired&error_description=...` → redirige bien vers `/nouveau-mot-de-passe`, affiche "Lien invalide ou expiré. Demandez un nouveau lien." + CTA "Demander un nouveau lien →"
- [x] Preview : `/#error=access_denied&error_code=otp_expired` (sans description) → même comportement
- [ ] À tester en prod après merge :
  - Relancer un `/reset-password` frais avec ton email perso → vérifier que tu atterris bien sur `/nouveau-mot-de-passe` et que tu peux définir le mot de passe
  - Tenter d'inviter `antony@skalcook.com` depuis `/superadmin` → devrait maintenant afficher "Un compte existe déjà avec cet email..." et la modale ne doit plus rester bloquée (l'alert est explicite, puis modal reste ouverte pour que tu corriges l'email)
  - Inviter un nouvel email valide → flow nominal

🤖 Generated with [Claude Code](https://claude.com/claude-code)