### PR TITLE
fix(dashboard): responsive mobile - header + overflow

### DIFF
--- a/app/bar/dashboard/page.js
+++ b/app/bar/dashboard/page.js
@@ -81,21 +81,25 @@ export default function BarDashboardPage() {
   )
 
   return (
-    <div style={{ minHeight: '100vh', background: c.fond }}>
+    <div style={{ minHeight: '100vh', background: c.fond, overflowX: 'hidden' }}>
 
       <Navbar section="bar" />
 
       <div style={{ padding: isMobile ? '12px' : '24px', maxWidth: '1100px', margin: '0 auto' }}>
 
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
-          <div style={{ fontSize: '11px', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', fontWeight: '500' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px', flexWrap: 'wrap', marginBottom: '20px' }}>
+          <div style={{ fontSize: '11px', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', fontWeight: '500', flex: '1 1 auto', minWidth: 0 }}>
             🍸 Dashboard Bar — {params['nom_etablissement'] || 'La Fantaisie'}
           </div>
           {nom && (
-            <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-              <span style={{ fontSize: '12px', color: c.texteMuted }}>Bonjour, <strong style={{ color: c.texte }}>{nom}</strong></span>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+              {!isMobile && (
+                <span style={{ fontSize: '12px', color: c.texteMuted }}>Bonjour, <strong style={{ color: c.texte }}>{nom}</strong></span>
+              )}
               <Badge bg={'#EEEDFE'} color={'#3C3489'}>
-                {role === 'admin' ? 'Administrateur' : role === 'bar' ? 'Bar' : 'Directeur'}
+                {isMobile
+                  ? (role === 'admin' ? 'Admin' : role === 'bar' ? 'Bar' : 'Dir.')
+                  : (role === 'admin' ? 'Administrateur' : role === 'bar' ? 'Bar' : 'Directeur')}
               </Badge>
             </div>
           )}

--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -166,28 +166,30 @@ export default function DashboardPage() {
   }
 
   return (
-    <div style={{ minHeight: '100vh', background: c.fond }}>
+    <div style={{ minHeight: '100vh', background: c.fond, overflowX: 'hidden' }}>
       <Navbar section="cuisine" />
       <InventaireBanner />
 
       <div className="no-print" style={{ padding: isMobile ? '12px' : '24px', maxWidth: '1100px', margin: '0 auto' }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
-          <div style={{ fontSize: '11px', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', fontWeight: '500' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px', flexWrap: 'wrap', marginBottom: '20px' }}>
+          <div style={{ fontSize: '11px', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.04em', fontWeight: '500', flex: '1 1 auto', minWidth: 0 }}>
             Tableau de bord Cuisine — {params['nom_etablissement'] || 'La Fantaisie'}
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            {nom && (
-              <>
-                <span style={{ fontSize: '12px', color: c.texteMuted }}>
-                  Bonjour, <strong style={{ color: c.texte }}>{nom}</strong>
-                </span>
-                <Badge
-                  bg={role === 'admin' ? '#F0E8E0' : role === 'cuisine' ? '#EAF3DE' : '#FAEEDA'}
-                  color={role === 'admin' ? '#2C1810' : role === 'cuisine' ? '#3B6D11' : '#854F0B'}
-                >
-                  {role === 'admin' ? 'Administrateur' : role === 'cuisine' ? 'Cuisine' : 'Directeur'}
-                </Badge>
-              </>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+            {nom && !isMobile && (
+              <span style={{ fontSize: '12px', color: c.texteMuted }}>
+                Bonjour, <strong style={{ color: c.texte }}>{nom}</strong>
+              </span>
+            )}
+            {role && (
+              <Badge
+                bg={role === 'admin' ? '#F0E8E0' : role === 'cuisine' ? '#EAF3DE' : '#FAEEDA'}
+                color={role === 'admin' ? '#2C1810' : role === 'cuisine' ? '#3B6D11' : '#854F0B'}
+              >
+                {isMobile
+                  ? (role === 'admin' ? 'Admin' : role === 'cuisine' ? 'Cuisine' : 'Dir.')
+                  : (role === 'admin' ? 'Administrateur' : role === 'cuisine' ? 'Cuisine' : 'Directeur')}
+              </Badge>
             )}
             <button
               onClick={() => setShowCustomize(true)}


### PR DESCRIPTION
## Contexte

Sur mobile (375px), le dashboard avait un **scroll horizontal parasite** causé par le header qui dépassait la largeur du viewport. Résultat visuel :
- Titre clippé à gauche
- Contenu poussé à droite
- Modal "Personnaliser" mal positionné quand ouvert

Cause racine : le header avait un flex sans wrap contenant ~550px de contenu (titre + "Bonjour, Antony" + badge "Administrateur" + ⚙ Personnaliser) dans un viewport de 375px.

## Changements

`app/dashboard/page.js` + `app/bar/dashboard/page.js` :

1. **Layout du header adaptable** : `flexWrap: 'wrap'` + `gap: '10px'` pour autoriser les retours à la ligne ; `minWidth: 0` + `flex: '1 1 auto'` sur le titre pour qu'il soit compressible
2. **Mobile only** : masquage du "Bonjour, {nom}" (le rôle dans le badge suffit) 
3. **Libellés courts sur mobile** : `Administrateur` → `Admin`, `Directeur` → `Dir.`
4. **Défense en profondeur** : `overflowX: 'hidden'` sur le conteneur racine pour empêcher tout widget mal géré de créer un scroll horizontal

## Plan de test

- [ ] Dashboard cuisine mobile : header sur une ligne propre, pas de scroll horizontal
- [ ] Dashboard bar mobile : idem
- [ ] Dashboard desktop : inchangé (libellés complets, texte "Bonjour, Antony" visible)
- [ ] Modal "Personnaliser" : s'affiche correctement centré quand cliqué

🤖 Generated with [Claude Code](https://claude.com/claude-code)