### PR TITLE
fix(superadmin): route client writes through service_role API

### DIFF
--- a/app/api/superadmin/create-client/route.ts
+++ b/app/api/superadmin/create-client/route.ts
@@ -1,0 +1,12 @@
+import { apiHandler } from '../../../../lib/apiHandler'
+import { createClientSchema } from '../../../../lib/validators/admin.schema'
+import { createClient } from '../../../../lib/services/admin.service'
+
+export const POST = apiHandler({
+  schema: createClientSchema,
+  guard: 'superadmin',
+  handler: async ({ data, db }) => {
+    const result = await createClient(db, data)
+    return Response.json(result)
+  },
+})

--- a/app/api/superadmin/update-client-settings/route.ts
+++ b/app/api/superadmin/update-client-settings/route.ts
@@ -1,0 +1,12 @@
+import { apiHandler } from '../../../../lib/apiHandler'
+import { updateClientSettingsSchema } from '../../../../lib/validators/admin.schema'
+import { updateClientSettings } from '../../../../lib/services/admin.service'
+
+export const POST = apiHandler({
+  schema: updateClientSettingsSchema,
+  guard: 'superadmin',
+  handler: async ({ data, db }) => {
+    const result = await updateClientSettings(db, data)
+    return Response.json(result)
+  },
+})

--- a/app/superadmin/page.js
+++ b/app/superadmin/page.js
@@ -168,20 +168,34 @@ export default function SuperAdminPage() {
       seuil_vert_boissons: parseFloat(seuilVertBoissons), seuil_orange_boissons: parseFloat(seuilOrangeBoissons),
     }
 
