### PR TITLE
fix(admin): ignorer les lignes acces_clients avec user_id null

### DIFF
--- a/lib/services/admin.service.ts
+++ b/lib/services/admin.service.ts
@@ -10,13 +10,19 @@ import { ValidationError, NotFoundError, ConflictError, ForbiddenError } from '.
 // ── List users for a client ────────────────────────────────────────────────
 
 export async function listClientUsers(db: SupabaseClient, clientId: string) {
-  const { data: accesRows, error } = await db
+  const { data: rawAccesRows, error } = await db
     .from('acces_clients')
     .select('user_id, role')
     .eq('client_id', clientId)
 
   if (error) throw new Error(error.message)
-  if (!accesRows || accesRows.length === 0) return []
+  if (!rawAccesRows || rawAccesRows.length === 0) return []
+
+  // Ignore les lignes corrompues (user_id null) qui cassent les endpoints
+  // de modification/suppression en aval (Zod rejette user_id=null). Ces
+  // lignes orphelines doivent être nettoyées directement en DB.
+  const accesRows = rawAccesRows.filter((r) => typeof r.user_id === 'string' && r.user_id.length > 0)
+  if (accesRows.length === 0) return []
 
   const userIds = accesRows.map((r) => r.user_id)
   const { data: profils } = await db


### PR DESCRIPTION
## Contexte

Sur l'établissement Fantaisie, la ligne utilisateur 'test' refusait toute modification ou suppression. L'amélioration de visibilité des erreurs (#51) a révélé la cause :

> \"Données invalides — user_id: Invalid input: expected string, received null\"

La table \`acces_clients\` contenait une ligne avec \`user_id = NULL\`, probablement insérée manuellement via le dashboard Supabase ou résidu d'un ancien bug. Cette ligne apparaissait dans /admin mais toute action échouait en 400 (Zod valide user_id comme UUID).

## Fix

\`listClientUsers\` filtre désormais les lignes dont \`user_id\` n'est pas une chaîne non-vide **avant** de les renvoyer au frontend. La ligne fantôme disparaît du listing, plus d'erreur 400.

## Note

La ligne corrompue reste **physiquement en DB** (ce fix la masque juste de l'UI). Pour un nettoyage complet :

\`\`\`sql
DELETE FROM acces_clients WHERE user_id IS NULL;
\`\`\`

## Plan de test

- [ ] La page /admin de Fantaisie ne liste plus 'test'
- [ ] Les autres utilisateurs s'affichent et peuvent toujours être modifiés/supprimés
- [ ] Aucun impact sur les établissements sans ligne corrompue

🤖 Generated with [Claude Code](https://claude.com/claude-code)