### PR TITLE
feat(dashboard): personnalisation du tableau de bord cuisine par user

### DIFF
--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -20,6 +20,7 @@ import SectionFichesAlerte from '../../components/dashboard/widgets/SectionFiche
 import SectionFichesParEspace from '../../components/dashboard/widgets/SectionFichesParEspace'
 import SectionPrixModifies from '../../components/dashboard/widgets/SectionPrixModifies'
 import SectionAllergenes from '../../components/dashboard/widgets/SectionAllergenes'
+import DashboardCustomizeModal from '../../components/dashboard/DashboardCustomizeModal'
 
 export default function DashboardPage() {
   const [fiches, setFiches] = useState([])
@@ -28,6 +29,7 @@ export default function DashboardPage() {
   const [params, setParams] = useState({})
   const [lieux, setLieux] = useState([])
   const [layout, setLayout] = useState(null)
+  const [showCustomize, setShowCustomize] = useState(false)
   const [loading, setLoading] = useState(true)
   const router = useRouter()
   const isMobile = useIsMobile()
@@ -158,19 +160,32 @@ export default function DashboardPage() {
           <div style={{ fontSize: '11px', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', fontWeight: '500' }}>
             Tableau de bord Cuisine — {params['nom_etablissement'] || 'La Fantaisie'}
           </div>
-          {nom && (
-            <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-              <span style={{ fontSize: '12px', color: c.texteMuted }}>
-                Bonjour, <strong style={{ color: c.texte }}>{nom}</strong>
-              </span>
-              <Badge
-                bg={role === 'admin' ? '#F0E8E0' : role === 'cuisine' ? '#EAF3DE' : '#FAEEDA'}
-                color={role === 'admin' ? '#2C1810' : role === 'cuisine' ? '#3B6D11' : '#854F0B'}
-              >
-                {role === 'admin' ? 'Administrateur' : role === 'cuisine' ? 'Cuisine' : 'Directeur'}
-              </Badge>
-            </div>
-          )}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            {nom && (
+              <>
+                <span style={{ fontSize: '12px', color: c.texteMuted }}>
+                  Bonjour, <strong style={{ color: c.texte }}>{nom}</strong>
+                </span>
+                <Badge
+                  bg={role === 'admin' ? '#F0E8E0' : role === 'cuisine' ? '#EAF3DE' : '#FAEEDA'}
+                  color={role === 'admin' ? '#2C1810' : role === 'cuisine' ? '#3B6D11' : '#854F0B'}
+                >
+                  {role === 'admin' ? 'Administrateur' : role === 'cuisine' ? 'Cuisine' : 'Directeur'}
+                </Badge>
+              </>
+            )}
+            <button
+              onClick={() => setShowCustomize(true)}
+              title="Personnaliser mon tableau de bord"
+              style={{
+                background: 'transparent', border: `0.5px solid ${c.bordure}`, color: c.texteMuted,
+                borderRadius: '8px', padding: '4px 10px', fontSize: '12px',
+                cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: '6px',
+              }}
+            >
+              ⚙{isMobile ? '' : ' Personnaliser'}
+            </button>
+          </div>
         </div>
 
         {kpiLayout.length > 0 && (
@@ -180,6 +195,18 @@ export default function DashboardPage() {
           }}>
             {kpiLayout.map((l) => <div key={l.id}>{renderWidget(l.id)}</div>)}
           </div>
+        )}
+
+        {showCustomize && (
+          <DashboardCustomizeModal
+            c={c}
+            initialLayout={layout}
+            onClose={() => setShowCustomize(false)}
+            onSaved={(next) => {
+              setLayout(next)
+              setShowCustomize(false)
+            }}
+          />
         )}
 
         {sectionRows.map((row, idx) => (

--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -20,6 +20,9 @@ import SectionFichesAlerte from '../../components/dashboard/widgets/SectionFiche
 import SectionFichesParEspace from '../../components/dashboard/widgets/SectionFichesParEspace'
 import SectionPrixModifies from '../../components/dashboard/widgets/SectionPrixModifies'
 import SectionAllergenes from '../../components/dashboard/widgets/SectionAllergenes'
+import KpiCaMtd from '../../components/dashboard/widgets/KpiCaMtd'
+import KpiMargeMtd from '../../components/dashboard/widgets/KpiMargeMtd'
+import SectionCrmEvenements from '../../components/dashboard/widgets/SectionCrmEvenements'
 import DashboardCustomizeModal from '../../components/dashboard/DashboardCustomizeModal'
 
 export default function DashboardPage() {
@@ -119,8 +122,12 @@ export default function DashboardPage() {
         return <SectionPrixModifies c={c} ingredientsPrixHausse={ingredientsPrixHausse} />
       case 'section-allergenes':
         return <SectionAllergenes c={c} fiches={fiches} lieux={lieux} params={params} />
-      // Widgets déclarés dans le catalog mais pas encore implémentés (étape 4) :
-      // kpi-ca-mtd, kpi-marge-mtd, section-crm-evenements
+      case 'kpi-ca-mtd':
+        return <KpiCaMtd c={c} isMobile={isMobile} />
+      case 'kpi-marge-mtd':
+        return <KpiMargeMtd c={c} isMobile={isMobile} />
+      case 'section-crm-evenements':
+        return <SectionCrmEvenements c={c} />
       default:
         return null
     }

--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -6,26 +6,29 @@ import { theme } from '../../lib/theme.jsx'
 import { useIsMobile } from '../../lib/useIsMobile'
 import { useTheme } from '../../lib/useTheme'
 import { useRole } from '../../lib/useRole'
-import { ALLERGENES } from '../../lib/allergenes'
 import { calculerFoodCost, foodCostColor, getSeuilsFromParams } from '../../lib/foodCost'
+import { getDashboardLayout, WIDGET_BY_ID } from '../../lib/dashboardPreferences'
 import Navbar from '../../components/Navbar'
 import InventaireBanner from '../../components/InventaireBanner'
-import * as XLSX from 'xlsx'
 import ChefLoader from '../../components/ChefLoader'
 import { Badge } from '../../components/ui'
+import KpiFoodCostMoyen from '../../components/dashboard/widgets/KpiFoodCostMoyen'
+import KpiFichesActives from '../../components/dashboard/widgets/KpiFichesActives'
+import KpiFichesAlerte from '../../components/dashboard/widgets/KpiFichesAlerte'
+import KpiPrixModifies from '../../components/dashboard/widgets/KpiPrixModifies'
+import SectionFichesAlerte from '../../components/dashboard/widgets/SectionFichesAlerte'
+import SectionFichesParEspace from '../../components/dashboard/widgets/SectionFichesParEspace'
+import SectionPrixModifies from '../../components/dashboard/widgets/SectionPrixModifies'
+import SectionAllergenes from '../../components/dashboard/widgets/SectionAllergenes'
 
 export default function DashboardPage() {
   const [fiches, setFiches] = useState([])
   const [menus, setMenus] = useState([])
   const [ingredientsPrixHausse, setIngredientsPrixHausse] = useState([])
   const [params, setParams] = useState({})
-  const [loading, setLoading] = useState(true)
-  const [filtreCategorie, setFiltreCategorie] = useState('toutes')
-  const [filtreSaison, setFiltreSaison] = useState('toutes')
-  const [filtreLieu, setFiltreLieu] = useState('tous')
   const [lieux, setLieux] = useState([])
-  const [isPrixExpanded, setIsPrixExpanded] = useState(false)
-  const [isAllergenesExpanded, setIsAllergenesExpanded] = useState(true)
+  const [layout, setLayout] = useState(null)
+  const [loading, setLoading] = useState(true)
   const router = useRouter()
   const isMobile = useIsMobile()
   const { c } = useTheme()
@@ -52,378 +55,146 @@ export default function DashboardPage() {
     if (!clientId) { setLoading(false); return }
     const p = await getParametres()
     setParams(p)
-    const { data: fichesData } = await supabase
-      .from('fiches').select('*').eq('client_id', clientId).neq('categorie', 'Sous-fiche').eq('archive', false)
-    const { data: lieuxData } = await supabase
-      .from('lieux').select('id, nom, emoji').eq('client_id', clientId).eq('section', 'cuisine').order('ordre')
-    const { data: menusData } = await supabase
-      .from('menus').select('*').eq('client_id', clientId).eq('archive', false)
-    const { data: prixData } = await supabase
-      .from('ingredients').select('*').eq('client_id', clientId)
-      .not('prix_precedent', 'is', null)
-      .order('prix_updated_at', { ascending: false })
-      .limit(20)
+    const [{ data: fichesData }, { data: lieuxData }, { data: menusData }, { data: prixData }, layoutData] = await Promise.all([
+      supabase.from('fiches').select('*').eq('client_id', clientId).neq('categorie', 'Sous-fiche').eq('archive', false),
+      supabase.from('lieux').select('id, nom, emoji').eq('client_id', clientId).eq('section', 'cuisine').order('ordre'),
+      supabase.from('menus').select('*').eq('client_id', clientId).eq('archive', false),
+      supabase.from('ingredients').select('*').eq('client_id', clientId)
+        .not('prix_precedent', 'is', null)
+        .order('prix_updated_at', { ascending: false })
+        .limit(20),
+      getDashboardLayout(),
+    ])
     setFiches(fichesData || [])
     setLieux(lieuxData || [])
     setMenus(menusData || [])
     setIngredientsPrixHausse(prixData || [])
+    setLayout(layoutData)
     setLoading(false)
   }
 
   const { seuilVert, seuilOrange, tva } = getSeuilsFromParams(params, 'cuisine')
   const foodCostFiche = (fiche) => calculerFoodCost(fiche.cout_portion, fiche.prix_ttc, tva)
 
-  const fichesAvecFC = fiches.filter(f => f.cout_portion && f.prix_ttc)
+  const fichesAvecFC = fiches.filter((f) => f.cout_portion && f.prix_ttc)
   const foodCostMoyen = fichesAvecFC.length > 0
     ? fichesAvecFC.reduce((sum, f) => sum + foodCostFiche(f), 0) / fichesAvecFC.length
     : null
 
   const fichesAlerte = fiches
-    .filter(f => { const fc = foodCostFiche(f); return fc && fc > seuilOrange })
+    .filter((f) => { const fc = foodCostFiche(f); return fc && fc > seuilOrange })
     .sort((a, b) => foodCostFiche(b) - foodCostFiche(a))
 
   const fichesFCColor = (fc) => foodCostColor(fc, seuilVert, seuilOrange)
 
-  const fichesByCategorie = theme.categories.map(cat => ({
-    cat, nb: fiches.filter(f => f.categorie === cat).length
-  })).filter(c => c.nb > 0)
+  const fichesByCategorie = theme.categories.map((cat) => ({
+    cat, nb: fiches.filter((f) => f.categorie === cat).length,
+  })).filter((item) => item.nb > 0)
 
-  const maxFiches = Math.max(...fichesByCategorie.map(c => c.nb), 1)
+  const maxFiches = Math.max(...fichesByCategorie.map((item) => item.nb), 1)
 
-  const fichesAvecAllergenes = fiches.filter(f => f.allergenes && f.allergenes.length > 0)
-  const fichesFiltreesAllergenes = fichesAvecAllergenes
-    .filter(f => filtreCategorie === 'toutes' || f.categorie === filtreCategorie)
-    .filter(f => filtreSaison === 'toutes' || f.saison === filtreSaison)
-    .filter(f => filtreLieu === 'tous' || f.lieu_id === filtreLieu)
-
-  const exportAllergenesExcel = () => {
-    const wb = XLSX.utils.book_new()
-    const rows = fichesFiltreesAllergenes.map(f => {
-      const row = { 'Fiche': f.nom, 'Catégorie': f.categorie || '—', 'Saison': f.saison || '—' }
-      ALLERGENES.forEach(a => { row[`${a.emoji} ${a.label}`] = f.allergenes?.includes(a.id) ? '✓' : '' })
-      return row
-    })
-    const ws = XLSX.utils.json_to_sheet(rows)
-    XLSX.utils.book_append_sheet(wb, ws, 'Allergènes')
-    XLSX.writeFile(wb, `allergenes_la_fantaisie_${new Date().toLocaleDateString('fr-FR').replace(/\//g, '-')}.xlsx`)
-  }
-
-  if (loading || roleLoading) return (
+  if (loading || roleLoading || !layout) return (
     <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', background: c.fond }}>
       <ChefLoader />
     </div>
   )
 
-  const today = new Date().toLocaleDateString('fr-FR')
+  const renderWidget = (id) => {
+    switch (id) {
+      case 'kpi-food-cost-moyen':
+        return <KpiFoodCostMoyen c={c} isMobile={isMobile} foodCostMoyen={foodCostMoyen} nbFiches={fichesAvecFC.length} fichesFCColor={fichesFCColor} />
+      case 'kpi-fiches-actives':
+        return <KpiFichesActives c={c} isMobile={isMobile} nbFiches={fiches.length} nbMenus={menus.length} onClick={() => router.push('/fiches')} />
+      case 'kpi-fiches-alerte':
+        return <KpiFichesAlerte c={c} isMobile={isMobile} nbAlertes={fichesAlerte.length} seuilOrange={seuilOrange} />
+      case 'kpi-prix-modifies':
+        return <KpiPrixModifies c={c} isMobile={isMobile} nbPrix={ingredientsPrixHausse.length} />
+      case 'section-fiches-alerte':
+        return <SectionFichesAlerte c={c} fichesAlerte={fichesAlerte} foodCostFiche={foodCostFiche} seuilOrange={seuilOrange} onFicheClick={(id) => router.push(`/fiches/${id}`)} />
+      case 'section-fiches-par-espace':
+        return <SectionFichesParEspace c={c} fichesByCategorie={fichesByCategorie} maxFiches={maxFiches} />
+      case 'section-prix-modifies':
+        return <SectionPrixModifies c={c} ingredientsPrixHausse={ingredientsPrixHausse} />
+      case 'section-allergenes':
+        return <SectionAllergenes c={c} fiches={fiches} lieux={lieux} params={params} />
+      // Widgets déclarés dans le catalog mais pas encore implémentés (étape 4) :
+      // kpi-ca-mtd, kpi-marge-mtd, section-crm-evenements
+      default:
+        return null
+    }
+  }
+
+  const visibleLayout = layout.filter((l) => l.visible && WIDGET_BY_ID[l.id])
+  const kpiLayout = visibleLayout.filter((l) => WIDGET_BY_ID[l.id].size === 'kpi')
+  const sectionLayout = visibleLayout.filter((l) => WIDGET_BY_ID[l.id].size !== 'kpi')
+
+  const kpiCols = isMobile ? 2 : Math.min(Math.max(kpiLayout.length, 1), 4)
+
+  // Grouper les sections en lignes : deux 'half' consécutives s'associent,
+  // sinon chaque widget prend toute la largeur.
+  const sectionRows = []
+  let i = 0
+  while (i < sectionLayout.length) {
+    const current = sectionLayout[i]
+    const next = sectionLayout[i + 1]
+    const currentSize = WIDGET_BY_ID[current.id].size
+    const nextSize = next ? WIDGET_BY_ID[next.id].size : null
+    if (currentSize === 'half' && nextSize === 'half') {
+      sectionRows.push([current, next])
+      i += 2
+    } else {
+      sectionRows.push([current])
+      i += 1
+    }
+  }
 
   return (
     <div style={{ minHeight: '100vh', background: c.fond }}>
-
       <Navbar section="cuisine" />
       <InventaireBanner />
 
-      {/* Vue écran */}
       <div className="no-print" style={{ padding: isMobile ? '12px' : '24px', maxWidth: '1100px', margin: '0 auto' }}>
-
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
           <div style={{ fontSize: '11px', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', fontWeight: '500' }}>
             Tableau de bord Cuisine — {params['nom_etablissement'] || 'La Fantaisie'}
           </div>
           {nom && (
             <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-              <span style={{ fontSize: '12px', color: c.texteMuted }}>Bonjour, <strong style={{ color: c.texte }}>{nom}</strong></span>
-              <Badge bg={role === 'admin' ? '#F0E8E0' : role === 'cuisine' ? '#EAF3DE' : '#FAEEDA'} color={role === 'admin' ? '#2C1810' : role === 'cuisine' ? '#3B6D11' : '#854F0B'}>
+              <span style={{ fontSize: '12px', color: c.texteMuted }}>
+                Bonjour, <strong style={{ color: c.texte }}>{nom}</strong>
+              </span>
+              <Badge
+                bg={role === 'admin' ? '#F0E8E0' : role === 'cuisine' ? '#EAF3DE' : '#FAEEDA'}
+                color={role === 'admin' ? '#2C1810' : role === 'cuisine' ? '#3B6D11' : '#854F0B'}
+              >
                 {role === 'admin' ? 'Administrateur' : role === 'cuisine' ? 'Cuisine' : 'Directeur'}
               </Badge>
             </div>
           )}
         </div>
 
-        {/* KPIs */}
-        <div style={{
-          display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : 'repeat(4, 1fr)',
-          gap: isMobile ? '10px' : '16px', marginBottom: '24px'
-        }}>
-          <div style={{ background: foodCostMoyen ? fichesFCColor(foodCostMoyen).bg : c.blanc, borderRadius: '12px', padding: isMobile ? '14px' : '20px', border: `0.5px solid ${c.bordure}` }}>
-            <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: '8px' }}>Food cost moyen</div>
-            <div className="sk-stat-value" style={{ fontSize: isMobile ? '28px' : '36px', color: foodCostMoyen ? fichesFCColor(foodCostMoyen).color : c.texte }}>
-              {foodCostMoyen ? `${foodCostMoyen.toFixed(1)}%` : '—'}
-            </div>
-            <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '4px' }}>Sur {fichesAvecFC.length} fiches</div>
-          </div>
-          <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '14px' : '20px', border: `0.5px solid ${c.bordure}`, cursor: 'pointer' }} onClick={() => router.push('/fiches')}>
-            <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: '8px' }}>Fiches actives</div>
-            <div className="sk-stat-value" style={{ fontSize: isMobile ? '28px' : '36px', color: c.texte }}>{fiches.length}</div>
-            <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '4px' }}>{menus.length} menu{menus.length > 1 ? 's' : ''}</div>
-          </div>
-          <div style={{ background: fichesAlerte.length > 0 ? '#FCEBEB' : '#EAF3DE', borderRadius: '12px', padding: isMobile ? '14px' : '20px', border: `0.5px solid ${c.bordure}` }}>
-            <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: '8px' }}>Fiches en alerte</div>
-            <div className="sk-stat-value" style={{ fontSize: isMobile ? '28px' : '36px', color: fichesAlerte.length > 0 ? '#A32D2D' : '#3B6D11' }}>{fichesAlerte.length}</div>
-            <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '4px' }}>Food cost {'>'} {seuilOrange}%</div>
-          </div>
-          <div style={{ background: ingredientsPrixHausse.length > 0 ? '#FAEEDA' : c.blanc, borderRadius: '12px', padding: isMobile ? '14px' : '20px', border: `0.5px solid ${c.bordure}` }}>
-            <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: '8px' }}>Prix modifiés</div>
-            <div className="sk-stat-value" style={{ fontSize: isMobile ? '28px' : '36px', color: ingredientsPrixHausse.length > 0 ? '#854F0B' : c.texte }}>{ingredientsPrixHausse.length}</div>
-            <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '4px' }}>Ingrédients récents</div>
-          </div>
-        </div>
-
-        <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr', gap: isMobile ? '12px' : '16px', marginBottom: '16px' }}>
-          <div style={{ background: c.blanc, borderRadius: '12px', border: `0.5px solid ${c.bordure}`, overflow: 'hidden' }}>
-            <div style={{ padding: '16px 20px', borderBottom: `0.5px solid ${c.bordure}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              <div style={{ fontSize: '13px', fontWeight: '500', color: c.texte }}>🚨 Fiches en alerte</div>
-              <span style={{ fontSize: '11px', color: c.texteMuted }}>Food cost {'>'} {seuilOrange}%</span>
-            </div>
-            {fichesAlerte.length === 0 ? (
-              <div style={{ padding: '24px', textAlign: 'center', color: c.texteMuted, fontSize: '13px' }}>✓ Aucune fiche en alerte</div>
-            ) : (
-              <div style={{ maxHeight: '300px', overflowY: 'auto' }}>
-                {fichesAlerte.slice(0, 10).map((fiche, i) => {
-                  const fc = foodCostFiche(fiche)
-                  return (
-                    <div key={fiche.id} onClick={() => router.push(`/fiches/${fiche.id}`)}
-                      style={{ padding: '12px 20px', cursor: 'pointer', borderBottom: i < fichesAlerte.length - 1 ? `0.5px solid ${c.bordure}` : 'none', display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: c.blanc }}
-                      onMouseEnter={e => e.currentTarget.style.background = c.fond}
-                      onMouseLeave={e => e.currentTarget.style.background = c.blanc}
-                    >
-                      <div>
-                        <div style={{ fontSize: '13px', fontWeight: '500', color: c.texte }}>{fiche.nom}</div>
-                        <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '2px' }}>{fiche.categorie}</div>
-                      </div>
-                      <Badge bg={'#FCEBEB'} color={'#A32D2D'}>{fc.toFixed(1)}%</Badge>
-                    </div>
-                  )
-                })}
-              </div>
-            )}
-          </div>
-          <div style={{ background: c.blanc, borderRadius: '12px', border: `0.5px solid ${c.bordure}`, overflow: 'hidden' }}>
-            <div style={{ padding: '16px 20px', borderBottom: `0.5px solid ${c.bordure}` }}>
-              <div style={{ fontSize: '13px', fontWeight: '500', color: c.texte }}>📊 Fiches par espace</div>
-            </div>
-            <div style={{ padding: '16px 20px' }}>
-              {fichesByCategorie.map(({ cat, nb }) => (
-                <div key={cat} style={{ marginBottom: '10px' }}>
-                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }}>
-                    <span style={{ fontSize: '12px', color: c.texte, fontWeight: '500' }}>{cat}</span>
-                    <span style={{ fontSize: '12px', color: c.texteMuted }}>{nb}</span>
-                  </div>
-                  <div style={{ background: c.fond, borderRadius: '20px', height: '6px', overflow: 'hidden' }}>
-                    <div style={{ background: c.accent, height: '100%', borderRadius: '20px', width: `${(nb / maxFiches) * 100}%`, transition: 'width 0.5s ease' }} />
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-
-        {/* SECTION PRIX MODIFIÉS RÉTRACTABLE */}
-        {ingredientsPrixHausse.length > 0 && (
-          <div style={{ background: c.blanc, borderRadius: '12px', border: `0.5px solid ${c.bordure}`, overflow: 'hidden', marginBottom: '16px' }}>
-            <div onClick={() => setIsPrixExpanded(!isPrixExpanded)} style={{
-              padding: '16px 20px',
-              borderBottom: isPrixExpanded ? `0.5px solid ${c.bordure}` : 'none',
-              display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-              cursor: 'pointer',
-              background: isPrixExpanded ? c.fond + '40' : c.blanc,
-              transition: 'background 0.2s ease'
-            }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                <div style={{ fontSize: '13px', fontWeight: '500', color: c.texte }}>📈 Ingrédients avec prix modifiés récemment</div>
-                <Badge bg={'#FAEEDA'} color={'#854F0B'} size="sm">
-                  {ingredientsPrixHausse.length} alertes
-                </Badge>
-              </div>
-              <div style={{ fontSize: '16px', color: c.texteMuted, fontWeight: '300' }}>
-                {isPrixExpanded ? '− Masquer' : '+ Développer'}
-              </div>
-            </div>
-            {isPrixExpanded && (
-              <div style={{ overflowX: 'auto' }}>
-                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '13px' }}>
-                  <thead>
-                    <tr style={{ background: c.fond }}>
-                      {['Ingrédient', 'Ancien prix', 'Nouveau prix', 'Variation', 'Date'].map((h, i) => (
-                        <th key={h} style={{ padding: '10px 16px', textAlign: i === 0 ? 'left' : 'right', fontSize: '11px', color: c.texteMuted, fontWeight: '500', textTransform: 'uppercase', borderBottom: `0.5px solid ${c.bordure}` }}>{h}</th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {ingredientsPrixHausse.map((ing, i) => {
-                      const variation = ing.prix_precedent && ing.prix_kg ? ((ing.prix_kg - ing.prix_precedent) / ing.prix_precedent * 100) : null
-                      const hausse = variation > 0
-                      return (
-                        <tr key={ing.id} style={{ borderBottom: i < ingredientsPrixHausse.length - 1 ? `0.5px solid ${c.bordure}` : 'none', background: c.blanc }}>
-                          <td style={{ padding: '10px 16px', fontWeight: '500', color: c.texte }}>{ing.nom}</td>
-                          <td style={{ padding: '10px 16px', textAlign: 'right', color: c.texteMuted }}>{ing.prix_precedent ? `${Number(ing.prix_precedent).toFixed(2)} €` : '—'}</td>
-                          <td style={{ padding: '10px 16px', textAlign: 'right', color: c.texte }}>{ing.prix_kg ? `${Number(ing.prix_kg).toFixed(2)} €` : '—'}</td>
-                          <td className="sk-td sk-td--right">
-                            {variation !== null && (
-                              <Badge bg={hausse ? '#FCEBEB' : '#EAF3DE'} color={hausse ? '#A32D2D' : '#3B6D11'} size="sm">
-                                {hausse ? '+' : ''}{variation.toFixed(1)}%
-                              </Badge>
-                            )}
-                          </td>
-                          <td style={{ padding: '10px 16px', textAlign: 'right', color: c.texteMuted, fontSize: '12px' }}>
-                            {ing.prix_updated_at ? new Date(ing.prix_updated_at).toLocaleDateString('fr-FR') : '—'}
-                          </td>
-                        </tr>
-                      )
-                    })}
-                  </tbody>
-                </table>
-              </div>
-            )}
+        {kpiLayout.length > 0 && (
+          <div style={{
+            display: 'grid', gridTemplateColumns: `repeat(${kpiCols}, 1fr)`,
+            gap: isMobile ? '10px' : '16px', marginBottom: '24px',
+          }}>
+            {kpiLayout.map((l) => <div key={l.id}>{renderWidget(l.id)}</div>)}
           </div>
         )}
 
-        {/* Tableau allergènes */}
-        <div style={{ background: c.blanc, borderRadius: '12px', border: `0.5px solid ${c.bordure}`, overflow: 'hidden' }}>
-          <div style={{ padding: '16px 20px', borderBottom: isAllergenesExpanded ? `0.5px solid ${c.bordure}` : 'none', display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '10px', background: isAllergenesExpanded ? c.fond + '40' : c.blanc, transition: 'background 0.2s ease' }}>
-            <div
-              onClick={() => setIsAllergenesExpanded(!isAllergenesExpanded)}
-              style={{ display: 'flex', alignItems: 'center', gap: '10px', cursor: 'pointer' }}
-            >
-              <div style={{ fontSize: '13px', fontWeight: '500', color: c.texte }}>⚠️ Tableau des allergènes</div>
-              <Badge bg={'#FCEBEB'} color={'#A32D2D'} size="sm">
-                {fichesAvecAllergenes.length} fiche{fichesAvecAllergenes.length > 1 ? 's' : ''}
-              </Badge>
-            </div>
-            <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
-              {isAllergenesExpanded && (
-                <>
-                  <select value={filtreCategorie} onChange={e => setFiltreCategorie(e.target.value)} style={{
-                    padding: '6px 10px', borderRadius: '8px', border: `0.5px solid ${c.bordure}`,
-                    fontSize: '12px', background: c.blanc, outline: 'none', color: c.texte, cursor: 'pointer'
-                  }}>
-                    <option value="toutes">Toutes les catégories</option>
-                    {theme.categories.map(cat => <option key={cat} value={cat}>{cat}</option>)}
-                  </select>
-                  <select value={filtreSaison} onChange={e => setFiltreSaison(e.target.value)} style={{
-                    padding: '6px 10px', borderRadius: '8px', border: `0.5px solid ${c.bordure}`,
-                    fontSize: '12px', background: c.blanc, outline: 'none', color: c.texte, cursor: 'pointer'
-                  }}>
-                    <option value="toutes">Toutes les saisons</option>
-                    {theme.saisons.map(s => <option key={s} value={s}>{s}</option>)}
-                  </select>
-                  {lieux.length > 0 && (
-                    <select value={filtreLieu} onChange={e => setFiltreLieu(e.target.value)} style={{
-                      padding: '6px 10px', borderRadius: '8px', border: `0.5px solid ${c.bordure}`,
-                      fontSize: '12px', background: c.blanc, outline: 'none', color: c.texte, cursor: 'pointer'
-                    }}>
-                      <option value="tous">Tous les lieux</option>
-                      {lieux.map(l => <option key={l.id} value={l.id}>{l.emoji ? `${l.emoji} ${l.nom}` : l.nom}</option>)}
-                    </select>
-                  )}
-                  <button onClick={exportAllergenesExcel} style={{ padding: '6px 12px', background: c.vert, color: 'white', border: 'none', borderRadius: '8px', fontSize: '12px', fontWeight: '600', cursor: 'pointer' }}>📊 Excel</button>
-                  <button onClick={() => window.print()} style={{ padding: '6px 12px', background: c.accent, color: c.principal, border: 'none', borderRadius: '8px', fontSize: '12px', fontWeight: '600', cursor: 'pointer' }}>🖨️ Imprimer</button>
-                </>
-              )}
-              <div
-                onClick={() => setIsAllergenesExpanded(!isAllergenesExpanded)}
-                style={{ fontSize: '16px', color: c.texteMuted, fontWeight: '300', cursor: 'pointer' }}
-              >
-                {isAllergenesExpanded ? '− Masquer' : '+ Développer'}
-              </div>
-            </div>
+        {sectionRows.map((row, idx) => (
+          <div
+            key={row.map((r) => r.id).join('|')}
+            style={{
+              display: 'grid',
+              gridTemplateColumns: isMobile || row.length === 1 ? '1fr' : '1fr 1fr',
+              gap: isMobile ? '12px' : '16px',
+              marginBottom: idx < sectionRows.length - 1 ? (isMobile ? '12px' : '16px') : 0,
+            }}
+          >
+            {row.map((l) => <div key={l.id}>{renderWidget(l.id)}</div>)}
           </div>
-          {isAllergenesExpanded && (
-          <div style={{ overflowX: 'auto' }}>
-            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px', minWidth: '900px' }}>
-              <thead>
-                <tr style={{ background: c.principal }}>
-                  <th style={{ padding: '10px 12px', textAlign: 'left', fontSize: '11px', color: c.accent, fontWeight: '500', textTransform: 'uppercase', position: 'sticky', left: 0, background: c.principal, zIndex: 1, minWidth: '160px' }}>
-                    Fiche / Catégorie
-                  </th>
-                  {ALLERGENES.map(a => (
-                    <th key={a.id} style={{ padding: '8px 4px', textAlign: 'center', fontSize: '10px', color: c.accent, fontWeight: '500', minWidth: '52px' }}>
-                      <div style={{ fontSize: '14px' }}>{a.emoji}</div>
-                      <div style={{ fontSize: '8px', textTransform: 'uppercase', letterSpacing: '0.5px', lineHeight: '1.2', marginTop: '2px' }}>{a.label}</div>
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {fichesFiltreesAllergenes.map((fiche, i) => (
-                  <tr key={fiche.id} style={{ borderBottom: `0.5px solid ${c.bordure}`, background: i % 2 === 0 ? c.blanc : c.fond }}>
-                    <td style={{ padding: '10px 12px', position: 'sticky', left: 0, background: i % 2 === 0 ? c.blanc : c.fond, zIndex: 1 }}>
-                      <div style={{ fontWeight: '500', color: c.texte, fontSize: '13px' }}>{fiche.nom}</div>
-                      <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '2px' }}>{fiche.categorie}</div>
-                    </td>
-                    {ALLERGENES.map(a => (
-                      <td key={a.id} style={{ padding: '8px 4px', textAlign: 'center' }}>
-                        {fiche.allergenes?.includes(a.id) ? (
-                          <div style={{ width: '20px', height: '20px', borderRadius: '50%', background: '#FCEBEB', border: '1.5px solid #A32D2D', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto', fontSize: '10px', color: '#A32D2D', fontWeight: '700' }}>✓</div>
-                        ) : (
-                          <div style={{ width: '20px', height: '20px', margin: '0 auto', opacity: 0.15, fontSize: '12px', textAlign: 'center', color: c.bordure }}>—</div>
-                        )}
-                      </td>
-                    ))}
-                  </tr>
-                ))}
-                {fichesFiltreesAllergenes.length === 0 && (
-                  <tr>
-                    <td colSpan={ALLERGENES.length + 1} style={{ padding: '30px', textAlign: 'center', color: c.texteMuted, fontSize: '13px' }}>
-                      Aucune fiche avec allergènes
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
-          )}
-        </div>
-      </div>
-
-      {/* Version impression */}
-      <div className="print-only dashboard-allergenes-print" style={{ fontFamily: 'sans-serif', color: '#1a1a1a', background: 'white', padding: '0' }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderBottom: '2px solid #2C1810', paddingBottom: '12px', marginBottom: '16px' }}>
-          <div>
-            <div style={{ fontSize: '8px', letterSpacing: '3px', textTransform: 'uppercase', color: '#8B7355', marginBottom: '4px' }}>Tableau des allergènes — Fiches actives</div>
-            <div style={{ fontSize: '18px', fontWeight: '600', color: '#2C1810', fontFamily: 'Georgia, serif' }}>{params['nom_etablissement'] || 'La Fantaisie'}</div>
-            <div style={{ fontSize: '9px', color: '#8B7355', marginTop: '2px' }}>Imprimé le {today} — {fichesFiltreesAllergenes.length} fiche{fichesFiltreesAllergenes.length > 1 ? 's' : ''}</div>
-          </div>
-          <img
-            src={params['logo_url'] || '/skalcook_logo.svg'}
-            alt={params['nom_etablissement'] || 'Skalcook'}
-            style={{ height: '60px', objectFit: 'contain' }}
-          />
-        </div>
-        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '9px', tableLayout: 'fixed' }}>
-          <thead>
-            <tr style={{ background: '#2C1810' }}>
-              <th style={{ padding: '6px 8px', textAlign: 'left', color: '#C4956A', fontWeight: '600', fontSize: '9px', textTransform: 'uppercase', width: '140px', wordWrap: 'break-word' }}>Fiche</th>
-              {ALLERGENES.map(a => (
-                <th key={a.id} style={{ padding: '4px 2px', textAlign: 'center', color: '#C4956A', fontWeight: '600', fontSize: '7px', textTransform: 'uppercase', lineHeight: '1.2' }}>
-                  <div style={{ fontSize: '10px' }}>{a.emoji}</div>
-                  <div style={{ fontSize: '6px', marginTop: '1px' }}>{a.label.replace('Céréales/Gluten', 'Gluten').replace('Graines de sésame', 'Sésame').replace('Anhydride sulfureux', 'Sulfites').replace('Fruits à coque', 'F. à coque')}</div>
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {fichesFiltreesAllergenes.map((fiche, i) => (
-              <tr key={fiche.id} style={{ background: i % 2 === 0 ? 'white' : '#FAF9F6', borderBottom: '0.5px solid #e8e4dc' }}>
-                <td style={{ padding: '5px 8px', fontWeight: '500', color: '#2C1810', fontSize: '9px', wordWrap: 'break-word' }}>
-                  {fiche.nom}
-                  <div style={{ fontSize: '7px', color: '#8B7355', marginTop: '1px' }}>{fiche.categorie}</div>
-                </td>
-                {ALLERGENES.map(a => (
-                  <td key={a.id} style={{ padding: '4px 2px', textAlign: 'center' }}>
-                    {fiche.allergenes?.includes(a.id) ? (
-                      <div style={{ width: '14px', height: '14px', borderRadius: '50%', background: '#FCEBEB', border: '1px solid #A32D2D', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto', fontSize: '8px', color: '#A32D2D', fontWeight: '700' }}>✓</div>
-                    ) : (
-                      <div style={{ color: '#ddd', fontSize: '8px', textAlign: 'center' }}>·</div>
-                    )}
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-        <div style={{ marginTop: '10px', borderTop: '1px solid #e8e4dc', paddingTop: '8px', fontSize: '7px', color: '#8B7355' }}>
-          <strong>Allergènes :</strong> {ALLERGENES.map(a => `${a.emoji} ${a.label}`).join(' — ')}
-        </div>
+        ))}
       </div>
     </div>
   )

--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -6,8 +6,9 @@ import { theme } from '../../lib/theme.jsx'
 import { useIsMobile } from '../../lib/useIsMobile'
 import { useTheme } from '../../lib/useTheme'
 import { useRole } from '../../lib/useRole'
+import { useTenant } from '../../lib/useTenant'
 import { calculerFoodCost, foodCostColor, getSeuilsFromParams } from '../../lib/foodCost'
-import { getDashboardLayout, WIDGET_BY_ID } from '../../lib/dashboardPreferences'
+import { getDashboardLayout, WIDGET_BY_ID, isWidgetAvailable } from '../../lib/dashboardPreferences'
 import Navbar from '../../components/Navbar'
 import InventaireBanner from '../../components/InventaireBanner'
 import ChefLoader from '../../components/ChefLoader'
@@ -38,6 +39,8 @@ export default function DashboardPage() {
   const isMobile = useIsMobile()
   const { c } = useTheme()
   const { role, nom, loading: roleLoading } = useRole()
+  const { tenant } = useTenant()
+  const modulesActifs = tenant?.modules_actifs || []
 
   useEffect(() => {
     checkUser()
@@ -133,7 +136,9 @@ export default function DashboardPage() {
     }
   }
 
-  const visibleLayout = layout.filter((l) => l.visible && WIDGET_BY_ID[l.id])
+  const visibleLayout = layout.filter(
+    (l) => l.visible && WIDGET_BY_ID[l.id] && isWidgetAvailable(WIDGET_BY_ID[l.id], modulesActifs),
+  )
   const kpiLayout = visibleLayout.filter((l) => WIDGET_BY_ID[l.id].size === 'kpi')
   const sectionLayout = visibleLayout.filter((l) => WIDGET_BY_ID[l.id].size !== 'kpi')
 
@@ -208,6 +213,7 @@ export default function DashboardPage() {
           <DashboardCustomizeModal
             c={c}
             initialLayout={layout}
+            modulesActifs={modulesActifs}
             onClose={() => setShowCustomize(false)}
             onSaved={(next) => {
               setLayout(next)

--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -23,6 +23,7 @@ import SectionPrixModifies from '../../components/dashboard/widgets/SectionPrixM
 import SectionAllergenes from '../../components/dashboard/widgets/SectionAllergenes'
 import KpiCaMtd from '../../components/dashboard/widgets/KpiCaMtd'
 import KpiMargeMtd from '../../components/dashboard/widgets/KpiMargeMtd'
+import KpiAvisNote from '../../components/dashboard/widgets/KpiAvisNote'
 import SectionCrmEvenements from '../../components/dashboard/widgets/SectionCrmEvenements'
 import DashboardCustomizeModal from '../../components/dashboard/DashboardCustomizeModal'
 
@@ -129,6 +130,8 @@ export default function DashboardPage() {
         return <KpiCaMtd c={c} isMobile={isMobile} />
       case 'kpi-marge-mtd':
         return <KpiMargeMtd c={c} isMobile={isMobile} />
+      case 'kpi-avis-note':
+        return <KpiAvisNote c={c} isMobile={isMobile} />
       case 'section-crm-evenements':
         return <SectionCrmEvenements c={c} />
       default:

--- a/components/dashboard/DashboardCustomizeModal.js
+++ b/components/dashboard/DashboardCustomizeModal.js
@@ -1,16 +1,18 @@
 'use client'
 import { useEffect, useState } from 'react'
-import { WIDGET_BY_ID, DEFAULT_LAYOUT, saveDashboardLayout, resetDashboardLayout } from '../../lib/dashboardPreferences'
+import { WIDGET_BY_ID, DEFAULT_LAYOUT, saveDashboardLayout, resetDashboardLayout, isWidgetAvailable } from '../../lib/dashboardPreferences'
 
 // Le layout est un array plat, mais l'UI regroupe visuellement les
 // widgets par type (KPIs vs sections) pour que l'user comprenne que
 // les KPIs sont toujours rendus avant les sections.
-function splitByGroup(layout) {
+// On filtre aussi les widgets dont le module est désactivé sur ce tenant.
+function splitByGroup(layout, modulesActifs) {
   const kpis = []
   const sections = []
   for (const entry of layout) {
     const widget = WIDGET_BY_ID[entry.id]
     if (!widget) continue
+    if (!isWidgetAvailable(widget, modulesActifs)) continue
     if (widget.size === 'kpi') kpis.push(entry)
     else sections.push(entry)
   }
@@ -29,7 +31,7 @@ function moveItem(list, index, direction) {
   return copy
 }
 
-export default function DashboardCustomizeModal({ c, initialLayout, onClose, onSaved }) {
+export default function DashboardCustomizeModal({ c, initialLayout, modulesActifs = [], onClose, onSaved }) {
   const [draft, setDraft] = useState(initialLayout)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState(null)
@@ -40,23 +42,42 @@ export default function DashboardCustomizeModal({ c, initialLayout, onClose, onS
     return () => window.removeEventListener('keydown', onKey)
   }, [onClose])
 
-  const { kpis, sections } = splitByGroup(draft)
+  const { kpis, sections } = splitByGroup(draft, modulesActifs)
 
   const toggleVisible = (id) => {
     setDraft(draft.map((l) => (l.id === id ? { ...l, visible: !l.visible } : l)))
   }
 
+  // Le réordonnancement doit préserver la position des widgets filtrés
+  // (modules désactivés) dans le layout stocké. On ne déplace les items
+  // que dans le sous-ensemble visible et on réinjecte les masqués à leur
+  // position d'origine.
   const move = (id, direction) => {
-    const { kpis, sections } = splitByGroup(draft)
-    const inKpis = kpis.findIndex((l) => l.id === id)
+    const visibleIds = new Set([...kpis, ...sections].map((e) => e.id))
+    const visibleOrder = draft.filter((e) => visibleIds.has(e.id))
+    const { kpis: visibleKpis, sections: visibleSections } = splitByGroup(visibleOrder, modulesActifs)
+
+    let nextVisible
+    const inKpis = visibleKpis.findIndex((l) => l.id === id)
     if (inKpis >= 0) {
-      setDraft(mergeGroups(moveItem(kpis, inKpis, direction), sections))
-      return
+      nextVisible = mergeGroups(moveItem(visibleKpis, inKpis, direction), visibleSections)
+    } else {
+      const inSections = visibleSections.findIndex((l) => l.id === id)
+      if (inSections < 0) return
+      nextVisible = mergeGroups(visibleKpis, moveItem(visibleSections, inSections, direction))
     }
-    const inSections = sections.findIndex((l) => l.id === id)
-    if (inSections >= 0) {
-      setDraft(mergeGroups(kpis, moveItem(sections, inSections, direction)))
+
+    const result = []
+    let vi = 0
+    for (const entry of draft) {
+      if (visibleIds.has(entry.id)) {
+        result.push(nextVisible[vi])
+        vi += 1
+      } else {
+        result.push(entry)
+      }
     }
+    setDraft(result)
   }
 
   const handleSave = async () => {

--- a/components/dashboard/DashboardCustomizeModal.js
+++ b/components/dashboard/DashboardCustomizeModal.js
@@ -1,0 +1,234 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { WIDGET_BY_ID, DEFAULT_LAYOUT, saveDashboardLayout, resetDashboardLayout } from '../../lib/dashboardPreferences'
+
+// Le layout est un array plat, mais l'UI regroupe visuellement les
+// widgets par type (KPIs vs sections) pour que l'user comprenne que
+// les KPIs sont toujours rendus avant les sections.
+function splitByGroup(layout) {
+  const kpis = []
+  const sections = []
+  for (const entry of layout) {
+    const widget = WIDGET_BY_ID[entry.id]
+    if (!widget) continue
+    if (widget.size === 'kpi') kpis.push(entry)
+    else sections.push(entry)
+  }
+  return { kpis, sections }
+}
+
+function mergeGroups(kpis, sections) {
+  return [...kpis, ...sections]
+}
+
+function moveItem(list, index, direction) {
+  const target = index + direction
+  if (target < 0 || target >= list.length) return list
+  const copy = [...list]
+  ;[copy[index], copy[target]] = [copy[target], copy[index]]
+  return copy
+}
+
+export default function DashboardCustomizeModal({ c, initialLayout, onClose, onSaved }) {
+  const [draft, setDraft] = useState(initialLayout)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const { kpis, sections } = splitByGroup(draft)
+
+  const toggleVisible = (id) => {
+    setDraft(draft.map((l) => (l.id === id ? { ...l, visible: !l.visible } : l)))
+  }
+
+  const move = (id, direction) => {
+    const { kpis, sections } = splitByGroup(draft)
+    const inKpis = kpis.findIndex((l) => l.id === id)
+    if (inKpis >= 0) {
+      setDraft(mergeGroups(moveItem(kpis, inKpis, direction), sections))
+      return
+    }
+    const inSections = sections.findIndex((l) => l.id === id)
+    if (inSections >= 0) {
+      setDraft(mergeGroups(kpis, moveItem(sections, inSections, direction)))
+    }
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      const clean = await saveDashboardLayout(draft)
+      onSaved(clean)
+    } catch (err) {
+      setError(err?.message || 'Erreur lors de la sauvegarde')
+      setSaving(false)
+    }
+  }
+
+  const handleReset = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      await resetDashboardLayout()
+      setDraft(DEFAULT_LAYOUT)
+      onSaved(DEFAULT_LAYOUT)
+    } catch (err) {
+      setError(err?.message || 'Erreur lors de la remise à zéro')
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      className="sk-dashboard-modal-backdrop"
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0, zIndex: 200,
+        background: 'rgba(9,9,11,0.45)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        padding: '16px',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: '100%', maxWidth: '520px', maxHeight: '90vh', overflowY: 'auto',
+          background: c.blanc, borderRadius: '14px',
+          border: `0.5px solid ${c.bordure}`, boxShadow: '0 20px 40px rgba(0,0,0,0.2)',
+          padding: '20px',
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '6px' }}>
+          <div style={{ fontSize: '17px', fontWeight: '600', color: c.texte }}>Personnaliser mon tableau de bord</div>
+          <button
+            onClick={onClose}
+            aria-label="Fermer"
+            style={{ background: 'transparent', border: 'none', fontSize: '20px', color: c.texteMuted, cursor: 'pointer', lineHeight: 1 }}
+          >
+            ×
+          </button>
+        </div>
+        <div style={{ fontSize: '12px', color: c.texteMuted, marginBottom: '16px' }}>
+          Activez/désactivez les widgets et choisissez leur ordre d'affichage.
+        </div>
+
+        <WidgetList c={c} title="KPIs" entries={kpis} onToggle={toggleVisible} onMove={move} />
+        <WidgetList c={c} title="Sections" entries={sections} onToggle={toggleVisible} onMove={move} />
+
+        {error && (
+          <div style={{ marginTop: '12px', padding: '10px 12px', background: '#FCEBEB', color: '#A32D2D', borderRadius: '8px', fontSize: '12px' }}>
+            {error}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px', marginTop: '18px', flexWrap: 'wrap' }}>
+          <button
+            onClick={handleReset}
+            disabled={saving}
+            style={{
+              background: 'transparent', color: c.texteMuted, border: `0.5px solid ${c.bordure}`,
+              borderRadius: '8px', padding: '8px 12px', fontSize: '12px',
+              cursor: saving ? 'not-allowed' : 'pointer', opacity: saving ? 0.6 : 1,
+            }}
+          >
+            ↺ Rétablir les valeurs par défaut
+          </button>
+          <div style={{ display: 'flex', gap: '10px' }}>
+            <button
+              onClick={onClose}
+              disabled={saving}
+              style={{
+                background: c.blanc, color: c.texteMuted, border: `0.5px solid ${c.bordure}`,
+                borderRadius: '8px', padding: '10px 14px', fontSize: '13px',
+                cursor: saving ? 'not-allowed' : 'pointer', opacity: saving ? 0.6 : 1,
+              }}
+            >
+              Annuler
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              style={{
+                background: c.accent, color: c.principal, border: 'none',
+                borderRadius: '8px', padding: '10px 14px', fontSize: '13px', fontWeight: '600',
+                cursor: saving ? 'not-allowed' : 'pointer', opacity: saving ? 0.6 : 1,
+              }}
+            >
+              {saving ? 'Enregistrement…' : 'Enregistrer'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function WidgetList({ c, title, entries, onToggle, onMove }) {
+  if (entries.length === 0) return null
+  return (
+    <div style={{ marginBottom: '12px' }}>
+      <div style={{ fontSize: '11px', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.05em', fontWeight: '500', marginBottom: '8px' }}>
+        {title}
+      </div>
+      <div style={{ border: `0.5px solid ${c.bordure}`, borderRadius: '10px', overflow: 'hidden' }}>
+        {entries.map((entry, i) => {
+          const widget = WIDGET_BY_ID[entry.id]
+          if (!widget) return null
+          return (
+            <div
+              key={entry.id}
+              style={{
+                display: 'flex', alignItems: 'center', gap: '10px',
+                padding: '10px 12px',
+                borderBottom: i < entries.length - 1 ? `0.5px solid ${c.bordure}` : 'none',
+                background: c.blanc,
+                opacity: entry.visible ? 1 : 0.55,
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={entry.visible}
+                onChange={() => onToggle(entry.id)}
+                style={{ cursor: 'pointer' }}
+              />
+              <div style={{ flex: 1, fontSize: '13px', color: c.texte }}>{widget.label}</div>
+              <button
+                onClick={() => onMove(entry.id, -1)}
+                disabled={i === 0}
+                aria-label="Monter"
+                style={{
+                  background: 'transparent', border: `0.5px solid ${c.bordure}`,
+                  borderRadius: '6px', padding: '4px 8px', color: c.texte,
+                  cursor: i === 0 ? 'not-allowed' : 'pointer', opacity: i === 0 ? 0.4 : 1,
+                  fontSize: '12px',
+                }}
+              >
+                ↑
+              </button>
+              <button
+                onClick={() => onMove(entry.id, 1)}
+                disabled={i === entries.length - 1}
+                aria-label="Descendre"
+                style={{
+                  background: 'transparent', border: `0.5px solid ${c.bordure}`,
+                  borderRadius: '6px', padding: '4px 8px', color: c.texte,
+                  cursor: i === entries.length - 1 ? 'not-allowed' : 'pointer',
+                  opacity: i === entries.length - 1 ? 0.4 : 1,
+                  fontSize: '12px',
+                }}
+              >
+                ↓
+              </button>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/widgets/KpiAvisNote.js
+++ b/components/dashboard/widgets/KpiAvisNote.js
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase, getClientId } from '../../../lib/supabase'
+
+export default function KpiAvisNote({ c, isMobile }) {
+  const [stats, setStats] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const router = useRouter()
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const clientId = await getClientId()
+      if (!clientId) { setLoading(false); return }
+      const { data } = await supabase
+        .from('avis')
+        .select('stars')
+        .eq('client_id', clientId)
+        .eq('archive', false)
+      if (cancelled) return
+      const rows = (data || []).filter((r) => r.stars != null)
+      const count = rows.length
+      const avg = count > 0 ? rows.reduce((sum, r) => sum + Number(r.stars), 0) / count : null
+      setStats({ avg, count })
+      setLoading(false)
+    })()
+    return () => { cancelled = true }
+  }, [])
+
+  const valeur = loading
+    ? '…'
+    : !stats || stats.count === 0
+      ? '—'
+      : `${stats.avg.toFixed(1)} ★`
+
+  return (
+    <div
+      onClick={() => router.push('/avis')}
+      style={{
+        background: c.blanc, borderRadius: '12px',
+        padding: isMobile ? '14px' : '20px',
+        border: `0.5px solid ${c.bordure}`,
+        cursor: 'pointer',
+      }}
+    >
+      <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: '8px' }}>Note moyenne</div>
+      <div className="sk-stat-value" style={{ fontSize: isMobile ? '28px' : '36px', color: c.texte }}>{valeur}</div>
+      <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '4px' }}>
+        {stats?.count ? `${stats.count} avis` : 'Aucun avis'}
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/widgets/KpiCaMtd.js
+++ b/components/dashboard/widgets/KpiCaMtd.js
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+import { supabase, getClientId } from '../../../lib/supabase'
+
+function firstDayOfMonthIso(d = new Date()) {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`
+}
+
+export default function KpiCaMtd({ c, isMobile }) {
+  const [ca, setCa] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const clientId = await getClientId()
+      if (!clientId) { setLoading(false); return }
+      const debut = firstDayOfMonthIso()
+      const { data } = await supabase
+        .from('ventes_journalieres')
+        .select('quantite_vendue, prix_vente_net')
+        .eq('client_id', clientId)
+        .gte('jour', debut)
+      if (cancelled) return
+      const total = (data || []).reduce(
+        (sum, row) => sum + (Number(row.quantite_vendue) || 0) * (Number(row.prix_vente_net) || 0),
+        0,
+      )
+      setCa(total)
+      setLoading(false)
+    })()
+    return () => { cancelled = true }
+  }, [])
+
+  const valeur = loading ? '…' : ca == null ? '—' : `${ca.toLocaleString('fr-FR', { maximumFractionDigits: 0 })} €`
+
+  return (
+    <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '14px' : '20px', border: `0.5px solid ${c.bordure}` }}>
+      <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: '8px' }}>CA cumulé mois en cours</div>
+      <div className="sk-stat-value" style={{ fontSize: isMobile ? '24px' : '30px', color: c.texte }}>{valeur}</div>
+      <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '4px' }}>Ventes du mois (HT net)</div>
+    </div>
+  )
+}