+    const { data: { session } } = await supabase.auth.getSession()
+    if (!session?.access_token) { setError('Session expirée. Reconnectez-vous.'); setSaving(false); return }
+    const authHeaders = { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` }
+
     if (vue === 'nouveau') {
-      const { data: client, error: err } = await supabase.from('clients').insert([payload]).select().single()
-      if (err) { setError('Erreur : ' + err.message); setSaving(false); return }
-      if (logoFile) {
-        const logoUrl = await uploadLogo(client.id)
-        await supabase.from('clients').update({ logo_url: logoUrl }).eq('id', client.id)
+      const res = await fetch('/api/superadmin/create-client', {
+        method: 'POST', headers: authHeaders, body: JSON.stringify(payload),
+      })
+      const json = await res.json().catch(() => ({}))
+      if (!res.ok) { setError('Erreur : ' + (json?.error || 'création impossible')); setSaving(false); return }
+      const newClient = json?.client
+      if (logoFile && newClient?.id) {
+        const logoUrl = await uploadLogo(newClient.id)
+        await fetch('/api/superadmin/update-client-settings', {
+          method: 'POST', headers: authHeaders,
+          body: JSON.stringify({ id: newClient.id, logo_url: logoUrl }),
+        })
       }
       setSuccess(`✓ Établissement "${nomEtablissement}" créé avec succès !`)
     } else {
       let logoUrl = logoExistant
       if (logoFile) logoUrl = await uploadLogo(clientSelectionne.id)
-      payload.logo_url = logoUrl
-      const { error: err } = await supabase.from('clients').update(payload).eq('id', clientSelectionne.id)
-      if (err) { setError('Erreur : ' + err.message); setSaving(false); return }
+      const res = await fetch('/api/superadmin/update-client-settings', {
+        method: 'POST', headers: authHeaders,
+        body: JSON.stringify({ id: clientSelectionne.id, ...payload, logo_url: logoUrl }),
+      })
+      const json = await res.json().catch(() => ({}))
+      if (!res.ok) { setError('Erreur : ' + (json?.error || 'mise à jour impossible')); setSaving(false); return }
       setSuccess(`✓ Établissement "${nomEtablissement}" mis à jour !`)
     }
 
@@ -191,7 +205,13 @@ export default function SuperAdminPage() {
   }
 
   const toggleActifClient = async (clientId, actifActuel) => {
-    await supabase.from('clients').update({ actif: !actifActuel }).eq('id', clientId)
+    const { data: { session } } = await supabase.auth.getSession()
+    if (!session?.access_token) return
+    await fetch('/api/superadmin/update-client-settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
+      body: JSON.stringify({ id: clientId, actif: !actifActuel }),
+    })
     await loadClients()
   }
 

--- a/lib/services/admin.service.ts
+++ b/lib/services/admin.service.ts
@@ -4,7 +4,7 @@
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { CreateUserInput, CreateGlobalUserInput, UpdateUserInput, UpdateClientInput } from '../validators/admin.schema'
+import type { CreateUserInput, CreateGlobalUserInput, UpdateUserInput, UpdateClientInput, CreateClientInput, UpdateClientSettingsInput } from '../validators/admin.schema'
 import { ValidationError, NotFoundError, ConflictError, ForbiddenError } from '../errors'
 
 // ── List users for a client ────────────────────────────────────────────────
@@ -310,6 +310,50 @@ export async function updateClient(db: SupabaseClient, input: UpdateClientInput)
 
   const { error } = await db.from('clients').update(dbUpdates).eq('id', id)
   if (error) throw new Error(error.message)
+
+  return { updated: true }
+}
+
+// ── Create client (establishment) ──────────────────────────────────────────
+// RLS bloque les INSERT sur `clients` côté client : on passe par service_role.
+
+export async function createClient(db: SupabaseClient, input: CreateClientInput) {
+  const { data, error } = await db
+    .from('clients')
+    .insert([input])
+    .select()
+    .single()
+
+  if (error) {
+    if (/duplicate|unique/i.test(error.message)) {
+      throw new ConflictError('Un établissement existe déjà avec ce slug.')
+    }
+    throw new Error(error.message)
+  }
+  return { client: data }
+}
+
+// ── Update client settings (full) ──────────────────────────────────────────
+
+export async function updateClientSettings(db: SupabaseClient, input: UpdateClientSettingsInput) {
+  const { id, ...updates } = input
+
+  const dbUpdates: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(updates)) {
+    if (value !== undefined) dbUpdates[key] = value
+  }
+
+  if (Object.keys(dbUpdates).length === 0) {
+    throw new ValidationError('Aucun champ à mettre à jour.')
+  }
+
+  const { error } = await db.from('clients').update(dbUpdates).eq('id', id)
+  if (error) {
+    if (/duplicate|unique/i.test(error.message)) {
+      throw new ConflictError('Un établissement existe déjà avec ce slug.')
+    }
+    throw new Error(error.message)
+  }
 
   return { updated: true }
 }

--- a/lib/validators/admin.schema.ts
+++ b/lib/validators/admin.schema.ts
@@ -64,6 +64,73 @@ export const createGlobalUserSchema = z.object({
 
 export type CreateGlobalUserInput = z.infer<typeof createGlobalUserSchema>
 
+// ── Client settings (create + full update) ────────────────────────────────
+// Used by /api/superadmin/create-client + /api/superadmin/update-client-settings
+// (writes to `clients` table are blocked by RLS côté client, donc on route tout
+// par le service_role).
+const hexColor = z.string().regex(/^#[0-9A-Fa-f]{6}$/, 'Couleur invalide')
+const slugFormat = z
+  .string()
+  .min(1)
+  .max(100)
+  .transform((s) => s.toLowerCase().trim().replace(/\s+/g, '-'))
+  .pipe(z.string().regex(/^[a-z0-9-]+$/, 'Slug invalide (a-z, 0-9, -)'))
+
+const clientSettingsFields = {
+  nom:                 z.string().min(1).max(255),
+  nom_etablissement:   z.string().min(1).max(255),
+  slug:                slugFormat,
+  adresse:             emptyToNull.optional().nullable(),
+  actif:               z.boolean(),
+  couleur_principale:  hexColor,
+  couleur_accent:      hexColor,
+  couleur_fond:        hexColor,
+  modules_actifs:      z.array(z.string()),
+  seuil_vert_cuisine:    z.number(),
+  seuil_orange_cuisine:  z.number(),
+  seuil_vert_boissons:   z.number(),
+  seuil_orange_boissons: z.number(),
+  logo_url:            emptyToNull.optional().nullable(),
+}
+
+export const createClientSchema = z.object({
+  nom:                 clientSettingsFields.nom,
+  nom_etablissement:   clientSettingsFields.nom_etablissement,
+  slug:                clientSettingsFields.slug,
+  adresse:             clientSettingsFields.adresse,
+  actif:               clientSettingsFields.actif.default(true),
+  couleur_principale:  clientSettingsFields.couleur_principale.default('#18181B'),
+  couleur_accent:      clientSettingsFields.couleur_accent.default('#6366F1'),
+  couleur_fond:        clientSettingsFields.couleur_fond.default('#F4F4F5'),
+  modules_actifs:      clientSettingsFields.modules_actifs.default([]),
+  seuil_vert_cuisine:    clientSettingsFields.seuil_vert_cuisine.default(28),
+  seuil_orange_cuisine:  clientSettingsFields.seuil_orange_cuisine.default(35),
+  seuil_vert_boissons:   clientSettingsFields.seuil_vert_boissons.default(22),
+  seuil_orange_boissons: clientSettingsFields.seuil_orange_boissons.default(28),
+})
+
+export type CreateClientInput = z.infer<typeof createClientSchema>
+
+export const updateClientSettingsSchema = z.object({
+  id:                  clientIdSchema,
+  nom:                 clientSettingsFields.nom.optional(),
+  nom_etablissement:   clientSettingsFields.nom_etablissement.optional(),
+  slug:                clientSettingsFields.slug.optional(),
+  adresse:             clientSettingsFields.adresse,
+  actif:               clientSettingsFields.actif.optional(),
+  couleur_principale:  clientSettingsFields.couleur_principale.optional(),
+  couleur_accent:      clientSettingsFields.couleur_accent.optional(),
+  couleur_fond:        clientSettingsFields.couleur_fond.optional(),
+  modules_actifs:      clientSettingsFields.modules_actifs.optional(),
+  seuil_vert_cuisine:    clientSettingsFields.seuil_vert_cuisine.optional(),
+  seuil_orange_cuisine:  clientSettingsFields.seuil_orange_cuisine.optional(),
+  seuil_vert_boissons:   clientSettingsFields.seuil_vert_boissons.optional(),
+  seuil_orange_boissons: clientSettingsFields.seuil_orange_boissons.optional(),
+  logo_url:            clientSettingsFields.logo_url,
+})
+
+export type UpdateClientSettingsInput = z.infer<typeof updateClientSettingsSchema>
+
 // ── Update client (legal info) ─────────────────────────────────────────────
 // Treat empty strings as "unset" so the page can send blank optional fields
 // without tripping the format validators (regex on siret/num_tva, email_contact).


### PR DESCRIPTION
## Summary
- Corrige l'erreur `new row violates row-level security policy for table "clients"` au clic sur « Nouvel établissement » dans `/superadmin`.
- La RLS n'autorise que le `SELECT` sur `public.clients` ; les `INSERT/UPDATE` faits côté browser via le client anon étaient bloqués, même pour un superadmin.
- Ajoute deux routes API superadmin qui passent par `service_role` (même pattern que `update-client/route.ts`) :
  - `POST /api/superadmin/create-client`
  - `POST /api/superadmin/update-client-settings`
- Refacto `saveClient` + `toggleActifClient` dans `app/superadmin/page.js` pour les appeler via Bearer token.
- Zéro migration SQL : on route simplement autour de la RLS existante.

## Test plan
- [ ] Sur `/superadmin`, créer un nouvel établissement avec slug/nom/nom_etablissement → l'établissement apparaît dans la liste.
- [ ] Upload d'un logo à la création → le logo s'affiche dans la liste après refresh.
- [ ] Éditer un établissement existant (couleurs, modules, seuils) → les changements persistent.
- [ ] Toggle actif/inactif depuis la liste → bascule correcte, pas d'erreur console.
- [ ] Vérifier qu'un user non-superadmin qui appellerait les routes reçoit 401/403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)