--- a/components/dashboard/widgets/KpiFichesActives.js
+++ b/components/dashboard/widgets/KpiFichesActives.js
@@ -1,0 +1,12 @@
+export default function KpiFichesActives({ c, isMobile, nbFiches, nbMenus, onClick }) {
+  return (
+    <div
+      onClick={onClick}
+      style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '14px' : '20px', border: `0.5px solid ${c.bordure}`, cursor: onClick ? 'pointer' : 'default' }}
+    >
+      <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: '8px' }}>Fiches actives</div>
+      <div className="sk-stat-value" style={{ fontSize: isMobile ? '28px' : '36px', color: c.texte }}>{nbFiches}</div>
+      <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '4px' }}>{nbMenus} menu{nbMenus > 1 ? 's' : ''}</div>
+    </div>
+  )
+}

--- a/components/dashboard/widgets/KpiFichesAlerte.js
+++ b/components/dashboard/widgets/KpiFichesAlerte.js
@@ -1,0 +1,9 @@
+export default function KpiFichesAlerte({ c, isMobile, nbAlertes, seuilOrange }) {
+  return (
+    <div style={{ background: nbAlertes > 0 ? '#FCEBEB' : '#EAF3DE', borderRadius: '12px', padding: isMobile ? '14px' : '20px', border: `0.5px solid ${c.bordure}` }}>
+      <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: '8px' }}>Fiches en alerte</div>
+      <div className="sk-stat-value" style={{ fontSize: isMobile ? '28px' : '36px', color: nbAlertes > 0 ? '#A32D2D' : '#3B6D11' }}>{nbAlertes}</div>
+      <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '4px' }}>Food cost {'>'} {seuilOrange}%</div>
+    </div>
+  )
+}

--- a/components/dashboard/widgets/KpiFoodCostMoyen.js
+++ b/components/dashboard/widgets/KpiFoodCostMoyen.js
@@ -1,0 +1,13 @@
+export default function KpiFoodCostMoyen({ c, isMobile, foodCostMoyen, nbFiches, fichesFCColor }) {
+  const bg = foodCostMoyen ? fichesFCColor(foodCostMoyen).bg : c.blanc
+  const color = foodCostMoyen ? fichesFCColor(foodCostMoyen).color : c.texte
+  return (
+    <div style={{ background: bg, borderRadius: '12px', padding: isMobile ? '14px' : '20px', border: `0.5px solid ${c.bordure}` }}>
+      <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: '8px' }}>Food cost moyen</div>
+      <div className="sk-stat-value" style={{ fontSize: isMobile ? '28px' : '36px', color }}>
+        {foodCostMoyen ? `${foodCostMoyen.toFixed(1)}%` : '—'}
+      </div>
+      <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '4px' }}>Sur {nbFiches} fiches</div>
+    </div>
+  )
+}

--- a/components/dashboard/widgets/KpiMargeMtd.js
+++ b/components/dashboard/widgets/KpiMargeMtd.js
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react'
+import { supabase, getClientId } from '../../../lib/supabase'
+
+function firstDayOfMonthIso(d = new Date()) {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`
+}
+
+export default function KpiMargeMtd({ c, isMobile }) {
+  const [stats, setStats] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const clientId = await getClientId()
+      if (!clientId) { setLoading(false); return }
+      const debut = firstDayOfMonthIso()
+      const [{ data: ventes }, { data: fiches }] = await Promise.all([
+        supabase
+          .from('ventes_journalieres')
+          .select('fiche_id, quantite_vendue, prix_vente_net')
+          .eq('client_id', clientId)
+          .gte('jour', debut),
+        supabase
+          .from('fiches')
+          .select('id, cout_portion')
+          .eq('client_id', clientId),
+      ])
+      if (cancelled) return
+      const coutById = new Map((fiches || []).map((f) => [f.id, f.cout_portion == null ? null : Number(f.cout_portion)]))
+      let ca = 0
+      let caAvecCout = 0
+      let coutTotal = 0
+      for (const row of ventes || []) {
+        const q = Number(row.quantite_vendue) || 0
+        const pu = Number(row.prix_vente_net) || 0
+        ca += q * pu
+        const cp = coutById.get(row.fiche_id)
+        if (cp != null) {
+          caAvecCout += q * pu
+          coutTotal += q * cp
+        }
+      }
+      const marge = caAvecCout - coutTotal
+      const margePct = caAvecCout > 0 ? (marge / caAvecCout) * 100 : null
+      setStats({ ca, marge, margePct })
+      setLoading(false)
+    })()
+    return () => { cancelled = true }
+  }, [])
+
+  const valeur = loading
+    ? '…'
+    : !stats || stats.ca === 0
+      ? '—'
+      : `${stats.marge.toLocaleString('fr-FR', { maximumFractionDigits: 0 })} €`
+  const pct = stats?.margePct != null ? `${stats.margePct.toFixed(1)}%` : null
+
+  return (
+    <div style={{ background: c.blanc, borderRadius: '12px', padding: isMobile ? '14px' : '20px', border: `0.5px solid ${c.bordure}` }}>
+      <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: '8px' }}>Marge mois en cours</div>
+      <div className="sk-stat-value" style={{ fontSize: isMobile ? '24px' : '30px', color: c.texte }}>{valeur}</div>
+      <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '4px' }}>
+        {pct ? `${pct} sur CA avec coût connu` : 'Marge brute sur fiches renseignées'}
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/widgets/KpiPrixModifies.js
+++ b/components/dashboard/widgets/KpiPrixModifies.js
@@ -1,0 +1,9 @@
+export default function KpiPrixModifies({ c, isMobile, nbPrix }) {
+  return (
+    <div style={{ background: nbPrix > 0 ? '#FAEEDA' : c.blanc, borderRadius: '12px', padding: isMobile ? '14px' : '20px', border: `0.5px solid ${c.bordure}` }}>
+      <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: '8px' }}>Prix modifiés</div>
+      <div className="sk-stat-value" style={{ fontSize: isMobile ? '28px' : '36px', color: nbPrix > 0 ? '#854F0B' : c.texte }}>{nbPrix}</div>
+      <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '4px' }}>Ingrédients récents</div>
+    </div>
+  )
+}

--- a/components/dashboard/widgets/SectionAllergenes.js
+++ b/components/dashboard/widgets/SectionAllergenes.js
@@ -1,0 +1,174 @@
+import { useState } from 'react'
+import * as XLSX from 'xlsx'
+import { Badge } from '../../ui'
+import { ALLERGENES } from '../../../lib/allergenes'
+import { theme } from '../../../lib/theme.jsx'
+
+export default function SectionAllergenes({ c, fiches, lieux, params }) {
+  const [filtreCategorie, setFiltreCategorie] = useState('toutes')
+  const [filtreSaison, setFiltreSaison] = useState('toutes')
+  const [filtreLieu, setFiltreLieu] = useState('tous')
+  const [isExpanded, setIsExpanded] = useState(true)
+
+  const fichesAvecAllergenes = fiches.filter((f) => f.allergenes && f.allergenes.length > 0)
+  const fichesFiltreesAllergenes = fichesAvecAllergenes
+    .filter((f) => filtreCategorie === 'toutes' || f.categorie === filtreCategorie)
+    .filter((f) => filtreSaison === 'toutes' || f.saison === filtreSaison)
+    .filter((f) => filtreLieu === 'tous' || f.lieu_id === filtreLieu)
+
+  const exportAllergenesExcel = () => {
+    const wb = XLSX.utils.book_new()
+    const rows = fichesFiltreesAllergenes.map((f) => {
+      const row = { Fiche: f.nom, Catégorie: f.categorie || '—', Saison: f.saison || '—' }
+      ALLERGENES.forEach((a) => { row[`${a.emoji} ${a.label}`] = f.allergenes?.includes(a.id) ? '✓' : '' })
+      return row
+    })
+    const ws = XLSX.utils.json_to_sheet(rows)
+    XLSX.utils.book_append_sheet(wb, ws, 'Allergènes')
+    XLSX.writeFile(wb, `allergenes_la_fantaisie_${new Date().toLocaleDateString('fr-FR').replace(/\//g, '-')}.xlsx`)
+  }
+
+  const today = new Date().toLocaleDateString('fr-FR')
+
+  return (
+    <>
+      <div className="no-print" style={{ background: c.blanc, borderRadius: '12px', border: `0.5px solid ${c.bordure}`, overflow: 'hidden' }}>
+        <div style={{ padding: '16px 20px', borderBottom: isExpanded ? `0.5px solid ${c.bordure}` : 'none', display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '10px', background: isExpanded ? c.fond + '40' : c.blanc, transition: 'background 0.2s ease' }}>
+          <div
+            onClick={() => setIsExpanded(!isExpanded)}
+            style={{ display: 'flex', alignItems: 'center', gap: '10px', cursor: 'pointer' }}
+          >
+            <div style={{ fontSize: '13px', fontWeight: '500', color: c.texte }}>⚠️ Tableau des allergènes</div>
+            <Badge bg={'#FCEBEB'} color={'#A32D2D'} size="sm">
+              {fichesAvecAllergenes.length} fiche{fichesAvecAllergenes.length > 1 ? 's' : ''}
+            </Badge>
+          </div>
+          <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
+            {isExpanded && (
+              <>
+                <select value={filtreCategorie} onChange={(e) => setFiltreCategorie(e.target.value)} style={{ padding: '6px 10px', borderRadius: '8px', border: `0.5px solid ${c.bordure}`, fontSize: '12px', background: c.blanc, outline: 'none', color: c.texte, cursor: 'pointer' }}>
+                  <option value="toutes">Toutes les catégories</option>
+                  {theme.categories.map((cat) => <option key={cat} value={cat}>{cat}</option>)}
+                </select>
+                <select value={filtreSaison} onChange={(e) => setFiltreSaison(e.target.value)} style={{ padding: '6px 10px', borderRadius: '8px', border: `0.5px solid ${c.bordure}`, fontSize: '12px', background: c.blanc, outline: 'none', color: c.texte, cursor: 'pointer' }}>
+                  <option value="toutes">Toutes les saisons</option>
+                  {theme.saisons.map((s) => <option key={s} value={s}>{s}</option>)}
+                </select>
+                {lieux.length > 0 && (
+                  <select value={filtreLieu} onChange={(e) => setFiltreLieu(e.target.value)} style={{ padding: '6px 10px', borderRadius: '8px', border: `0.5px solid ${c.bordure}`, fontSize: '12px', background: c.blanc, outline: 'none', color: c.texte, cursor: 'pointer' }}>
+                    <option value="tous">Tous les lieux</option>
+                    {lieux.map((l) => <option key={l.id} value={l.id}>{l.emoji ? `${l.emoji} ${l.nom}` : l.nom}</option>)}
+                  </select>
+                )}
+                <button onClick={exportAllergenesExcel} style={{ padding: '6px 12px', background: c.vert, color: 'white', border: 'none', borderRadius: '8px', fontSize: '12px', fontWeight: '600', cursor: 'pointer' }}>📊 Excel</button>
+                <button onClick={() => window.print()} style={{ padding: '6px 12px', background: c.accent, color: c.principal, border: 'none', borderRadius: '8px', fontSize: '12px', fontWeight: '600', cursor: 'pointer' }}>🖨️ Imprimer</button>
+              </>
+            )}
+            <div
+              onClick={() => setIsExpanded(!isExpanded)}
+              style={{ fontSize: '16px', color: c.texteMuted, fontWeight: '300', cursor: 'pointer' }}
+            >
+              {isExpanded ? '− Masquer' : '+ Développer'}
+            </div>
+          </div>
+        </div>
+        {isExpanded && (
+          <div style={{ overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px', minWidth: '900px' }}>
+              <thead>
+                <tr style={{ background: c.principal }}>
+                  <th style={{ padding: '10px 12px', textAlign: 'left', fontSize: '11px', color: c.accent, fontWeight: '500', textTransform: 'uppercase', position: 'sticky', left: 0, background: c.principal, zIndex: 1, minWidth: '160px' }}>
+                    Fiche / Catégorie
+                  </th>
+                  {ALLERGENES.map((a) => (
+                    <th key={a.id} style={{ padding: '8px 4px', textAlign: 'center', fontSize: '10px', color: c.accent, fontWeight: '500', minWidth: '52px' }}>
+                      <div style={{ fontSize: '14px' }}>{a.emoji}</div>
+                      <div style={{ fontSize: '8px', textTransform: 'uppercase', letterSpacing: '0.5px', lineHeight: '1.2', marginTop: '2px' }}>{a.label}</div>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {fichesFiltreesAllergenes.map((fiche, i) => (
+                  <tr key={fiche.id} style={{ borderBottom: `0.5px solid ${c.bordure}`, background: i % 2 === 0 ? c.blanc : c.fond }}>
+                    <td style={{ padding: '10px 12px', position: 'sticky', left: 0, background: i % 2 === 0 ? c.blanc : c.fond, zIndex: 1 }}>
+                      <div style={{ fontWeight: '500', color: c.texte, fontSize: '13px' }}>{fiche.nom}</div>
+                      <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '2px' }}>{fiche.categorie}</div>
+                    </td>
+                    {ALLERGENES.map((a) => (
+                      <td key={a.id} style={{ padding: '8px 4px', textAlign: 'center' }}>
+                        {fiche.allergenes?.includes(a.id) ? (
+                          <div style={{ width: '20px', height: '20px', borderRadius: '50%', background: '#FCEBEB', border: '1.5px solid #A32D2D', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto', fontSize: '10px', color: '#A32D2D', fontWeight: '700' }}>✓</div>
+                        ) : (
+                          <div style={{ width: '20px', height: '20px', margin: '0 auto', opacity: 0.15, fontSize: '12px', textAlign: 'center', color: c.bordure }}>—</div>
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+                {fichesFiltreesAllergenes.length === 0 && (
+                  <tr>
+                    <td colSpan={ALLERGENES.length + 1} style={{ padding: '30px', textAlign: 'center', color: c.texteMuted, fontSize: '13px' }}>
+                      Aucune fiche avec allergènes
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Version impression */}
+      <div className="print-only dashboard-allergenes-print" style={{ fontFamily: 'sans-serif', color: '#1a1a1a', background: 'white', padding: '0' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderBottom: '2px solid #2C1810', paddingBottom: '12px', marginBottom: '16px' }}>
+          <div>
+            <div style={{ fontSize: '8px', letterSpacing: '3px', textTransform: 'uppercase', color: '#8B7355', marginBottom: '4px' }}>Tableau des allergènes — Fiches actives</div>
+            <div style={{ fontSize: '18px', fontWeight: '600', color: '#2C1810', fontFamily: 'Georgia, serif' }}>{params['nom_etablissement'] || 'La Fantaisie'}</div>
+            <div style={{ fontSize: '9px', color: '#8B7355', marginTop: '2px' }}>Imprimé le {today} — {fichesFiltreesAllergenes.length} fiche{fichesFiltreesAllergenes.length > 1 ? 's' : ''}</div>
+          </div>
+          <img
+            src={params['logo_url'] || '/skalcook_logo.svg'}
+            alt={params['nom_etablissement'] || 'Skalcook'}
+            style={{ height: '60px', objectFit: 'contain' }}
+          />
+        </div>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '9px', tableLayout: 'fixed' }}>
+          <thead>
+            <tr style={{ background: '#2C1810' }}>
+              <th style={{ padding: '6px 8px', textAlign: 'left', color: '#C4956A', fontWeight: '600', fontSize: '9px', textTransform: 'uppercase', width: '140px', wordWrap: 'break-word' }}>Fiche</th>
+              {ALLERGENES.map((a) => (
+                <th key={a.id} style={{ padding: '4px 2px', textAlign: 'center', color: '#C4956A', fontWeight: '600', fontSize: '7px', textTransform: 'uppercase', lineHeight: '1.2' }}>
+                  <div style={{ fontSize: '10px' }}>{a.emoji}</div>
+                  <div style={{ fontSize: '6px', marginTop: '1px' }}>{a.label.replace('Céréales/Gluten', 'Gluten').replace('Graines de sésame', 'Sésame').replace('Anhydride sulfureux', 'Sulfites').replace('Fruits à coque', 'F. à coque')}</div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {fichesFiltreesAllergenes.map((fiche, i) => (
+              <tr key={fiche.id} style={{ background: i % 2 === 0 ? 'white' : '#FAF9F6', borderBottom: '0.5px solid #e8e4dc' }}>
+                <td style={{ padding: '5px 8px', fontWeight: '500', color: '#2C1810', fontSize: '9px', wordWrap: 'break-word' }}>
+                  {fiche.nom}
+                  <div style={{ fontSize: '7px', color: '#8B7355', marginTop: '1px' }}>{fiche.categorie}</div>
+                </td>
+                {ALLERGENES.map((a) => (
+                  <td key={a.id} style={{ padding: '4px 2px', textAlign: 'center' }}>
+                    {fiche.allergenes?.includes(a.id) ? (
+                      <div style={{ width: '14px', height: '14px', borderRadius: '50%', background: '#FCEBEB', border: '1px solid #A32D2D', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto', fontSize: '8px', color: '#A32D2D', fontWeight: '700' }}>✓</div>
+                    ) : (
+                      <div style={{ color: '#ddd', fontSize: '8px', textAlign: 'center' }}>·</div>
+                    )}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div style={{ marginTop: '10px', borderTop: '1px solid #e8e4dc', paddingTop: '8px', fontSize: '7px', color: '#8B7355' }}>
+          <strong>Allergènes :</strong> {ALLERGENES.map((a) => `${a.emoji} ${a.label}`).join(' — ')}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/components/dashboard/widgets/SectionCrmEvenements.js
+++ b/components/dashboard/widgets/SectionCrmEvenements.js
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase, getClientId } from '../../../lib/supabase'
+import { Badge } from '../../ui'
+
+function todayIso() {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function formatDate(iso) {
+  if (!iso) return '—'
+  const d = new Date(`${iso}T00:00:00`)
+  return d.toLocaleDateString('fr-FR', { weekday: 'short', day: '2-digit', month: 'short' })
+}
+
+const STATUT_LABELS = {
+  demande: 'Demande',
+  devis_envoye: 'Devis envoyé',
+  degustation: 'Dégustation',
+  negociation: 'Négociation',
+  acompte: 'Acompte',
+  confirme: 'Confirmé',
+  realise: 'Réalisé',
+  facture: 'Facturé',
+  paye: 'Payé',
+}
+
+export default function SectionCrmEvenements({ c }) {
+  const [evenements, setEvenements] = useState([])
+  const [loading, setLoading] = useState(true)
+  const router = useRouter()
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const clientId = await getClientId()
+      if (!clientId) { setLoading(false); return }
+      const { data } = await supabase
+        .from('crm_evenements')
+        .select('id, titre, date_evenement, heure_debut, nb_convives, statut, crm_client_id')
+        .eq('client_id', clientId)
+        .gte('date_evenement', todayIso())
+        .not('statut', 'in', '(annule,perdu)')
+        .order('date_evenement', { ascending: true })
+        .limit(5)
+      if (cancelled) return
+      setEvenements(data || [])
+      setLoading(false)
+    })()
+    return () => { cancelled = true }
+  }, [])
+
+  return (
+    <div style={{ background: c.blanc, borderRadius: '12px', border: `0.5px solid ${c.bordure}`, overflow: 'hidden' }}>
+      <div style={{ padding: '16px 20px', borderBottom: `0.5px solid ${c.bordure}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={{ fontSize: '13px', fontWeight: '500', color: c.texte }}>📅 Événements à venir</div>
+        <span style={{ fontSize: '11px', color: c.texteMuted }}>5 prochains</span>
+      </div>
+      {loading ? (
+        <div style={{ padding: '24px', textAlign: 'center', color: c.texteMuted, fontSize: '13px' }}>Chargement…</div>
+      ) : evenements.length === 0 ? (
+        <div style={{ padding: '24px', textAlign: 'center', color: c.texteMuted, fontSize: '13px' }}>Aucun événement à venir</div>
+      ) : (
+        <div>
+          {evenements.map((ev, i) => (
+            <div
+              key={ev.id}
+              onClick={() => router.push(`/crm/evenements/${ev.id}`)}
+              style={{
+                padding: '12px 20px', cursor: 'pointer',
+                borderBottom: i < evenements.length - 1 ? `0.5px solid ${c.bordure}` : 'none',
+                display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '12px',
+                background: c.blanc,
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.background = c.fond)}
+              onMouseLeave={(e) => (e.currentTarget.style.background = c.blanc)}
+            >
+              <div style={{ minWidth: 0, flex: 1 }}>
+                <div style={{ fontSize: '13px', fontWeight: '500', color: c.texte, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {ev.titre || 'Sans titre'}
+                </div>
+                <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '2px' }}>
+                  {formatDate(ev.date_evenement)}
+                  {ev.heure_debut ? ` · ${ev.heure_debut.slice(0, 5)}` : ''}
+                  {ev.nb_convives ? ` · ${ev.nb_convives} convives` : ''}
+                </div>
+              </div>
+              <Badge bg={'#F0E8E0'} color={'#2C1810'} size="sm">
+                {STATUT_LABELS[ev.statut] || ev.statut}
+              </Badge>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/dashboard/widgets/SectionFichesAlerte.js
+++ b/components/dashboard/widgets/SectionFichesAlerte.js
@@ -1,0 +1,36 @@
+import { Badge } from '../../ui'
+
+export default function SectionFichesAlerte({ c, fichesAlerte, foodCostFiche, seuilOrange, onFicheClick }) {
+  return (
+    <div style={{ background: c.blanc, borderRadius: '12px', border: `0.5px solid ${c.bordure}`, overflow: 'hidden' }}>
+      <div style={{ padding: '16px 20px', borderBottom: `0.5px solid ${c.bordure}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={{ fontSize: '13px', fontWeight: '500', color: c.texte }}>🚨 Fiches en alerte</div>
+        <span style={{ fontSize: '11px', color: c.texteMuted }}>Food cost {'>'} {seuilOrange}%</span>
+      </div>
+      {fichesAlerte.length === 0 ? (
+        <div style={{ padding: '24px', textAlign: 'center', color: c.texteMuted, fontSize: '13px' }}>✓ Aucune fiche en alerte</div>
+      ) : (
+        <div style={{ maxHeight: '300px', overflowY: 'auto' }}>
+          {fichesAlerte.slice(0, 10).map((fiche, i) => {
+            const fc = foodCostFiche(fiche)
+            return (
+              <div
+                key={fiche.id}
+                onClick={() => onFicheClick(fiche.id)}
+                style={{ padding: '12px 20px', cursor: 'pointer', borderBottom: i < fichesAlerte.length - 1 ? `0.5px solid ${c.bordure}` : 'none', display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: c.blanc }}
+                onMouseEnter={(e) => (e.currentTarget.style.background = c.fond)}
+                onMouseLeave={(e) => (e.currentTarget.style.background = c.blanc)}
+              >
+                <div>
+                  <div style={{ fontSize: '13px', fontWeight: '500', color: c.texte }}>{fiche.nom}</div>
+                  <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '2px' }}>{fiche.categorie}</div>
+                </div>
+                <Badge bg={'#FCEBEB'} color={'#A32D2D'}>{fc.toFixed(1)}%</Badge>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/dashboard/widgets/SectionFichesParEspace.js
+++ b/components/dashboard/widgets/SectionFichesParEspace.js
@@ -1,0 +1,22 @@
+export default function SectionFichesParEspace({ c, fichesByCategorie, maxFiches }) {
+  return (
+    <div style={{ background: c.blanc, borderRadius: '12px', border: `0.5px solid ${c.bordure}`, overflow: 'hidden' }}>
+      <div style={{ padding: '16px 20px', borderBottom: `0.5px solid ${c.bordure}` }}>
+        <div style={{ fontSize: '13px', fontWeight: '500', color: c.texte }}>📊 Fiches par espace</div>
+      </div>
+      <div style={{ padding: '16px 20px' }}>
+        {fichesByCategorie.map(({ cat, nb }) => (
+          <div key={cat} style={{ marginBottom: '10px' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }}>
+              <span style={{ fontSize: '12px', color: c.texte, fontWeight: '500' }}>{cat}</span>
+              <span style={{ fontSize: '12px', color: c.texteMuted }}>{nb}</span>
+            </div>
+            <div style={{ background: c.fond, borderRadius: '20px', height: '6px', overflow: 'hidden' }}>
+              <div style={{ background: c.accent, height: '100%', borderRadius: '20px', width: `${(nb / maxFiches) * 100}%`, transition: 'width 0.5s ease' }} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/widgets/SectionPrixModifies.js
+++ b/components/dashboard/widgets/SectionPrixModifies.js
@@ -1,0 +1,69 @@
+import { useState } from 'react'
+import { Badge } from '../../ui'
+
+export default function SectionPrixModifies({ c, ingredientsPrixHausse }) {
+  const [isExpanded, setIsExpanded] = useState(false)
+  if (ingredientsPrixHausse.length === 0) return null
+
+  return (
+    <div style={{ background: c.blanc, borderRadius: '12px', border: `0.5px solid ${c.bordure}`, overflow: 'hidden' }}>
+      <div
+        onClick={() => setIsExpanded(!isExpanded)}
+        style={{
+          padding: '16px 20px',
+          borderBottom: isExpanded ? `0.5px solid ${c.bordure}` : 'none',
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+          cursor: 'pointer',
+          background: isExpanded ? c.fond + '40' : c.blanc,
+          transition: 'background 0.2s ease',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <div style={{ fontSize: '13px', fontWeight: '500', color: c.texte }}>📈 Ingrédients avec prix modifiés récemment</div>
+          <Badge bg={'#FAEEDA'} color={'#854F0B'} size="sm">
+            {ingredientsPrixHausse.length} alertes
+          </Badge>
+        </div>
+        <div style={{ fontSize: '16px', color: c.texteMuted, fontWeight: '300' }}>
+          {isExpanded ? '− Masquer' : '+ Développer'}
+        </div>
+      </div>
+      {isExpanded && (
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '13px' }}>
+            <thead>
+              <tr style={{ background: c.fond }}>
+                {['Ingrédient', 'Ancien prix', 'Nouveau prix', 'Variation', 'Date'].map((h, i) => (
+                  <th key={h} style={{ padding: '10px 16px', textAlign: i === 0 ? 'left' : 'right', fontSize: '11px', color: c.texteMuted, fontWeight: '500', textTransform: 'uppercase', borderBottom: `0.5px solid ${c.bordure}` }}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {ingredientsPrixHausse.map((ing, i) => {
+                const variation = ing.prix_precedent && ing.prix_kg ? ((ing.prix_kg - ing.prix_precedent) / ing.prix_precedent * 100) : null
+                const hausse = variation > 0
+                return (
+                  <tr key={ing.id} style={{ borderBottom: i < ingredientsPrixHausse.length - 1 ? `0.5px solid ${c.bordure}` : 'none', background: c.blanc }}>
+                    <td style={{ padding: '10px 16px', fontWeight: '500', color: c.texte }}>{ing.nom}</td>
+                    <td style={{ padding: '10px 16px', textAlign: 'right', color: c.texteMuted }}>{ing.prix_precedent ? `${Number(ing.prix_precedent).toFixed(2)} €` : '—'}</td>
+                    <td style={{ padding: '10px 16px', textAlign: 'right', color: c.texte }}>{ing.prix_kg ? `${Number(ing.prix_kg).toFixed(2)} €` : '—'}</td>
+                    <td className="sk-td sk-td--right">
+                      {variation !== null && (
+                        <Badge bg={hausse ? '#FCEBEB' : '#EAF3DE'} color={hausse ? '#A32D2D' : '#3B6D11'} size="sm">
+                          {hausse ? '+' : ''}{variation.toFixed(1)}%
+                        </Badge>
+                      )}
+                    </td>
+                    <td style={{ padding: '10px 16px', textAlign: 'right', color: c.texteMuted, fontSize: '12px' }}>
+                      {ing.prix_updated_at ? new Date(ing.prix_updated_at).toLocaleDateString('fr-FR') : '—'}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/dashboardPreferences.js
+++ b/lib/dashboardPreferences.js
@@ -3,19 +3,23 @@ import { supabase, getClientId } from './supabase'
 // Source de vérité des widgets du dashboard cuisine (/dashboard).
 // L'ordre ici = ordre par défaut si l'user n'a pas encore de prefs.
 // `defaultVisible: false` = widget disponible mais masqué par défaut.
+// `size`: 'kpi' (cellule dans la grille KPI), 'half' (demi-largeur, paire
+// avec une autre 'half' consécutive visible), 'full' (pleine largeur).
 export const WIDGET_CATALOG = [
-  { id: 'kpi-food-cost-moyen',       label: 'KPI — Food cost moyen',              group: 'kpi',     defaultVisible: true },
-  { id: 'kpi-fiches-actives',        label: 'KPI — Fiches actives',                group: 'kpi',     defaultVisible: true },
-  { id: 'kpi-fiches-alerte',         label: 'KPI — Fiches en alerte',              group: 'kpi',     defaultVisible: true },
-  { id: 'kpi-prix-modifies',         label: 'KPI — Prix modifiés',                 group: 'kpi',     defaultVisible: true },
-  { id: 'kpi-ca-mtd',                label: 'KPI — CA cumulé mois en cours',       group: 'kpi',     defaultVisible: false },
-  { id: 'kpi-marge-mtd',             label: 'KPI — Marge mois en cours',           group: 'kpi',     defaultVisible: false },
-  { id: 'section-fiches-alerte',     label: 'Section — Fiches en alerte',          group: 'section', defaultVisible: true },
-  { id: 'section-fiches-par-espace', label: 'Section — Fiches par espace',         group: 'section', defaultVisible: true },
-  { id: 'section-prix-modifies',     label: 'Section — Ingrédients prix modifiés', group: 'section', defaultVisible: true },
-  { id: 'section-crm-evenements',    label: 'Section — Événements CRM à venir',    group: 'section', defaultVisible: false },
-  { id: 'section-allergenes',        label: 'Tableau — Allergènes',                group: 'section', defaultVisible: true },
+  { id: 'kpi-food-cost-moyen',       label: 'KPI — Food cost moyen',              size: 'kpi',  defaultVisible: true },
+  { id: 'kpi-fiches-actives',        label: 'KPI — Fiches actives',                size: 'kpi',  defaultVisible: true },
+  { id: 'kpi-fiches-alerte',         label: 'KPI — Fiches en alerte',              size: 'kpi',  defaultVisible: true },
+  { id: 'kpi-prix-modifies',         label: 'KPI — Prix modifiés',                 size: 'kpi',  defaultVisible: true },
+  { id: 'kpi-ca-mtd',                label: 'KPI — CA cumulé mois en cours',       size: 'kpi',  defaultVisible: false },
+  { id: 'kpi-marge-mtd',             label: 'KPI — Marge mois en cours',           size: 'kpi',  defaultVisible: false },
+  { id: 'section-fiches-alerte',     label: 'Section — Fiches en alerte',          size: 'half', defaultVisible: true },
+  { id: 'section-fiches-par-espace', label: 'Section — Fiches par espace',         size: 'half', defaultVisible: true },
+  { id: 'section-prix-modifies',     label: 'Section — Ingrédients prix modifiés', size: 'full', defaultVisible: true },
+  { id: 'section-crm-evenements',    label: 'Section — Événements CRM à venir',    size: 'half', defaultVisible: false },
+  { id: 'section-allergenes',        label: 'Tableau — Allergènes',                size: 'full', defaultVisible: true },
 ]
+
+export const WIDGET_BY_ID = Object.fromEntries(WIDGET_CATALOG.map((w) => [w.id, w]))
 
 export const WIDGET_IDS = WIDGET_CATALOG.map((w) => w.id)
 

--- a/lib/dashboardPreferences.js
+++ b/lib/dashboardPreferences.js
@@ -5,21 +5,30 @@ import { supabase, getClientId } from './supabase'
 // `defaultVisible: false` = widget disponible mais masqué par défaut.
 // `size`: 'kpi' (cellule dans la grille KPI), 'half' (demi-largeur, paire
 // avec une autre 'half' consécutive visible), 'full' (pleine largeur).
+// `requiresModule`: id de module (clients.modules_actifs) nécessaire ;
+// si absent = widget toujours disponible.
 export const WIDGET_CATALOG = [
   { id: 'kpi-food-cost-moyen',       label: 'KPI — Food cost moyen',              size: 'kpi',  defaultVisible: true },
   { id: 'kpi-fiches-actives',        label: 'KPI — Fiches actives',                size: 'kpi',  defaultVisible: true },
   { id: 'kpi-fiches-alerte',         label: 'KPI — Fiches en alerte',              size: 'kpi',  defaultVisible: true },
   { id: 'kpi-prix-modifies',         label: 'KPI — Prix modifiés',                 size: 'kpi',  defaultVisible: true },
-  { id: 'kpi-ca-mtd',                label: 'KPI — CA cumulé mois en cours',       size: 'kpi',  defaultVisible: false },
-  { id: 'kpi-marge-mtd',             label: 'KPI — Marge mois en cours',           size: 'kpi',  defaultVisible: false },
+  { id: 'kpi-ca-mtd',                label: 'KPI — CA cumulé mois en cours',       size: 'kpi',  defaultVisible: false, requiresModule: 'gestion' },
+  { id: 'kpi-marge-mtd',             label: 'KPI — Marge mois en cours',           size: 'kpi',  defaultVisible: false, requiresModule: 'gestion' },
   { id: 'section-fiches-alerte',     label: 'Section — Fiches en alerte',          size: 'half', defaultVisible: true },
   { id: 'section-fiches-par-espace', label: 'Section — Fiches par espace',         size: 'half', defaultVisible: true },
   { id: 'section-prix-modifies',     label: 'Section — Ingrédients prix modifiés', size: 'full', defaultVisible: true },
-  { id: 'section-crm-evenements',    label: 'Section — Événements CRM à venir',    size: 'half', defaultVisible: false },
+  { id: 'section-crm-evenements',    label: 'Section — Événements CRM à venir',    size: 'half', defaultVisible: false, requiresModule: 'crm' },
   { id: 'section-allergenes',        label: 'Tableau — Allergènes',                size: 'full', defaultVisible: true },
 ]
 
 export const WIDGET_BY_ID = Object.fromEntries(WIDGET_CATALOG.map((w) => [w.id, w]))
+
+// Un widget sans requiresModule est toujours disponible.
+// Avec requiresModule : uniquement si l'id est dans modules_actifs du tenant.
+export function isWidgetAvailable(widget, modulesActifs) {
+  if (!widget?.requiresModule) return true
+  return Array.isArray(modulesActifs) && modulesActifs.includes(widget.requiresModule)
+}
 
 export const WIDGET_IDS = WIDGET_CATALOG.map((w) => w.id)
 

--- a/lib/dashboardPreferences.js
+++ b/lib/dashboardPreferences.js
@@ -1,0 +1,110 @@
+import { supabase, getClientId } from './supabase'
+
+// Source de vérité des widgets du dashboard cuisine (/dashboard).
+// L'ordre ici = ordre par défaut si l'user n'a pas encore de prefs.
+// `defaultVisible: false` = widget disponible mais masqué par défaut.
+export const WIDGET_CATALOG = [
+  { id: 'kpi-food-cost-moyen',       label: 'KPI — Food cost moyen',              group: 'kpi',     defaultVisible: true },
+  { id: 'kpi-fiches-actives',        label: 'KPI — Fiches actives',                group: 'kpi',     defaultVisible: true },
+  { id: 'kpi-fiches-alerte',         label: 'KPI — Fiches en alerte',              group: 'kpi',     defaultVisible: true },
+  { id: 'kpi-prix-modifies',         label: 'KPI — Prix modifiés',                 group: 'kpi',     defaultVisible: true },
+  { id: 'kpi-ca-mtd',                label: 'KPI — CA cumulé mois en cours',       group: 'kpi',     defaultVisible: false },
+  { id: 'kpi-marge-mtd',             label: 'KPI — Marge mois en cours',           group: 'kpi',     defaultVisible: false },
+  { id: 'section-fiches-alerte',     label: 'Section — Fiches en alerte',          group: 'section', defaultVisible: true },
+  { id: 'section-fiches-par-espace', label: 'Section — Fiches par espace',         group: 'section', defaultVisible: true },
+  { id: 'section-prix-modifies',     label: 'Section — Ingrédients prix modifiés', group: 'section', defaultVisible: true },
+  { id: 'section-crm-evenements',    label: 'Section — Événements CRM à venir',    group: 'section', defaultVisible: false },
+  { id: 'section-allergenes',        label: 'Tableau — Allergènes',                group: 'section', defaultVisible: true },
+]
+
+export const WIDGET_IDS = WIDGET_CATALOG.map((w) => w.id)
+
+export const DEFAULT_LAYOUT = WIDGET_CATALOG.map((w) => ({
+  id: w.id,
+  visible: w.defaultVisible,
+}))
+
+// Fusion d'un layout stocké avec le catalog : on jette les ids inconnus
+// (widget supprimé du catalog) et on ajoute à la fin les widgets du catalog
+// pas encore connus (nouveau widget livré après que l'user a sauvegardé).
+export function reconcileLayout(storedLayout) {
+  const known = new Set(WIDGET_IDS)
+  const seen = new Set()
+  const merged = []
+
+  if (Array.isArray(storedLayout)) {
+    for (const entry of storedLayout) {
+      if (!entry || typeof entry.id !== 'string') continue
+      if (!known.has(entry.id) || seen.has(entry.id)) continue
+      merged.push({ id: entry.id, visible: entry.visible !== false })
+      seen.add(entry.id)
+    }
+  }
+
+  for (const w of WIDGET_CATALOG) {
+    if (seen.has(w.id)) continue
+    merged.push({ id: w.id, visible: w.defaultVisible })
+  }
+
+  return merged
+}
+
+// Récupère le layout réconcilié pour l'user courant sur le tenant courant.
+// Retourne toujours un array valide (jamais null) grâce à reconcileLayout.
+export async function getDashboardLayout() {
+  const clientId = await getClientId()
+  if (!clientId) return reconcileLayout(null)
+
+  const { data: userData } = await supabase.auth.getUser()
+  const userId = userData?.user?.id
+  if (!userId) return reconcileLayout(null)
+
+  const { data, error } = await supabase
+    .from('user_dashboard_preferences')
+    .select('layout')
+    .eq('user_id', userId)
+    .eq('client_id', clientId)
+    .maybeSingle()
+
+  if (error || !data) return reconcileLayout(null)
+  return reconcileLayout(data.layout)
+}
+
+// Upsert du layout. On ne stocke que des entrées valides (ids du catalog).
+export async function saveDashboardLayout(layout) {
+  const clientId = await getClientId()
+  if (!clientId) throw new Error('Aucun établissement actif')
+
+  const { data: userData } = await supabase.auth.getUser()
+  const userId = userData?.user?.id
+  if (!userId) throw new Error('Utilisateur non authentifié')
+
+  const clean = reconcileLayout(layout)
+
+  const { error } = await supabase
+    .from('user_dashboard_preferences')
+    .upsert(
+      { user_id: userId, client_id: clientId, layout: clean },
+      { onConflict: 'user_id,client_id' }
+    )
+
+  if (error) throw error
+  return clean
+}
+
+// Remise aux valeurs par défaut : on supprime la ligne.
+// Au prochain load, getDashboardLayout() retournera DEFAULT_LAYOUT.
+export async function resetDashboardLayout() {
+  const clientId = await getClientId()
+  if (!clientId) return
+
+  const { data: userData } = await supabase.auth.getUser()
+  const userId = userData?.user?.id
+  if (!userId) return
+
+  await supabase
+    .from('user_dashboard_preferences')
+    .delete()
+    .eq('user_id', userId)
+    .eq('client_id', clientId)
+}

--- a/lib/dashboardPreferences.js
+++ b/lib/dashboardPreferences.js
@@ -14,6 +14,7 @@ export const WIDGET_CATALOG = [
   { id: 'kpi-prix-modifies',         label: 'KPI — Prix modifiés',                 size: 'kpi',  defaultVisible: true },
   { id: 'kpi-ca-mtd',                label: 'KPI — CA cumulé mois en cours',       size: 'kpi',  defaultVisible: false, requiresModule: 'gestion' },
   { id: 'kpi-marge-mtd',             label: 'KPI — Marge mois en cours',           size: 'kpi',  defaultVisible: false, requiresModule: 'gestion' },
+  { id: 'kpi-avis-note',             label: 'KPI — Note moyenne des avis',         size: 'kpi',  defaultVisible: false, requiresModule: 'avis' },
   { id: 'section-fiches-alerte',     label: 'Section — Fiches en alerte',          size: 'half', defaultVisible: true },
   { id: 'section-fiches-par-espace', label: 'Section — Fiches par espace',         size: 'half', defaultVisible: true },
   { id: 'section-prix-modifies',     label: 'Section — Ingrédients prix modifiés', size: 'full', defaultVisible: true },

--- a/supabase/migrations/20260419010000_user_dashboard_preferences.sql
+++ b/supabase/migrations/20260419010000_user_dashboard_preferences.sql
@@ -1,0 +1,67 @@
+-- ============================================================================
+-- user_dashboard_preferences : layout personnalisé du dashboard par user et
+-- par tenant.
+--
+-- layout = jsonb array dans l'ordre d'affichage voulu :
+--   [{ "id": "kpi-food-cost-moyen", "visible": true }, ...]
+--
+-- Si pas de ligne pour un (user_id, client_id) : le dashboard utilise le
+-- defaultLayout côté client (ordre actuel, tout visible).
+--
+-- Un user qui a accès à plusieurs établissements a un layout distinct
+-- par tenant (d'où la clé unique composée).
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.user_dashboard_preferences (
+  id         uuid        DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id    uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  client_id  uuid        NOT NULL REFERENCES public.clients(id) ON DELETE CASCADE,
+  layout     jsonb       NOT NULL DEFAULT '[]'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, client_id)
+);
+
+CREATE INDEX IF NOT EXISTS user_dashboard_preferences_user_client_idx
+  ON public.user_dashboard_preferences (user_id, client_id);
+
+-- ─── Trigger updated_at ─────────────────────────────────────────────────────
+DROP TRIGGER IF EXISTS user_dashboard_preferences_set_updated_at ON public.user_dashboard_preferences;
+CREATE TRIGGER user_dashboard_preferences_set_updated_at
+  BEFORE UPDATE ON public.user_dashboard_preferences
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at_timestamp();
+
+-- ─── RLS ────────────────────────────────────────────────────────────────────
+ALTER TABLE public.user_dashboard_preferences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY user_dashboard_preferences_select ON public.user_dashboard_preferences
+  FOR SELECT TO authenticated
+  USING (
+    auth.uid() = user_id
+    AND public.user_has_client_access(client_id)
+  );
+
+CREATE POLICY user_dashboard_preferences_insert ON public.user_dashboard_preferences
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    auth.uid() = user_id
+    AND public.user_has_client_access(client_id)
+  );
+
+CREATE POLICY user_dashboard_preferences_update ON public.user_dashboard_preferences
+  FOR UPDATE TO authenticated
+  USING (
+    auth.uid() = user_id
+    AND public.user_has_client_access(client_id)
+  )
+  WITH CHECK (
+    auth.uid() = user_id
+    AND public.user_has_client_access(client_id)
+  );
+
+CREATE POLICY user_dashboard_preferences_delete ON public.user_dashboard_preferences
+  FOR DELETE TO authenticated
+  USING (
+    auth.uid() = user_id
+    AND public.user_has_client_access(client_id)
+  );


### PR DESCRIPTION
## Summary
- Chaque user peut maintenant choisir quels widgets afficher sur `/dashboard` et dans quel ordre (par tenant, donc distinct s'il a accès à plusieurs établissements).
- Ajoute 3 widgets optionnels : CA cumulé du mois en cours, Marge du mois en cours, Événements CRM à venir.

## Changes
- **Étape 1 — Migration + helper** : nouvelle table `user_dashboard_preferences` (user_id, client_id, layout jsonb) avec RLS stricte (`auth.uid() = user_id AND user_has_client_access(client_id)`). `lib/dashboardPreferences.js` expose `WIDGET_CATALOG`, `getDashboardLayout`, `saveDashboardLayout`, `resetDashboardLayout`, avec `reconcileLayout` pour tolérer les layouts stockés obsolètes (widget supprimé du catalog = ignoré, nouveau widget ajouté = appended avec son `defaultVisible`).
- **Étape 2 — Refactor widgets** : `app/dashboard/page.js` découpé en composants `components/dashboard/widgets/*`. La page est désormais un assembleur : `layout.filter(visible).map(renderWidget)`. Grille dynamique : KPIs en `repeat(min(n,4), 1fr)`, sections `half` consécutives auto-pairées en deux colonnes, sinon pleine largeur. Comportement visuel identique en layout par défaut.
- **Étape 3 — UI personnalisation** : bouton ⚙ dans le header du dashboard → `DashboardCustomizeModal`. Checkbox visible/masqué + flèches ↑↓ pour réordonner (intra-groupe KPIs / intra-groupe Sections, puisque le rendu groupe déjà KPIs avant sections). Bouton "Rétablir les valeurs par défaut" (supprime la ligne). Fermeture sur Escape + backdrop.
- **Étape 4 — Nouveaux widgets** :
  - `KpiCaMtd` : `SUM(qte × prix_vente_net)` sur `ventes_journalieres` du mois en cours.
  - `KpiMargeMtd` : marge brute sur les ventes dont la fiche a un `cout_portion` connu, avec marge % sur ce périmètre.
  - `SectionCrmEvenements` : 5 prochains `crm_evenements` (`date_evenement >= today`, statut ∉ {annule, perdu}).
  - Tous `defaultVisible: false` → l'user les active via la modale, la vue par défaut reste inchangée pour les users existants.

La migration a déjà été appliquée sur le projet Supabase main (MCP). Advisors Supabase : zéro alerte sur la nouvelle table.

## Test plan
- [ ] Ouvrir `/dashboard` sur un compte existant : rendu identique à avant (KPIs + sections + tableau allergènes dans le même ordre).
- [ ] Cliquer sur ⚙ Personnaliser → la modale s'ouvre avec la liste complète des widgets regroupés (KPIs / Sections).
- [ ] Décocher "Tableau — Allergènes" → Enregistrer → la section disparaît. Reload → toujours masquée.
- [ ] Activer "KPI — CA cumulé mois en cours" + "KPI — Marge mois en cours" → les 2 KPIs apparaissent avec des chiffres cohérents par rapport à `/controle-gestion/marges`.
- [ ] Activer "Section — Événements CRM à venir" → affiche les 5 prochains événements, clic → ouvre la page événement.
- [ ] Flèches ↑↓ dans la modale : réorganiser l'ordre des KPIs → impact visible après Enregistrer.
- [ ] Bouton "Rétablir les valeurs par défaut" → retour à l'état initial (widgets de base visibles, nouveaux widgets masqués).
- [ ] RLS : se connecter avec un user B, vérifier qu'il ne voit pas les prefs du user A (layout par défaut au premier accès).
- [ ] Multi-tenant : un user superadmin qui bascule entre 2 clients voit un layout distinct par tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)