### PR TITLE
feat(achats): refonte module achats (TVA ligne, statut avoir, UI import + autocomplete)

### DIFF
--- a/app/api/achats/create-ingredient/route.ts
+++ b/app/api/achats/create-ingredient/route.ts
@@ -7,7 +7,7 @@ export const POST = apiHandler({
   guard: 'adminOrSuperadmin',
   clientIdFrom: 'body.clientId',
   handler: async ({ data, db }) => {
-    const result = await createIngredient(db, data)
-    return Response.json(result)
+    const ingredient = await createIngredient(db, data)
+    return Response.json({ ingredient })
   },
 })

--- a/app/api/achats/parse-facture/route.ts
+++ b/app/api/achats/parse-facture/route.ts
@@ -2,7 +2,17 @@ import Anthropic from '@anthropic-ai/sdk'
 import { apiHandler } from '../../../../lib/apiHandler'
 import { z } from 'zod'
 
-const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+// Instancié lazy à la première requête : assure que process.env.ANTHROPIC_API_KEY
+// est bien chargé (utile en dev Turbopack) et permet de retourner une erreur
+// claire si la clé manque, au lieu d'un 500 opaque.
+let anthropicClient: Anthropic | null = null
+function getAnthropic(): Anthropic {
+  if (anthropicClient) return anthropicClient
+  const key = process.env.ANTHROPIC_API_KEY
+  if (!key) throw new Error('ANTHROPIC_API_KEY non défini côté serveur.')
+  anthropicClient = new Anthropic({ apiKey: key })
+  return anthropicClient
+}
 
 const schema = z.object({
   fileBase64: z.string().min(1, 'fileBase64 requis'),
@@ -21,12 +31,14 @@ Format attendu :
   "fournisseur": "Nom du fournisseur (string ou null)",
   "date_facture": "YYYY-MM-DD (string ou null)",
   "numero_facture": "Numéro ou référence de la facture (string ou null)",
+  "montant_tva_total": 33.50,
   "lignes": [
     {
       "designation": "Nom du produit tel qu'il apparaît sur la facture",
       "quantite": 5.0,
       "unite": "kg",
-      "prix_unitaire_ht": 2.50
+      "prix_unitaire_ht": 2.50,
+      "taux_tva": 5.5
     }
   ]
 }
@@ -34,6 +46,14 @@ Format attendu :
 Règles :
 - unite doit être l'unité standard la plus proche (kg, g, L, mL, pièce, carton, etc.)
 - prix_unitaire_ht est le prix HT PAR UNITÉ (pas le total de la ligne)
+- taux_tva est le taux de TVA applicable à la ligne en pourcentage (ex: 5.5 pour 5,5%, 10 pour 10%, 20 pour 20%).
+  Beaucoup de factures alimentaires distinguent plusieurs taux (5,5% pour les denrées,
+  10% pour la restauration sur place, 20% pour le non-alimentaire). Cherche les
+  colonnes "Code TVA", "Taux", "TVA" ou les codes G1/G2/G3 qui renvoient à un
+  tableau récap en pied de page. Si tu ne peux pas le déduire, utilise null.
+- montant_tva_total est le total de la TVA en euros tel qu'il apparaît au pied
+  de la facture (ligne "Montant TVA" ou "Total TVA"). Quand il y a plusieurs
+  taux, c'est la somme des TVA par taux. Pas en pourcentage. Si absent, null.
 - Si une valeur est absente ou illisible, utilise null
 - Ne retourne QUE le JSON, rien d'autre`
 
@@ -48,7 +68,7 @@ export const POST = apiHandler({
       ? { type: 'document' as const, source: { type: 'base64' as const, media_type: 'application/pdf' as const, data: fileBase64 } }
       : { type: 'image' as const, source: { type: 'base64' as const, media_type: mimeType as 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif', data: fileBase64 } }
 
-    const message = await anthropic.messages.create({
+    const message = await getAnthropic().messages.create({
       model: 'claude-opus-4-5',
       max_tokens: 2048,
       messages: [
@@ -62,7 +82,9 @@ export const POST = apiHandler({
       ],
     })
 
-    const rawText = (message.content[0] as { text: string }).text ?? ''
+    // Trouve le premier bloc de type 'text' (évite de planter si un thinking block précède)
+    const textBlock = message.content.find((b) => b.type === 'text')
+    const rawText = textBlock && 'text' in textBlock ? textBlock.text : ''
 
     let parsed: Record<string, unknown>
     try {
@@ -79,17 +101,34 @@ export const POST = apiHandler({
 
     const lignes = ((parsed.lignes as Array<Record<string, unknown>>) || [])
       .filter((l) => l && l.designation)
-      .map((l) => ({
-        designation: String(l.designation ?? '').trim(),
-        quantite: Number(l.quantite) || 1,
-        unite: String(l.unite ?? '').trim() || null,
-        prix_unitaire_ht: Number(l.prix_unitaire_ht) || 0,
-      }))
+      .map((l) => {
+        const tauxRaw = l.taux_tva
+        const taux = tauxRaw == null ? null : Number(tauxRaw)
+        return {
+          designation: String(l.designation ?? '').trim(),
+          quantite: Number(l.quantite) || 1,
+          unite: String(l.unite ?? '').trim() || null,
+          prix_unitaire_ht: Number(l.prix_unitaire_ht) || 0,
+          taux_tva: taux != null && Number.isFinite(taux) && taux >= 0 && taux <= 100 ? taux : null,
+        }
+      })
+
+    // Filtre date_facture : on n'accepte que YYYY-MM-DD valide, sinon null
+    // (évite que Claude renvoie "hier" ou "2024-13-45" et fasse péter l'insert)
+    const rawDate = (parsed.date_facture as string) ?? null
+    const dateFactureValide = rawDate && /^\d{4}-\d{2}-\d{2}$/.test(rawDate) && !Number.isNaN(Date.parse(rawDate))
+      ? rawDate
+      : null
+
+    const tvaTotalRaw = parsed.montant_tva_total
+    const tvaTotal = tvaTotalRaw == null ? null : Number(tvaTotalRaw)
+    const montantTvaTotal = tvaTotal != null && Number.isFinite(tvaTotal) && tvaTotal >= 0 ? tvaTotal : null
 
     return Response.json({
       fournisseur: (parsed.fournisseur as string) ?? null,
-      date_facture: (parsed.date_facture as string) ?? null,
+      date_facture: dateFactureValide,
       numero_facture: (parsed.numero_facture as string) ?? null,
+      montant_tva_total: montantTvaTotal,
       lignes,
     })
   },

--- a/app/controle-gestion/achats/[id]/page.js
+++ b/app/controle-gestion/achats/[id]/page.js
@@ -6,7 +6,7 @@ import { supabase, getClientId } from '../../../../lib/supabase'
 import { useIsMobile } from '../../../../lib/useIsMobile'
 import { useTheme } from '../../../../lib/useTheme'
 import { useRole } from '../../../../lib/useRole'
-import { normDesig, makeLigneId } from '../../../../lib/achatsHelpers'
+import { normDesig, makeLigneId, badgeStyleFor, statutLabel } from '../../../../lib/achatsHelpers'
 import Navbar from '../../../../components/Navbar'
 import BackButton from '../../../../components/BackButton'
 
@@ -48,6 +48,7 @@ export default function AchatsDetailPage() {
   const [editDate, setEditDate] = useState('')
   const [editStatut, setEditStatut] = useState('facture')
   const [editTauxTva, setEditTauxTva] = useState(5.5)
+  const [editMontantTvaSaisi, setEditMontantTvaSaisi] = useState(null)
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
 
@@ -82,7 +83,7 @@ export default function AchatsDetailPage() {
 
     const { data: fac, error: fErr } = await supabase
       .from('achats_factures')
-      .select('id, fournisseur, numero_facture, date_facture, total_ht, statut, taux_tva, fichier_url, created_at')
+      .select('id, fournisseur, numero_facture, date_facture, total_ht, statut, taux_tva, montant_tva, fichier_url, created_at')
       .eq('id', id)
       .eq('client_id', clientId)
       .maybeSingle()
@@ -93,7 +94,7 @@ export default function AchatsDetailPage() {
 
     const { data: rows, error: lErr } = await supabase
       .from('achats_lignes')
-      .select('id, designation, ingredient_id, quantite, unite, prix_unitaire_ht, remise, montant_ht, ingredients(nom)')
+      .select('id, designation, ingredient_id, quantite, unite, prix_unitaire_ht, remise, montant_ht, taux_tva, ingredients(nom)')
       .eq('facture_id', id)
       .eq('client_id', clientId)
       .order('designation')
@@ -137,6 +138,7 @@ export default function AchatsDetailPage() {
     setEditDate(facture.date_facture || '')
     setEditStatut(facture.statut || 'facture')
     setEditTauxTva(facture.taux_tva ?? 5.5)
+    setEditMontantTvaSaisi(facture.montant_tva != null ? Math.abs(Number(facture.montant_tva)) : null)
     setEditLignes(
       lignes.map((l) => ({
         _id: makeLigneId(),
@@ -145,6 +147,7 @@ export default function AchatsDetailPage() {
         unite: l.unite || '',
         prix_unitaire_ht: Number(l.prix_unitaire_ht) || 0,
         remise: Number(l.remise) || 0,
+        taux_tva: l.taux_tva != null ? Number(l.taux_tva) : null,
         ingredient_id: l.ingredient_id || null,
         ingredient_nom: l.ingredients?.nom || null,
       }))
@@ -163,7 +166,7 @@ export default function AchatsDetailPage() {
   const addEditLigne = () => {
     setEditLignes((prev) => [
       ...prev,
-      { _id: makeLigneId(), designation: '', quantite: 1, unite: '', prix_unitaire_ht: 0, remise: 0, ingredient_id: null, ingredient_nom: null },
+      { _id: makeLigneId(), designation: '', quantite: 1, unite: '', prix_unitaire_ht: 0, remise: 0, taux_tva: null, ingredient_id: null, ingredient_nom: null },
     ])
   }
   const linkIngredientToEdit = (lid, ing) => {
@@ -183,7 +186,20 @@ export default function AchatsDetailPage() {
     }, 0),
     [editLignes]
   )
-  const editMontantTva = editTotalHt * (Number(editTauxTva) || 0) / 100
+  // TVA par ligne : si la ligne a son propre taux, il prime ; sinon fallback sur editTauxTva.
+  const editMontantTvaCalcule = useMemo(
+    () => editLignes.reduce((s, l) => {
+      const r = Number(l.remise) || 0
+      const ht = (Number(l.quantite) || 0) * (Number(l.prix_unitaire_ht) || 0) * (1 - r / 100)
+      const taux = l.taux_tva != null && l.taux_tva !== '' ? Number(l.taux_tva) : Number(editTauxTva) || 0
+      return s + ht * taux / 100
+    }, 0),
+    [editLignes, editTauxTva]
+  )
+  // Saisie utilisateur prime sur le calcul.
+  const editMontantTva = editMontantTvaSaisi != null && editMontantTvaSaisi !== ''
+    ? Number(editMontantTvaSaisi)
+    : editMontantTvaCalcule
   const editTotalTtc = editTotalHt + editMontantTva
 
   const handleSaveEdit = async () => {
@@ -200,6 +216,7 @@ export default function AchatsDetailPage() {
           unite: l.unite || null,
           prix_unitaire_ht: Number(l.prix_unitaire_ht) || 0,
           remise: Number(l.remise) || 0,
+          taux_tva: l.taux_tva != null && l.taux_tva !== '' ? Number(l.taux_tva) : null,
         }))
       const res = await fetch('/api/achats/update-facture', {
         method: 'PATCH',
@@ -212,6 +229,7 @@ export default function AchatsDetailPage() {
           dateFacture: editDate,
           statut: editStatut,
           tauxTva: Number(editTauxTva) || 0,
+          montantTva: editMontantTvaSaisi != null && editMontantTvaSaisi !== '' ? Number(editMontantTvaSaisi) : null,
           lignes: lignesPayload,
         }),
       })
@@ -352,11 +370,20 @@ export default function AchatsDetailPage() {
                         <select style={inputS} value={editStatut} onChange={e => setEditStatut(e.target.value)}>
                           <option value="bl">Bon de livraison</option>
                           <option value="facture">Facture</option>
+                          <option value="avoir">Avoir</option>
                         </select>
                       </label>
                       <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: c.texteMuted, gridColumn: isMobile ? 'auto' : 'span 2' }}>
-                        TVA (%)
-                        <input style={{ ...inputS, maxWidth: 140 }} type="number" min="0" max="100" step="0.1" value={editTauxTva} onChange={e => setEditTauxTva(e.target.value)} />
+                        Total TVA (€)
+                        <input
+                          style={{ ...inputS, maxWidth: 200 }}
+                          type="number"
+                          min="0" step="0.01"
+                          value={editMontantTvaSaisi ?? ''}
+                          placeholder={formatEuro(editMontantTvaCalcule)}
+                          title="Saisissez le total TVA tel qu'il apparaît en pied de facture, ou laissez vide pour calculer automatiquement"
+                          onChange={e => setEditMontantTvaSaisi(e.target.value === '' ? null : e.target.value)}
+                        />
                       </label>
                       <div style={{ gridColumn: isMobile ? 'auto' : 'span 2', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
                         <div style={{ display: 'flex', gap: 16, fontSize: 13, color: c.texteMuted, fontVariantNumeric: 'tabular-nums' }}>
@@ -375,9 +402,7 @@ export default function AchatsDetailPage() {
                       <div>
                         <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4 }}>
                           <div style={{ fontSize: isMobile ? 18 : 22, fontWeight: 600, color: c.texte }}>{facture.fournisseur || '—'}</div>
-                          {isBl
-                            ? <span style={{ fontSize: 11, fontWeight: 600, padding: '2px 8px', borderRadius: 4, background: '#FEF3C7', color: '#92400E' }}>BL</span>
-                            : <span style={{ fontSize: 11, fontWeight: 600, padding: '2px 8px', borderRadius: 4, background: '#D1FAE5', color: '#065F46' }}>Facture</span>}
+                          <span style={badgeStyleFor(facture.statut)}>{statutLabel(facture.statut)}</span>
                         </div>
                         {facture.numero_facture && <div style={{ fontSize: 13, color: c.texteMuted }}>N° {facture.numero_facture}</div>}
                         <div style={{ fontSize: 13, color: c.texteMuted }}>{formatDate(facture.date_facture)}</div>
@@ -385,11 +410,22 @@ export default function AchatsDetailPage() {
                       <div style={{ textAlign: 'right' }}>
                         <div style={{ fontSize: 11, color: c.texteMuted, fontWeight: 500, textTransform: 'uppercase' }}>Total HT</div>
                         <div style={{ fontSize: isMobile ? 20 : 26, fontWeight: 600, color: c.texte }}>{formatEuro(ht)}</div>
-                        {facture.taux_tva != null && (
-                          <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 4, fontVariantNumeric: 'tabular-nums' }}>
-                            TVA {Number(facture.taux_tva).toLocaleString('fr-FR', { maximumFractionDigits: 2 })} % · TTC <strong style={{ color: c.texte }}>{formatEuro(ht * (1 + Number(facture.taux_tva) / 100))}</strong>
-                          </div>
-                        )}
+                        {(() => {
+                          // 1. Si la facture a un montant_tva saisi, il prime.
+                          // 2. Sinon, on calcule depuis les taux par ligne (avec fallback taux global).
+                          const tvaGlobale = Number(facture.taux_tva ?? 0)
+                          const montantTvaCalcule = lignes.reduce((s, l) => {
+                            const taux = l.taux_tva != null ? Number(l.taux_tva) : tvaGlobale
+                            return s + (Number(l.montant_ht) || 0) * taux / 100
+                          }, 0)
+                          const montantTva = facture.montant_tva != null ? Number(facture.montant_tva) : montantTvaCalcule
+                          if (!montantTva && !tvaGlobale) return null
+                          return (
+                            <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 4, fontVariantNumeric: 'tabular-nums' }}>
+                              TVA <strong style={{ color: c.texte }}>{formatEuro(montantTva)}</strong> · TTC <strong style={{ color: c.texte }}>{formatEuro(ht + montantTva)}</strong>
+                            </div>
+                          )
+                        })()}
                       </div>
                     </div>
                   )}
@@ -423,6 +459,7 @@ export default function AchatsDetailPage() {
                               <th style={th}>Unité</th>
                               <th style={thR}>Prix HT/u</th>
                               <th style={thR}>Remise %</th>
+                              <th style={thR}>TVA %</th>
                               <th style={thR}>Total HT</th>
                               <th style={th}>Ingrédient</th>
                               <th style={th} />
@@ -470,6 +507,15 @@ export default function AchatsDetailPage() {
                                       type="number" min="0" max="100" step="0.1"
                                       value={l.remise}
                                       onChange={e => updateEditLigne(l._id, 'remise', e.target.value)}
+                                    />
+                                  </td>
+                                  <td style={{ ...td, textAlign: 'right' }}>
+                                    <input
+                                      style={{ ...inputS, fontSize: 13, padding: '6px 8px', textAlign: 'right', width: 60 }}
+                                      type="number" min="0" max="100" step="0.1"
+                                      value={l.taux_tva ?? ''}
+                                      placeholder={String(editTauxTva)}
+                                      onChange={e => updateEditLigne(l._id, 'taux_tva', e.target.value === '' ? null : e.target.value)}
                                     />
                                   </td>
                                   <td style={{ ...tdR, fontVariantNumeric: 'tabular-nums' }}>{formatEuro(totalLigne)}</td>
@@ -525,7 +571,7 @@ export default function AchatsDetailPage() {
                           </tbody>
                           <tfoot>
                             <tr style={{ fontWeight: 600, background: c.fond }}>
-                              <td style={{ ...td, color: c.texte }} colSpan={5}>Total HT</td>
+                              <td style={{ ...td, color: c.texte }} colSpan={6}>Total HT</td>
                               <td style={{ ...tdR, color: c.texte }}>{formatEuro(editTotalHt)}</td>
                               <td style={td} colSpan={2} />
                             </tr>
@@ -547,6 +593,7 @@ export default function AchatsDetailPage() {
                             <th style={th}>Unité</th>
                             <th style={thR}>Prix HT/u</th>
                             <th style={thR}>Remise</th>
+                            <th style={thR}>TVA</th>
                             <th style={thR}>Total HT</th>
                             <th style={th}>Ingrédient</th>
                           </tr>
@@ -559,6 +606,7 @@ export default function AchatsDetailPage() {
                               <td style={tdM}>{l.unite || '—'}</td>
                               <td style={tdR}>{formatEuro(l.prix_unitaire_ht)}</td>
                               <td style={tdM}>{l.remise ? `${l.remise} %` : '—'}</td>
+                              <td style={tdM}>{l.taux_tva != null ? `${Number(l.taux_tva).toLocaleString('fr-FR', { maximumFractionDigits: 2 })} %` : '—'}</td>
                               <td style={tdR}>{formatEuro(l.montant_ht)}</td>
                               <td style={td}>
                                 {l.ingredients?.nom
@@ -570,7 +618,7 @@ export default function AchatsDetailPage() {
                         </tbody>
                         <tfoot>
                           <tr style={{ fontWeight: 600, background: c.fond }}>
-                            <td style={{ ...td, color: c.texte }} colSpan={5}>Total</td>
+                            <td style={{ ...td, color: c.texte }} colSpan={6}>Total</td>
                             <td style={{ ...tdR, color: c.texte }}>{formatEuro(lignes.reduce((s, l) => s + (Number(l.montant_ht) || 0), 0))}</td>
                             <td style={td} />
                           </tr>

--- a/app/controle-gestion/achats/import/page.js
+++ b/app/controle-gestion/achats/import/page.js
@@ -1,21 +1,32 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { supabase, getClientId } from '../../../../lib/supabase'
 import { useIsMobile } from '../../../../lib/useIsMobile'
 import { useTheme } from '../../../../lib/useTheme'
 import { useRole } from '../../../../lib/useRole'
 import Navbar from '../../../../components/Navbar'
+import BackButton from '../../../../components/BackButton'
+import IngredientAutocomplete from '../../../../components/IngredientAutocomplete'
 import { normDesig, todayIso, yesterdayIso, fmtPrix, fmtDelta, fileToBase64, makeLigneId, enrichLigne } from '../../../../lib/achatsHelpers'
 
 // ─── Composant principal ─────────────────────────────────────────────────────
 
 export default function AchatsImportPage() {
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const isManuelMode = searchParams.get('mode') === 'manuel'
   const { c } = useTheme()
   const isMobile = useIsMobile()
   const { role, loading: roleLoading } = useRole()
+
+  // ── Layout ───────────────────────────────────────────────────────────────
+  // Mode OCR desktop : PDF à gauche, metadonnées + lignes en cartes à droite (Option A).
+  // Mode manuel desktop : pleine largeur, lignes en tableau.
+  // Mobile : flex column, lignes en cartes.
+  const ocrSideBySide = !isMobile && !isManuelMode
+  const useCardLayout = isMobile || ocrSideBySide
 
   // ── Auth ──────────────────────────────────────────────────────────────────
   const [authReady, setAuthReady] = useState(false)
@@ -23,7 +34,10 @@ export default function AchatsImportPage() {
 
   // ── Machine d'état ────────────────────────────────────────────────────────
   // 'upload' | 'extracting' | 'review' | 'saving' | 'done'
-  const [step, setStep] = useState('upload')
+  const [step, setStep] = useState(isManuelMode ? 'review' : 'upload')
+
+  // ── Création auto des ingrédients manquants au save ──────────────────────
+  const [autoCreateMissing, setAutoCreateMissing] = useState(true)
 
   // ── Fichier ───────────────────────────────────────────────────────────────
   const [previewUrl, setPreviewUrl] = useState(null)
@@ -36,7 +50,9 @@ export default function AchatsImportPage() {
   const [dateFacture, setDateFacture] = useState(yesterdayIso())
   const [numeroFacture, setNumeroFacture] = useState('')
   const [statut, setStatut] = useState('facture')
-  const [tauxTva, setTauxTva] = useState(5.5) // % par défaut (alimentaire)
+  const [tauxTva, setTauxTva] = useState(5.5) // % par défaut (alimentaire) — fallback pour les lignes sans taux
+  // Total TVA saisi en pied de facture (override). null = calcul automatique.
+  const [montantTvaSaisi, setMontantTvaSaisi] = useState(null)
 
   // ── Lignes enrichies ──────────────────────────────────────────────────────
   // Chaque ligne : { _id, designation, quantite, unite, prix_unitaire_ht, remise,
@@ -47,6 +63,7 @@ export default function AchatsImportPage() {
   // ── Caches de réconciliation ──────────────────────────────────────────────
   const [fournisseurMapping, setFournisseurMapping] = useState({}) // norm → { ingredient_id }
   const [ingredientsById, setIngredientsById] = useState({})       // id   → { nom, prix_kg, unite }
+  const [tvaByIngredient, setTvaByIngredient] = useState({})       // id   → dernier taux_tva utilisé
 
   // Index nom normalisé → ingrédient (recalculé quand ingredientsById change)
   const ingredientsByNorm = useMemo(
@@ -64,7 +81,18 @@ export default function AchatsImportPage() {
     }, 0),
     [lignes]
   )
-  const montantTva = totalHtFacture * (Number(tauxTva) || 0) / 100
+  // Si une ligne a son propre taux_tva, il prime ; sinon fallback sur tauxTva global.
+  const montantTvaCalcule = useMemo(
+    () => lignes.reduce((s, l) => {
+      const r = Number(l.remise) || 0
+      const ht = (Number(l.quantite) || 0) * (Number(l.prix_unitaire_ht) || 0) * (1 - r / 100)
+      const taux = l.taux_tva != null && l.taux_tva !== '' ? Number(l.taux_tva) : Number(tauxTva) || 0
+      return s + ht * taux / 100
+    }, 0),
+    [lignes, tauxTva]
+  )
+  // Si l'utilisateur a saisi un montant TVA en pied, il prime sur le calcul.
+  const montantTva = montantTvaSaisi != null && montantTvaSaisi !== '' ? Number(montantTvaSaisi) : montantTvaCalcule
   const totalTtcFacture = totalHtFacture + montantTva
 
   // ── UX ────────────────────────────────────────────────────────────────────
@@ -118,13 +146,14 @@ export default function AchatsImportPage() {
         headers: { 'Authorization': `Bearer ${session.access_token}` },
       })
       if (!res.ok) return
-      const { mappings, ingredients } = await res.json()
+      const { mappings, ingredients, tvaByIngredient: tvaMap } = await res.json()
       setFournisseurMapping(
         Object.fromEntries((mappings || []).map(m => [m.designation_norm, m]))
       )
       setIngredientsById(
         Object.fromEntries((ingredients || []).map(i => [i.id, i]))
       )
+      setTvaByIngredient(tvaMap || {})
     } catch (err) {
       console.warn('loadReconciliation error:', err)
     }
@@ -137,8 +166,23 @@ export default function AchatsImportPage() {
   // ─── Réconciliation d'une ligne ───────────────────────────────────────────
 
   const enrichLigneLocal = useCallback((ligne) => {
-    return enrichLigne(ligne, fournisseurMapping, ingredientsById, ingredientsByNorm)
-  }, [fournisseurMapping, ingredientsById, ingredientsByNorm])
+    return enrichLigne(ligne, fournisseurMapping, ingredientsById, ingredientsByNorm, tvaByIngredient)
+  }, [fournisseurMapping, ingredientsById, ingredientsByNorm, tvaByIngredient])
+
+  // En mode manuel : amorçage avec une ligne vide dès que l'auth est prête.
+  const manuelInitDone = useRef(false)
+  useEffect(() => {
+    if (!isManuelMode || !authReady || manuelInitDone.current) return
+    manuelInitDone.current = true
+    setLignes([enrichLigneLocal({
+      _id: makeLigneId(),
+      designation: '',
+      quantite: 1,
+      unite: 'kg',
+      prix_unitaire_ht: 0,
+      remise: 0,
+    })])
+  }, [isManuelMode, authReady, enrichLigneLocal])
 
   // ─── Extraction IA ────────────────────────────────────────────────────────
 
@@ -162,6 +206,10 @@ export default function AchatsImportPage() {
       setFournisseur(result.fournisseur || '')
       setDateFacture(result.date_facture || yesterdayIso())
       setNumeroFacture(result.numero_facture || '')
+      // Si l'OCR a détecté le montant TVA en pied, on le préremplit
+      if (result.montant_tva_total != null) {
+        setMontantTvaSaisi(Number(result.montant_tva_total))
+      }
       const enriched = (result.lignes || []).map(l =>
         enrichLigneLocal({
           _id:              makeLigneId(),
@@ -169,6 +217,7 @@ export default function AchatsImportPage() {
           quantite:         Number(l.quantite) || 1,
           unite:            l.unite || '',
           prix_unitaire_ht: Number(l.prix_unitaire_ht) || 0,
+          taux_tva:         l.taux_tva != null ? Number(l.taux_tva) : null,
         })
       )
       setLignes(enriched)
@@ -235,9 +284,15 @@ export default function AchatsImportPage() {
   // ─── Édition des lignes ───────────────────────────────────────────────────
 
   const updateLigne = useCallback((id, field, value) => {
-    setLignes(prev => prev.map(l =>
-      l._id !== id ? l : enrichLigneLocal({ ...l, [field]: value })
-    ))
+    setLignes(prev => prev.map(l => {
+      if (l._id !== id) return l
+      // Si l'utilisateur modifie le prix ou la TVA lui-même, on désactive le
+      // pré-remplissage auto pour ne plus l'écraser ensuite.
+      const next = { ...l, [field]: value }
+      if (field === 'prix_unitaire_ht') next.prix_auto = false
+      if (field === 'taux_tva') next.tva_auto = false
+      return enrichLigneLocal(next)
+    }))
   }, [enrichLigneLocal])
 
   const addLigne = useCallback(() => {
@@ -318,28 +373,59 @@ export default function AchatsImportPage() {
   }, [clientId, newIngNom])
 
   const handleLinkIngredient = useCallback((ligne, ing) => {
-    const prixEff = Number(ligne.prix_unitaire_ht) * (1 - (Number(ligne.remise) || 0) / 100)
+    // L'utilisateur avait-il déjà saisi son propre prix / TVA avant le link ?
+    const userHadOwnPrice = ligne.prix_auto === false && Number(ligne.prix_unitaire_ht) > 0
+    const userHadOwnTva = ligne.tva_auto === false && ligne.taux_tva != null && ligne.taux_tva !== ''
     const prixActuel = ing.prix_kg ? Number(ing.prix_kg) : null
-    const deltaPrix = prixActuel && prixEff ? ((prixEff - prixActuel) / prixActuel) * 100 : null
+    const prixLigneFinal = userHadOwnPrice
+      ? Number(ligne.prix_unitaire_ht)
+      : (prixActuel && Number.isFinite(prixActuel) ? prixActuel : 0)
+    const remiseFactor = 1 - (Number(ligne.remise) || 0) / 100
+    const prixEff = prixLigneFinal * remiseFactor
+    const deltaPrix = prixActuel && prixEff && userHadOwnPrice
+      ? ((prixEff - prixActuel) / prixActuel) * 100
+      : null
+    // Pré-remplit la TVA depuis l'historique de l'ingrédient si l'utilisateur n'a pas saisi.
+    const tvaHist = tvaByIngredient[ing.id] != null ? Number(tvaByIngredient[ing.id]) : null
+    const tauxTvaFinal = userHadOwnTva
+      ? Number(ligne.taux_tva)
+      : (tvaHist != null && Number.isFinite(tvaHist) ? tvaHist : (ligne.taux_tva ?? null))
     setLignes(prev => prev.map(l =>
       l._id !== ligne._id ? l : {
         ...l,
-        ingredient_id:  ing.id,
-        ingredient_nom: ing.nom,
-        prix_actuel:    prixActuel,
+        prix_unitaire_ht: prixLigneFinal,
+        prix_auto:        !userHadOwnPrice,
+        taux_tva:         tauxTvaFinal,
+        tva_auto:         !userHadOwnTva,
+        ingredient_id:    ing.id,
+        ingredient_nom:   ing.nom,
+        prix_actuel:      prixActuel,
         deltaPrix,
-        reconnu:        true,
-        updatePrice:    false,
+        reconnu:          true,
+        updatePrice:      userHadOwnPrice,
       }
     ))
     setLinkingIngFor(null)
     setLinkSearch('')
-  }, [])
+  }, [tvaByIngredient])
+
+  // Sélection depuis l'autocomplete de désignation : remplit la désignation
+  // avec le nom canonique de l'ingrédient + lie l'ingrédient (pré-remplit
+  // prix et TVA via handleLinkIngredient).
+  const handleSelectFromAutocomplete = useCallback((ligne, ing) => {
+    handleLinkIngredient({ ...ligne, designation: ing.nom }, ing)
+  }, [handleLinkIngredient])
 
   const handleSave = useCallback(async (forceInsert = false) => {
     if (!fournisseur.trim()) { setError('Le nom du fournisseur est requis.'); return }
     if (!dateFacture)        { setError('La date de la facture est requise.'); return }
-    if (lignes.length === 0) { setError('Ajoutez au moins une ligne avant d\'enregistrer.'); return }
+    // Ne garde que les lignes avec une désignation non vide (les autres sont des
+    // lignes-brouillon que l'utilisateur n'a pas remplies).
+    const lignesValides = lignes.filter((l) => l.designation && l.designation.trim())
+    if (lignesValides.length === 0) {
+      setError('Ajoutez au moins une ligne avec une désignation avant d\'enregistrer.')
+      return
+    }
     setError('')
     setDuplicateWarning(null)
     setStep('saving')
@@ -352,7 +438,13 @@ export default function AchatsImportPage() {
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${session.access_token}`,
         },
-        body: JSON.stringify({ clientId, fournisseur, numeroFacture, dateFacture, statut, lignes, forceInsert, fileBase64, fileMime, tauxTva: Number(tauxTva) || 0 }),
+        body: JSON.stringify({
+          clientId, fournisseur, numeroFacture, dateFacture, statut,
+          lignes: lignesValides, forceInsert, fileBase64, fileMime,
+          tauxTva: Number(tauxTva) || 0,
+          montantTva: montantTvaSaisi != null && montantTvaSaisi !== '' ? Number(montantTvaSaisi) : null,
+          autoCreateMissing,
+        }),
       })
       const result = await res.json()
 
@@ -362,16 +454,29 @@ export default function AchatsImportPage() {
         return
       }
 
-      if (!res.ok) throw new Error(result.error || 'Erreur lors de l\'enregistrement.')
+      if (!res.ok) {
+        // Remonter le détail Zod si dispo pour aider au diagnostic
+        if (result.details?.fieldErrors) {
+          const flat = Object.entries(result.details.fieldErrors)
+            .map(([k, v]) => `${k} : ${(v ).join(', ')}`)
+            .join(' · ')
+          throw new Error(`${result.error || 'Données invalides'} — ${flat}`)
+        }
+        throw new Error(result.error || 'Erreur lors de l\'enregistrement.')
+      }
 
       setPrixMajCount(result.prix_maj ?? 0)
+      // Avertir si l'upload du fichier source a échoué (stockage non bloquant)
+      if (result.file_uploaded === false) {
+        window.alert('Facture enregistrée, mais le fichier source n\'a pas pu être stocké. Vous pourrez la consulter sans aperçu PDF/image.')
+      }
       router.push('/controle-gestion/achats')
     } catch (err) {
       console.error('handleSave error:', err)
       setError(err.message || 'Erreur lors de l\'enregistrement.')
       setStep('review')
     }
-  }, [clientId, fournisseur, numeroFacture, dateFacture, statut, lignes, fileBase64, fileMime])
+  }, [clientId, fournisseur, numeroFacture, dateFacture, statut, lignes, fileBase64, fileMime, autoCreateMissing, router, tauxTva, montantTvaSaisi])
 
   // ─── Styles partagés ─────────────────────────────────────────────────────
 
@@ -428,13 +533,43 @@ export default function AchatsImportPage() {
       <Navbar section="cuisine" />
       <div style={{ padding: pad, maxWidth: 1200, margin: '0 auto' }}>
 
+        {/* Bouton retour */}
+        <div style={{ marginBottom: 12 }}>
+          <BackButton
+            fallback="/controle-gestion/achats"
+            label="← Retour aux achats"
+            style={{ background: 'transparent', border: 'none', color: c.texteMuted, fontSize: 13, padding: 0, cursor: 'pointer' }}
+          />
+        </div>
+
         {/* En-tête */}
-        <h1 style={{ margin: '0 0 4px', fontSize: isMobile ? 22 : 26, fontWeight: 700, color: c.texte }}>
-          Importation de factures
-        </h1>
-        <p style={{ margin: '0 0 28px', fontSize: 14, color: c.texteMuted }}>
-          Photographiez ou déposez une facture fournisseur — les lignes sont extraites automatiquement.
-        </p>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', flexWrap: 'wrap', gap: 12, marginBottom: 28 }}>
+          <div>
+            <h1 style={{ margin: '0 0 4px', fontSize: isMobile ? 22 : 26, fontWeight: 700, color: c.texte }}>
+              {isManuelMode ? 'Saisie manuelle d\'une facture' : 'Importation de factures'}
+            </h1>
+            <p style={{ margin: 0, fontSize: 14, color: c.texteMuted }}>
+              {isManuelMode
+                ? 'Saisissez les lignes une à une — créez les ingrédients manquants à la volée.'
+                : 'Photographiez ou déposez une facture fournisseur — les lignes sont extraites automatiquement.'}
+            </p>
+          </div>
+          {!isManuelMode ? (
+            <button
+              onClick={() => router.push('/controle-gestion/achats/import?mode=manuel')}
+              style={{ padding: '8px 14px', borderRadius: 8, fontSize: 13, border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte, cursor: 'pointer' }}
+            >
+              ✏️ Saisir manuellement
+            </button>
+          ) : (
+            <button
+              onClick={() => router.push('/controle-gestion/achats/import')}
+              style={{ padding: '8px 14px', borderRadius: 8, fontSize: 13, border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte, cursor: 'pointer' }}
+            >
+              📷 Importer une photo / PDF
+            </button>
+          )}
+        </div>
 
         {/* Erreur globale */}
         {error && (
@@ -558,10 +693,45 @@ export default function AchatsImportPage() {
         {/* ══ STEP : REVIEW ══════════════════════════════════════════════════ */}
         {(step === 'review' || step === 'saving') && (
           <>
-          <div style={isMobile ? { display: 'flex', flexDirection: 'column', gap: 20 } : { display: 'grid', gridTemplateColumns: '2fr 3fr', gap: 0, alignItems: 'start' }}>
+          <div style={
+            isMobile
+              ? { display: 'flex', flexDirection: 'column', gap: 20 }
+              : isManuelMode
+                ? { display: 'block' }
+                : { display: 'grid', gridTemplateColumns: '3fr 2fr', gap: 24, alignItems: 'start' }
+          }>
 
-            {/* ── Colonne gauche : métadonnées + lignes ── */}
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 20, padding: isMobile ? 0 : '0 24px 0 0' }}>
+            {/* ── Colonne PDF : sticky, à GAUCHE en mode OCR side-by-side ── */}
+            {ocrSideBySide && (
+              <div style={{ position: 'sticky', top: 76, height: 'calc(100vh - 90px)', display: 'flex', flexDirection: 'column' }}>
+                {previewUrl && (
+                  isPdf ? (
+                    <iframe
+                      src={previewUrl}
+                      title="Aperçu facture PDF"
+                      style={{ width: '100%', flex: 1, borderRadius: 10, border: `1px solid ${c.bordure}`, background: c.blanc }}
+                    />
+                  ) : (
+                    <img
+                      src={previewUrl}
+                      alt="Aperçu facture"
+                      style={{ width: '100%', flex: 1, objectFit: 'contain', borderRadius: 10, border: `1px solid ${c.bordure}`, background: c.blanc }}
+                    />
+                  )
+                )}
+                {!previewUrl && (
+                  <div style={{ flex: 1, background: c.blanc, border: `1px solid ${c.bordure}`, borderRadius: 10, display: 'flex', alignItems: 'center', justifyContent: 'center', color: c.texteMuted, fontSize: 14 }}>
+                    Aucun fichier
+                  </div>
+                )}
+                <button style={{ ...btnSecondary, marginTop: 10, width: '100%' }} onClick={resetForm}>
+                  ↩ Changer de fichier
+                </button>
+              </div>
+            )}
+
+            {/* ── Colonne droite (Option A) ou pleine largeur (manuel) : métadonnées ── */}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
 
               {/* Aperçu fichier — mobile uniquement */}
               {isMobile && previewUrl && (
@@ -603,6 +773,7 @@ export default function AchatsImportPage() {
                     <select style={inputS} value={statut} onChange={e => setStatut(e.target.value)}>
                       <option value="facture">Facture</option>
                       <option value="bl">Bon de livraison (BL)</option>
+                      <option value="avoir">Avoir</option>
                     </select>
                   </label>
                 </div>
@@ -618,13 +789,15 @@ export default function AchatsImportPage() {
                     />
                   </label>
                   <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: c.texteMuted }}>
-                    TVA (%)
+                    Total TVA (€)
                     <input
                       style={inputS}
                       type="number"
-                      min="0" max="100" step="0.1"
-                      value={tauxTva}
-                      onChange={e => setTauxTva(e.target.value)}
+                      min="0" step="0.01"
+                      value={montantTvaSaisi ?? ''}
+                      placeholder={fmtPrix(montantTvaCalcule)}
+                      title="Saisissez le total TVA tel qu'il apparaît en pied de facture, ou laissez vide pour calculer automatiquement"
+                      onChange={e => setMontantTvaSaisi(e.target.value === '' ? null : e.target.value)}
                     />
                   </label>
                   <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: c.texteMuted }}>
@@ -638,40 +811,8 @@ export default function AchatsImportPage() {
                 </div>
               </div>
 
-            </div>
-
-            {/* ── Colonne droite : aperçu PDF ── */}
-            {!isMobile && (
-              <div style={{ position: 'sticky', top: 76, height: 'calc(100vh - 90px)', display: 'flex', flexDirection: 'column', borderLeft: `1px solid ${c.bordure}`, paddingLeft: 24 }}>
-                {previewUrl && (
-                  isPdf ? (
-                    <iframe
-                      src={previewUrl}
-                      title="Aperçu facture PDF"
-                      style={{ width: '100%', flex: 1, borderRadius: 10, border: `1px solid ${c.bordure}` }}
-                    />
-                  ) : (
-                    <img
-                      src={previewUrl}
-                      alt="Aperçu facture"
-                      style={{ width: '100%', flex: 1, objectFit: 'contain', borderRadius: 10, border: `1px solid ${c.bordure}`, background: c.blanc }}
-                    />
-                  )
-                )}
-                {!previewUrl && (
-                  <div style={{ flex: 1, background: c.blanc, border: `1px solid ${c.bordure}`, borderRadius: 10, display: 'flex', alignItems: 'center', justifyContent: 'center', color: c.texteMuted, fontSize: 14 }}>
-                    Aucun fichier
-                  </div>
-                )}
-                <button style={{ ...btnSecondary, marginTop: 10, width: '100%' }} onClick={resetForm}>
-                  ↩ Changer de fichier
-                </button>
-              </div>
-            )}
-          </div>
-
-          {/* ── Lignes pleine largeur ── */}
-          <div style={{ marginTop: 20, display: 'flex', flexDirection: 'column', gap: 16 }}>
+          {/* ── Lignes (incluses dans la colonne droite en mode side-by-side) ── */}
+          <div style={{ marginTop: 0, display: 'flex', flexDirection: 'column', gap: 16 }}>
             <div style={{ background: c.blanc, border: `1px solid ${c.bordure}`, borderRadius: 12, overflow: 'hidden' }}>
               <div style={{ padding: '12px 16px', borderBottom: `1px solid ${c.bordure}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                 <p style={{ margin: 0, fontWeight: 600, fontSize: 14, color: c.texte }}>
@@ -684,12 +825,12 @@ export default function AchatsImportPage() {
 
                 {lignes.length === 0 && (
                   <p style={{ padding: 20, margin: 0, fontSize: 13, color: c.texteMuted, textAlign: 'center' }}>
-                    Aucune ligne. Cliquez sur "+ Ajouter une ligne" pour commencer.
+                    Aucune ligne. Cliquez sur &laquo;&nbsp;+ Ajouter une ligne&nbsp;&raquo; pour commencer.
                   </p>
                 )}
 
-                {lignes.length > 0 && !isMobile && (
-                  /* ── Tableau desktop ── */
+                {lignes.length > 0 && !useCardLayout && (
+                  /* ── Tableau desktop (mode manuel uniquement) ── */
                   <div style={{ overflowX: 'auto' }}>
                     <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 950 }}>
                       <thead>
@@ -699,6 +840,7 @@ export default function AchatsImportPage() {
                           <th style={{ ...th, width: '5%' }}>Unité</th>
                           <th style={{ ...th, width: '9%', textAlign: 'right' }}>Prix HT/u</th>
                           <th style={{ ...th, width: '6%', textAlign: 'right' }}>Remise %</th>
+                          <th style={{ ...th, width: '7%', textAlign: 'right' }}>TVA %</th>
                           <th style={{ ...th, width: '9%', textAlign: 'right' }}>Total HT</th>
                           <th style={{ ...th, width: '12%', textAlign: 'center' }}>Reconnu</th>
                           <th style={{ ...th, width: '7%', textAlign: 'center' }}>Δ Prix</th>
@@ -716,11 +858,12 @@ export default function AchatsImportPage() {
                           return (
                             <tr key={l._id}>
                               <td style={td}>
-                                <input
-                                  style={{ ...inputS, fontSize: 13 }}
+                                <IngredientAutocomplete
+                                  ingredients={Object.values(ingredientsById)}
                                   value={l.designation}
-                                  placeholder="Nom du produit"
-                                  onChange={e => updateLigne(l._id, 'designation', e.target.value)}
+                                  onChange={(text) => updateLigne(l._id, 'designation', text)}
+                                  onSelect={(ing) => handleSelectFromAutocomplete(l, ing)}
+                                  inputStyle={{ ...inputS, fontSize: 13 }}
                                 />
                                 {l.ingredient_nom && (
                                   <div style={{ fontSize: 11, color: c.texteMuted, marginTop: 2 }}>→ {l.ingredient_nom}</div>
@@ -756,6 +899,15 @@ export default function AchatsImportPage() {
                                   type="number" min="0" max="100" step="0.1"
                                   value={l.remise ?? 0}
                                   onChange={e => updateLigne(l._id, 'remise', e.target.value)}
+                                />
+                              </td>
+                              <td style={{ ...td, textAlign: 'right' }}>
+                                <input
+                                  style={{ ...inputS, textAlign: 'right', width: 60 }}
+                                  type="number" min="0" max="100" step="0.1"
+                                  value={l.taux_tva ?? ''}
+                                  placeholder={String(tauxTva)}
+                                  onChange={e => updateLigne(l._id, 'taux_tva', e.target.value === '' ? null : e.target.value)}
                                 />
                               </td>
                               <td style={{ ...td, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
@@ -820,7 +972,7 @@ export default function AchatsImportPage() {
                                     <button
                                       onClick={() => { setCreatingIngFor(l._id); setNewIngNom(l.designation); setLinkingIngFor(null) }}
                                       style={{ fontSize: 10, padding: '2px 6px', background: 'transparent', border: `1px solid ${c.accent}`, color: c.accent, borderRadius: 4, cursor: 'pointer', whiteSpace: 'nowrap' }}
-                                    >＋ Créer l'ingrédient</button>
+                                    >＋ Créer l&rsquo;ingrédient</button>
                                   </div>
                                 )}
                               </td>
@@ -855,8 +1007,8 @@ export default function AchatsImportPage() {
                   </div>
                 )}
 
-                {lignes.length > 0 && isMobile && (
-                  /* ── Cards mobile ── */
+                {lignes.length > 0 && useCardLayout && (
+                  /* ── Cartes (mobile + OCR desktop side-by-side) ── */
                   <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
                     {lignes.map((l, idx) => {
                       const delta = fmtDelta(l.deltaPrix)
@@ -866,12 +1018,15 @@ export default function AchatsImportPage() {
                         <div key={l._id} style={{ padding: '14px 16px', borderBottom: idx < lignes.length - 1 ? `1px solid ${c.bordure}` : 'none' }}>
                           {/* Ligne 1 : désignation + badge */}
                           <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 8, marginBottom: 8 }}>
-                            <input
-                              style={{ ...inputS, fontSize: 15, fontWeight: 500, flex: 1 }}
-                              value={l.designation}
-                              placeholder="Nom du produit"
-                              onChange={e => updateLigne(l._id, 'designation', e.target.value)}
-                            />
+                            <div style={{ flex: 1 }}>
+                              <IngredientAutocomplete
+                                ingredients={Object.values(ingredientsById)}
+                                value={l.designation}
+                                onChange={(text) => updateLigne(l._id, 'designation', text)}
+                                onSelect={(ing) => handleSelectFromAutocomplete(l, ing)}
+                                inputStyle={{ ...inputS, fontSize: 15, fontWeight: 500 }}
+                              />
+                            </div>
                             {l.reconnu ? <span style={badgeVert}>✓</span> : <span style={badgeGris}>?</span>}
                           </div>
                           {l.ingredient_nom && (
@@ -932,10 +1087,10 @@ export default function AchatsImportPage() {
                             <button
                               onClick={() => { setLinkingIngFor(l._id); setLinkSearch(''); setCreatingIngFor(null) }}
                               style={{ fontSize: 11, padding: '3px 8px', background: 'transparent', border: `1px solid ${c.bordure}`, color: c.texteMuted, borderRadius: 6, cursor: 'pointer', marginBottom: 6 }}
-                            >Changer l'ingrédient lié</button>
+                            >Changer l&rsquo;ingrédient lié</button>
                           )}
-                          {/* Ligne 2 : Qté / Unité / Prix */}
-                          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8, marginBottom: 8 }}>
+                          {/* Ligne 2 : Qté / Unité / Prix / TVA */}
+                          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 8, marginBottom: 8 }}>
                             <label style={{ display: 'flex', flexDirection: 'column', gap: 3, fontSize: 11, color: c.texteMuted }}>
                               Quantité
                               <input style={inputS} type="number" min="0" step="0.001" value={l.quantite}
@@ -950,6 +1105,12 @@ export default function AchatsImportPage() {
                               Prix HT/u
                               <input style={inputS} type="number" min="0" step="0.01" value={l.prix_unitaire_ht}
                                 onChange={e => updateLigne(l._id, 'prix_unitaire_ht', e.target.value)} />
+                            </label>
+                            <label style={{ display: 'flex', flexDirection: 'column', gap: 3, fontSize: 11, color: c.texteMuted }}>
+                              TVA %
+                              <input style={inputS} type="number" min="0" max="100" step="0.1" value={l.taux_tva ?? ''}
+                                placeholder={String(tauxTva)}
+                                onChange={e => updateLigne(l._id, 'taux_tva', e.target.value === '' ? null : e.target.value)} />
                             </label>
                           </div>
                           {/* Ligne 3 : total + delta + actions */}
@@ -997,7 +1158,16 @@ export default function AchatsImportPage() {
             )}
 
             {/* Bouton enregistrer */}
-            <div style={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: 10, justifyContent: 'flex-end' }}>
+            <div style={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: 10, alignItems: isMobile ? 'stretch' : 'center', justifyContent: 'flex-end' }}>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: c.texteMuted, cursor: 'pointer' }}>
+                <input
+                  type="checkbox"
+                  checked={autoCreateMissing}
+                  onChange={e => setAutoCreateMissing(e.target.checked)}
+                  style={{ width: 16, height: 16 }}
+                />
+                Créer auto les ingrédients manquants
+              </label>
               <button
                 style={{ ...btnPrimary, opacity: step === 'saving' ? 0.6 : 1 }}
                 disabled={step === 'saving'}
@@ -1007,6 +1177,8 @@ export default function AchatsImportPage() {
               </button>
             </div>
           </div>
+            </div>{/* fin colonne droite metadonnées+lignes */}
+          </div>{/* fin wrapper grid */}
           </>
         )}
 

--- a/app/controle-gestion/achats/page.js
+++ b/app/controle-gestion/achats/page.js
@@ -2,10 +2,12 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import * as XLSX from 'xlsx'
 import { supabase, getClientId } from '../../../lib/supabase'
 import { useIsMobile } from '../../../lib/useIsMobile'
 import { useTheme } from '../../../lib/useTheme'
 import { useRole } from '../../../lib/useRole'
+import { badgeStyleFor, statutLabel } from '../../../lib/achatsHelpers'
 import Navbar from '../../../components/Navbar'
 
 function formatEuro(n) {
@@ -18,6 +20,7 @@ function formatDate(s) {
   return new Date(s).toLocaleDateString('fr-FR')
 }
 
+
 export default function AchatsListPage() {
   const router = useRouter()
   const isMobile = useIsMobile()
@@ -28,12 +31,15 @@ export default function AchatsListPage() {
   const [clientId, setClientId] = useState(null)
   const [factures, setFactures] = useState([])
   const [nbLignesByFacture, setNbLignesByFacture] = useState({})
+  const [tvaByFacture, setTvaByFacture] = useState({})
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [recherche, setRecherche] = useState('')
   const [dateDebut, setDateDebut] = useState('')
   const [dateFin, setDateFin] = useState('')
+  const [statutsActifs, setStatutsActifs] = useState(['bl', 'facture', 'avoir'])
   const [deleting, setDeleting] = useState(null)
+  const [exporting, setExporting] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -62,7 +68,7 @@ export default function AchatsListPage() {
 
     const { data: rows, error: fErr } = await supabase
       .from('achats_factures')
-      .select('id, fournisseur, numero_facture, date_facture, total_ht, statut, created_at')
+      .select('id, fournisseur, numero_facture, date_facture, total_ht, taux_tva, montant_tva, statut, created_at')
       .eq('client_id', cid)
       .is('deleted_at', null)
       .order('date_facture', { ascending: false })
@@ -75,19 +81,29 @@ export default function AchatsListPage() {
 
     const ids = (rows || []).map((r) => r.id)
     let counts = {}
+    let tvaCalculeeByFacture = {}
     if (ids.length > 0) {
       const { data: lignes } = await supabase
         .from('achats_lignes')
-        .select('facture_id')
+        .select('facture_id, montant_ht, taux_tva')
         .in('facture_id', ids)
         .eq('client_id', cid)
+      const tauxGlobalById = Object.fromEntries((rows || []).map(r => [r.id, Number(r.taux_tva) || 0]))
       for (const l of (lignes || [])) {
         counts[l.facture_id] = (counts[l.facture_id] || 0) + 1
+        const taux = l.taux_tva != null ? Number(l.taux_tva) : tauxGlobalById[l.facture_id] || 0
+        tvaCalculeeByFacture[l.facture_id] = (tvaCalculeeByFacture[l.facture_id] || 0) + (Number(l.montant_ht) || 0) * taux / 100
       }
+    }
+    // Si la facture a un montant_tva saisi, il prime sur le calcul.
+    const tvaByFacture = {}
+    for (const r of rows || []) {
+      tvaByFacture[r.id] = r.montant_tva != null ? Number(r.montant_tva) : (tvaCalculeeByFacture[r.id] || 0)
     }
 
     setFactures(rows || [])
     setNbLignesByFacture(counts)
+    setTvaByFacture(tvaByFacture)
     setLoading(false)
   }, [])
 
@@ -95,6 +111,48 @@ export default function AchatsListPage() {
     if (!authReady) return
     loadFactures()
   }, [authReady, loadFactures])
+
+  const handleExport = async () => {
+    if (!clientId) return
+    setExporting(true)
+    setError('')
+    try {
+      if (facturesFiltrees.length === 0) {
+        setError('Aucune facture à exporter.')
+        return
+      }
+      // Pied de facture : 1 ligne = 1 facture, avec HT / TVA / TTC.
+      // Le champ TVA est calculé en respectant les taux par ligne (déjà agrégé
+      // dans tvaByFacture au load).
+      const rows = facturesFiltrees.map((f) => {
+        const ht  = Number(f.total_ht) || 0
+        const tva = tvaByFacture[f.id] || 0
+        return {
+          'N° facture':   f.numero_facture || '',
+          'Date':         f.date_facture || '',
+          'Fournisseur':  f.fournisseur || '',
+          'Statut':       statutLabel(f.statut),
+          'HT':           ht,
+          'TVA':          tva,
+          'TTC':          ht + tva,
+        }
+      })
+
+      const ws = XLSX.utils.json_to_sheet(rows)
+      ws['!cols'] = [
+        { wch: 14 }, { wch: 12 }, { wch: 28 }, { wch: 9  },
+        { wch: 12 }, { wch: 12 }, { wch: 12 },
+      ]
+      const wb = XLSX.utils.book_new()
+      XLSX.utils.book_append_sheet(wb, ws, 'Factures')
+      const today = new Date().toISOString().slice(0, 10)
+      XLSX.writeFile(wb, `achats_${today}.xlsx`)
+    } catch (err) {
+      setError(`Export impossible : ${err.message}`)
+    } finally {
+      setExporting(false)
+    }
+  }
 
   const handleDelete = async (f, e) => {
     e.stopPropagation()
@@ -165,10 +223,19 @@ export default function AchatsListPage() {
     // Filtre date (sur date_facture)
     if (dateDebut && (!f.date_facture || f.date_facture < dateDebut)) return false
     if (dateFin && (!f.date_facture || f.date_facture > dateFin)) return false
+    // Filtre statut
+    const s = f.statut || 'facture'
+    if (!statutsActifs.includes(s)) return false
     return true
   })
 
+  const toggleStatut = (k) => {
+    setStatutsActifs((prev) => prev.includes(k) ? prev.filter(x => x !== k) : [...prev, k])
+  }
+
   const totalHT = facturesFiltrees.reduce((s, f) => s + (Number(f.total_ht) || 0), 0)
+  const totalTVA = facturesFiltrees.reduce((s, f) => s + (tvaByFacture[f.id] || 0), 0)
+  const totalTTC = totalHT + totalTVA
 
   const th = {
     padding: isMobile ? '10px 8px' : '11px 14px',
@@ -200,7 +267,7 @@ export default function AchatsListPage() {
               Historique des factures importées
             </p>
           </div>
-          <div style={{ display: 'flex', gap: 8 }}>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
             <button
               onClick={() => router.push('/controle-gestion/fournisseurs')}
               style={{
@@ -210,16 +277,40 @@ export default function AchatsListPage() {
             >
               🏢 Fournisseurs
             </button>
+            <button
+              onClick={handleExport}
+              disabled={exporting || facturesFiltrees.length === 0}
+              title={facturesFiltrees.length === 0 ? 'Aucune facture à exporter' : 'Exporter les factures filtrées en Excel'}
+              style={{
+                padding: '8px 14px', borderRadius: 8, fontSize: 13,
+                border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte,
+                cursor: exporting || facturesFiltrees.length === 0 ? 'not-allowed' : 'pointer',
+                opacity: exporting || facturesFiltrees.length === 0 ? 0.6 : 1,
+              }}
+            >
+              {exporting ? 'Export…' : '⬇ Exporter Excel'}
+            </button>
             {role === 'admin' && (
-              <button
-                onClick={() => router.push('/controle-gestion/achats/import')}
-                style={{
-                  padding: '8px 14px', borderRadius: 8, fontSize: 13,
-                  border: 'none', background: c.accent, color: '#fff', cursor: 'pointer', fontWeight: 500,
-                }}
-              >
-                + Nouvelle facture
-              </button>
+              <>
+                <button
+                  onClick={() => router.push('/controle-gestion/achats/import?mode=manuel')}
+                  style={{
+                    padding: '8px 14px', borderRadius: 8, fontSize: 13,
+                    border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte, cursor: 'pointer',
+                  }}
+                >
+                  ✏️ Saisir manuellement
+                </button>
+                <button
+                  onClick={() => router.push('/controle-gestion/achats/import')}
+                  style={{
+                    padding: '8px 14px', borderRadius: 8, fontSize: 13,
+                    border: 'none', background: c.accent, color: c.texte, cursor: 'pointer', fontWeight: 500,
+                  }}
+                >
+                  + Importer (OCR)
+                </button>
+              </>
             )}
           </div>
         </div>
@@ -283,6 +374,32 @@ export default function AchatsListPage() {
           )}
         </div>
 
+        {/* Filtre par statut */}
+        <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8, marginBottom: 16 }}>
+          <span style={{ fontSize: 12, color: c.texteMuted }}>Statut</span>
+          {[
+            { k: 'bl',      label: 'BL' },
+            { k: 'facture', label: 'Factures' },
+            { k: 'avoir',   label: 'Avoirs' },
+          ].map((p) => {
+            const actif = statutsActifs.includes(p.k)
+            return (
+              <button
+                key={p.k}
+                onClick={() => toggleStatut(p.k)}
+                style={{
+                  padding: '6px 10px', borderRadius: 8, fontSize: 12,
+                  border: `1px solid ${actif ? c.accent : c.bordure}`,
+                  background: actif ? c.accentClair : c.blanc,
+                  color: c.texte, cursor: 'pointer',
+                }}
+              >
+                {p.label}
+              </button>
+            )
+          })}
+        </div>
+
         {error && <p style={{ color: '#B91C1C', fontSize: 14, marginBottom: 16 }}>{error}</p>}
 
         {loading && <p style={{ color: c.texteMuted, fontSize: 14 }}>Chargement…</p>}
@@ -300,10 +417,10 @@ export default function AchatsListPage() {
               <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
                 {facturesFiltrees.map((f) => {
                   const ht = Number(f.total_ht) || 0
+                  const tva = tvaByFacture[f.id] || 0
+                  const ttc = ht + tva
                   const nb = nbLignesByFacture[f.id] ?? 0
-                  const badgeStyle = f.statut === 'bl'
-                    ? { fontSize: 11, fontWeight: 600, padding: '2px 8px', borderRadius: 4, background: '#FEF3C7', color: '#92400E' }
-                    : { fontSize: 11, fontWeight: 600, padding: '2px 8px', borderRadius: 4, background: '#D1FAE5', color: '#065F46' }
+                  const badgeStyle = badgeStyleFor(f.statut)
                   return (
                     <div
                       key={f.id}
@@ -318,16 +435,19 @@ export default function AchatsListPage() {
                         <span style={{ fontSize: 15, fontWeight: 600, color: c.texte }}>
                           {f.fournisseur || <span style={{ color: c.texteMuted, fontWeight: 400 }}>—</span>}
                         </span>
-                        <span style={badgeStyle}>{f.statut === 'bl' ? 'BL' : 'Facture'}</span>
+                        <span style={badgeStyle}>{statutLabel(f.statut)}</span>
                       </div>
                       {/* Ligne 2 : n° facture · date */}
                       <div style={{ fontSize: 13, color: c.texteMuted, marginBottom: 8 }}>
                         {f.numero_facture ? `N° ${f.numero_facture}` : '—'}{f.date_facture ? ` · ${formatDate(f.date_facture)}` : ''}
                       </div>
-                      {/* Ligne 3 : articles + total */}
-                      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                      {/* Ligne 3 : articles + montants HT/TVA/TTC */}
+                      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', flexWrap: 'wrap', gap: 8 }}>
                         <span style={{ fontSize: 13, color: c.texteMuted }}>{nb} article{nb !== 1 ? 's' : ''}</span>
-                        <span style={{ fontSize: 15, fontWeight: 600, color: c.texte, fontVariantNumeric: 'tabular-nums' }}>{formatEuro(ht)}</span>
+                        <div style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+                          <div style={{ fontSize: 12, color: c.texteMuted }}>HT {formatEuro(ht)} · TVA {formatEuro(tva)}</div>
+                          <div style={{ fontSize: 16, fontWeight: 600, color: c.texte }}>{formatEuro(ttc)} <span style={{ fontSize: 11, color: c.texteMuted, fontWeight: 400 }}>TTC</span></div>
+                        </div>
                       </div>
                       {role === 'admin' && (
                         <div style={{ marginTop: 10, textAlign: 'right' }} onClick={e => e.stopPropagation()}>
@@ -344,9 +464,12 @@ export default function AchatsListPage() {
                   )
                 })}
                 {/* Total mobile */}
-                <div style={{ background: c.fond, borderRadius: 10, border: `0.5px solid ${c.bordure}`, padding: '12px 16px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <div style={{ background: c.fond, borderRadius: 10, border: `0.5px solid ${c.bordure}`, padding: '12px 16px', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', flexWrap: 'wrap', gap: 8 }}>
                   <span style={{ fontSize: 13, color: c.texteMuted }}>{facturesFiltrees.length} facture{facturesFiltrees.length !== 1 ? 's' : ''}</span>
-                  <span style={{ fontSize: 15, fontWeight: 600, color: c.texte }}>{formatEuro(totalHT)}</span>
+                  <div style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+                    <div style={{ fontSize: 12, color: c.texteMuted }}>HT {formatEuro(totalHT)} · TVA {formatEuro(totalTVA)}</div>
+                    <div style={{ fontSize: 16, fontWeight: 600, color: c.texte }}>{formatEuro(totalTTC)} <span style={{ fontSize: 11, color: c.texteMuted, fontWeight: 400 }}>TTC</span></div>
+                  </div>
                 </div>
               </div>
             ) : (
@@ -361,13 +484,17 @@ export default function AchatsListPage() {
                         <th style={th}>Date</th>
                         <th style={th}>Statut</th>
                         <th style={thR}>Articles</th>
-                        <th style={thR}>Total HT</th>
+                        <th style={thR}>HT</th>
+                        <th style={thR}>TVA</th>
+                        <th style={thR}>TTC</th>
                         {role === 'admin' && <th style={th} />}
                       </tr>
                     </thead>
                     <tbody>
                       {facturesFiltrees.map((f, i) => {
                         const ht = Number(f.total_ht) || 0
+                        const tva = tvaByFacture[f.id] || 0
+                        const ttc = ht + tva
                         const nb = nbLignesByFacture[f.id] ?? 0
                         return (
                           <tr
@@ -387,12 +514,12 @@ export default function AchatsListPage() {
                             <td style={tdM}>{f.numero_facture || '—'}</td>
                             <td style={tdM}>{formatDate(f.date_facture)}</td>
                             <td style={td}>
-                              {f.statut === 'bl'
-                                ? <span style={{ fontSize: 11, fontWeight: 600, padding: '2px 8px', borderRadius: 4, background: '#FEF3C7', color: '#92400E' }}>BL</span>
-                                : <span style={{ fontSize: 11, fontWeight: 600, padding: '2px 8px', borderRadius: 4, background: '#D1FAE5', color: '#065F46' }}>Facture</span>}
+                              <span style={badgeStyleFor(f.statut)}>{statutLabel(f.statut)}</span>
                             </td>
                             <td style={tdM}>{nb}</td>
                             <td style={tdR}>{formatEuro(ht)}</td>
+                            <td style={tdR}>{formatEuro(tva)}</td>
+                            <td style={tdR}>{formatEuro(ttc)}</td>
                             {role === 'admin' && (
                               <td style={{ ...td, textAlign: 'right' }} onClick={e => e.stopPropagation()}>
                                 <button
@@ -415,6 +542,9 @@ export default function AchatsListPage() {
                         </td>
                         <td style={td} colSpan={3} />
                         <td style={{ ...tdR, color: c.texte }}>{formatEuro(totalHT)}</td>
+                        <td style={{ ...tdR, color: c.texte }}>{formatEuro(totalTVA)}</td>
+                        <td style={{ ...tdR, color: c.texte }}>{formatEuro(totalTTC)}</td>
+                        {role === 'admin' && <td style={td} />}
                       </tr>
                     </tfoot>
                   </table>

--- a/components/IngredientAutocomplete.jsx
+++ b/components/IngredientAutocomplete.jsx
@@ -1,0 +1,169 @@
+'use client'
+import { useState, useRef, useLayoutEffect } from 'react'
+import { createPortal } from 'react-dom'
+import { useTheme } from '../lib/useTheme'
+
+const MAX_LIST_HEIGHT = 240
+const MARGIN = 4
+const VIEWPORT_PADDING = 8
+
+/**
+ * Champ de saisie de désignation pour ligne de facture, avec autocomplétion
+ * sur la liste des ingrédients du client.
+ *
+ * Différences avec <IngredientSearch> (utilisé dans les fiches techniques) :
+ * - value = texte libre (pas un ingredient_id)
+ * - onChange(text) → saisie libre, l'utilisateur peut taper une désignation
+ *   qui ne correspond à aucun ingrédient (ex : libellé OCR)
+ * - onSelect(ingredient) → quand l'utilisateur clique sur une suggestion ;
+ *   le parent décide de remplir la désignation et de lier l'ingrédient
+ *
+ * La liste de suggestions est rendue via un Portal (position fixed) pour
+ * échapper aux conteneurs `overflow` (tableau, modal) qui la rogneraient.
+ */
+export default function IngredientAutocomplete({
+  ingredients = [],
+  value = '',
+  onChange,
+  onSelect,
+  placeholder = 'Nom du produit',
+  style = {},
+  inputStyle = {},
+}) {
+  const { c } = useTheme()
+  const [ouvert, setOuvert] = useState(false)
+  const [surbrillance, setSurbrillance] = useState(-1)
+  const [coords, setCoords] = useState(null)
+  const inputRef = useRef(null)
+
+  const recherche = String(value || '')
+
+  // Match par début de mot (évite "BOEUF" quand on tape "OEUF")
+  const ingredientsFiltres = recherche.length > 0
+    ? ingredients.filter(i => {
+        const termeNorm = recherche.toLowerCase()
+        const nomNorm = (i.nom || '').toLowerCase()
+        return nomNorm.startsWith(termeNorm) ||
+          nomNorm.split(/[\s\-]+/).some(mot => mot.startsWith(termeNorm))
+      }).slice(0, 12)
+    : []
+
+  const computeCoords = () => {
+    if (!inputRef.current) return null
+    const rect = inputRef.current.getBoundingClientRect()
+    const spaceBelow = window.innerHeight - rect.bottom - VIEWPORT_PADDING
+    const spaceAbove = rect.top - VIEWPORT_PADDING
+    const flipAbove = spaceBelow < 120 && spaceAbove > spaceBelow
+    const maxHeight = Math.max(80, Math.min(MAX_LIST_HEIGHT, flipAbove ? spaceAbove : spaceBelow))
+    return {
+      left: rect.left,
+      width: rect.width,
+      top: flipAbove ? null : rect.bottom + MARGIN,
+      bottom: flipAbove ? window.innerHeight - rect.top + MARGIN : null,
+      maxHeight,
+    }
+  }
+
+  useLayoutEffect(() => {
+    if (!ouvert || ingredientsFiltres.length === 0) return
+    // Sync DOM measurement → state : useLayoutEffect est l'endroit prévu pour ça.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setCoords(computeCoords())
+    const onReposition = () => setCoords(computeCoords())
+    window.addEventListener('scroll', onReposition, true)
+    window.addEventListener('resize', onReposition)
+    return () => {
+      window.removeEventListener('scroll', onReposition, true)
+      window.removeEventListener('resize', onReposition)
+    }
+  }, [ouvert, recherche, ingredientsFiltres.length])
+
+  const handleInput = (e) => {
+    onChange(e.target.value)
+    setOuvert(true)
+    setSurbrillance(-1)
+  }
+
+  const handleSelect = (ing) => {
+    onSelect(ing)
+    setOuvert(false)
+    setSurbrillance(-1)
+  }
+
+  const handleKeyDown = (e) => {
+    if (!ouvert || ingredientsFiltres.length === 0) return
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setSurbrillance(prev => Math.min(prev + 1, ingredientsFiltres.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setSurbrillance(prev => Math.max(prev - 1, 0))
+    } else if (e.key === 'Enter' && surbrillance >= 0) {
+      e.preventDefault()
+      handleSelect(ingredientsFiltres[surbrillance])
+    } else if (e.key === 'Escape') {
+      setOuvert(false)
+    }
+  }
+
+  const handleBlur = () => {
+    // Délai pour permettre le onMouseDown des suggestions
+    setTimeout(() => setOuvert(false), 150)
+  }
+
+  const showList = ouvert && ingredientsFiltres.length > 0 && coords && typeof document !== 'undefined'
+
+  return (
+    <div style={{ position: 'relative', width: '100%', ...style }}>
+      <input
+        ref={inputRef}
+        type="text"
+        value={recherche}
+        onChange={handleInput}
+        onFocus={() => recherche.length > 0 && setOuvert(true)}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        style={inputStyle}
+      />
+
+      {showList && createPortal(
+        <div
+          style={{
+            position: 'fixed',
+            left: coords.left,
+            width: coords.width,
+            top: coords.top ?? undefined,
+            bottom: coords.bottom ?? undefined,
+            background: c.blanc, borderRadius: 8, zIndex: 1000,
+            border: `1px solid ${c.bordure}`,
+            boxShadow: '0 4px 20px rgba(0,0,0,0.1)',
+            maxHeight: coords.maxHeight, overflowY: 'auto',
+          }}
+        >
+          {ingredientsFiltres.map((ing, idx) => (
+            <div
+              key={ing.id}
+              onMouseDown={() => handleSelect(ing)}
+              onMouseEnter={() => setSurbrillance(idx)}
+              style={{
+                padding: '8px 12px', cursor: 'pointer', fontSize: 13,
+                color: c.texte,
+                background: surbrillance === idx ? c.accentClair : c.blanc,
+                borderBottom: idx < ingredientsFiltres.length - 1 ? `0.5px solid ${c.bordure}` : 'none',
+              }}
+            >
+              <div style={{ fontWeight: 500 }}>{ing.nom}</div>
+              {ing.prix_kg != null && (
+                <div style={{ fontSize: 11, color: c.texteMuted }}>
+                  {Number(ing.prix_kg).toFixed(2)} € / {ing.unite || 'kg'}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>,
+        document.body
+      )}
+    </div>
+  )
+}

--- a/lib/__tests__/achats.service.test.ts
+++ b/lib/__tests__/achats.service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { normDesignation } from '../services/achats.service'
+import { normDesignation, computeLigneEffective } from '../services/achats.service'
 
 describe('normDesignation', () => {
   it('normalizes accented characters', () => {
@@ -22,5 +22,41 @@ describe('normDesignation', () => {
 
   it('normalizes multiple spaces', () => {
     expect(normDesignation('tomates   cerises   bio')).toBe('tomates cerises bio')
+  })
+})
+
+describe('computeLigneEffective', () => {
+  it('calcule le montant standard sans remise (signe positif)', () => {
+    const r = computeLigneEffective({ quantite: 5, prix_unitaire_ht: 2 })
+    expect(r.prixEffectif).toBe(2)
+    expect(r.montantHt).toBe(10)
+    expect(r.remise).toBe(0)
+  })
+
+  it('applique la remise sur le prix unitaire', () => {
+    const r = computeLigneEffective({ quantite: 10, prix_unitaire_ht: 10, remise: 20 })
+    expect(r.prixEffectif).toBe(8)
+    expect(r.montantHt).toBe(80)
+    expect(r.remise).toBe(20)
+  })
+
+  it('avoir : montant négatif mais prix unitaire reste positif', () => {
+    const r = computeLigneEffective({ quantite: 3, prix_unitaire_ht: 4 }, -1)
+    // prix unitaire reste positif (sert de référence pour la mercuriale)
+    expect(r.prixEffectif).toBe(4)
+    // montant porte le signe → négatif pour un avoir
+    expect(r.montantHt).toBe(-12)
+  })
+
+  it('avoir avec remise : remise gardée, montant négatif', () => {
+    const r = computeLigneEffective({ quantite: 2, prix_unitaire_ht: 10, remise: 50 }, -1)
+    expect(r.prixEffectif).toBe(5)
+    expect(r.montantHt).toBe(-10)
+    expect(r.remise).toBe(50)
+  })
+
+  it('quantité ou prix à 0 donne un montant à 0', () => {
+    expect(computeLigneEffective({ quantite: 0, prix_unitaire_ht: 5 }).montantHt).toBe(0)
+    expect(computeLigneEffective({ quantite: 5, prix_unitaire_ht: 0 }).montantHt).toBe(0)
   })
 })

--- a/lib/achatsHelpers.js
+++ b/lib/achatsHelpers.js
@@ -54,11 +54,29 @@ export function makeLigneId() {
   return Math.random().toString(36).slice(2)
 }
 
+export const STATUT_BADGES = {
+  bl:      { label: 'BL',      bg: '#FEF3C7', fg: '#92400E' },
+  facture: { label: 'Facture', bg: '#D1FAE5', fg: '#065F46' },
+  avoir:   { label: 'Avoir',   bg: '#FEE2E2', fg: '#991B1B' },
+}
+
+export function badgeStyleFor(statut) {
+  const meta = STATUT_BADGES[statut] || STATUT_BADGES.facture
+  return {
+    fontSize: 11, fontWeight: 600, padding: '2px 8px', borderRadius: 4,
+    background: meta.bg, color: meta.fg,
+  }
+}
+
+export function statutLabel(statut) {
+  return (STATUT_BADGES[statut] || STATUT_BADGES.facture).label
+}
+
 /**
  * Enrichit une ligne de facture avec la réconciliation ingrédient.
  * 3 niveaux : mapping exact → nom normalisé exact → inclusion partielle.
  */
-export function enrichLigne(ligne, fournisseurMapping, ingredientsById, ingredientsByNorm) {
+export function enrichLigne(ligne, fournisseurMapping, ingredientsById, ingredientsByNorm, tvaByIngredient = {}) {
   const norm = normDesig(ligne.designation)
 
   // Niveau 1 : mapping appris
@@ -81,17 +99,67 @@ export function enrichLigne(ligne, fournisseurMapping, ingredientsById, ingredie
 
   const ingId = ing?.id ?? null
   const prixActuel = ing ? Number(ing.prix_kg) : null
-  const prixLigne = Number(ligne.prix_unitaire_ht) || 0
-  const delta = prixActuel && prixLigne ? ((prixLigne - prixActuel) / prixActuel) * 100 : null
+  const prixLigneActuel = Number(ligne.prix_unitaire_ht) || 0
+
+  // Distingue "prix auto-rempli" (depuis la mercuriale) vs "prix saisi par l'utilisateur".
+  // - true : le prix vient d'un pré-remplissage automatique, on peut le réécrire/effacer
+  //   au prochain enrich (ex : si la désignation change et qu'on perd la reconnaissance)
+  // - false : l'utilisateur a tapé son propre prix, on ne le touche plus jamais
+  //   (sauf si le user efface le champ explicitement)
+  // - undefined : nouvelle ligne, on traite comme "auto" par défaut
+  const prixAuto = ligne.prix_auto !== false
+
+  let prixLigne
+  let nouveauPrixAuto
+  if (ing && prixAuto) {
+    // Ingrédient reconnu + l'utilisateur n'a pas saisi son propre prix → prix de réf
+    prixLigne = prixActuel != null && Number.isFinite(prixActuel) ? prixActuel : 0
+    nouveauPrixAuto = true
+  } else if (!ing && prixAuto) {
+    // Plus reconnu et le prix venait d'un pré-remplissage auto → reset à 0
+    prixLigne = 0
+    nouveauPrixAuto = true
+  } else {
+    // L'utilisateur a saisi son propre prix → on le respecte
+    prixLigne = prixLigneActuel
+    nouveauPrixAuto = false
+  }
+
+  const delta = prixActuel && prixLigne && !nouveauPrixAuto
+    ? ((prixLigne - prixActuel) / prixActuel) * 100
+    : null
+
+  // ── Pré-remplissage TVA ────────────────────────────────────────────────
+  // Même logique que pour le prix : si l'utilisateur n'a pas saisi sa propre TVA,
+  // on propose le dernier taux_tva utilisé pour cet ingrédient (historique).
+  const tvaAuto = ligne.tva_auto !== false
+  const tvaHistorique = ingId && tvaByIngredient[ingId] != null ? Number(tvaByIngredient[ingId]) : null
+  let tauxTvaLigne
+  let nouveauTvaAuto
+  if (ing && tvaAuto && tvaHistorique != null) {
+    tauxTvaLigne = tvaHistorique
+    nouveauTvaAuto = true
+  } else if (!ing && tvaAuto) {
+    tauxTvaLigne = null
+    nouveauTvaAuto = true
+  } else {
+    tauxTvaLigne = ligne.taux_tva ?? null
+    nouveauTvaAuto = false
+  }
 
   return {
     ...ligne,
     _id: ligne._id || makeLigneId(),
+    prix_unitaire_ht: prixLigne,
+    prix_auto: nouveauPrixAuto,
+    taux_tva: tauxTvaLigne,
+    tva_auto: nouveauTvaAuto,
     ingredient_id: ingId,
     ingredient_nom: ing?.nom ?? null,
     prix_actuel: prixActuel,
     deltaPrix: delta,
     reconnu: !!ingId,
-    updatePrice: !!ingId,
+    // MAJ prix : seulement si l'utilisateur a saisi un prix réel (pas auto-rempli).
+    updatePrice: !!ingId && !nouveauPrixAuto,
   }
 }

--- a/lib/services/achats.service.ts
+++ b/lib/services/achats.service.ts
@@ -19,10 +19,15 @@ export function normDesignation(s: string | null | undefined): string {
     .trim()
 }
 
-function computeLigneEffective(ligne: { quantite: number; prix_unitaire_ht: number; remise?: number }) {
+export function computeLigneEffective(
+  ligne: { quantite: number; prix_unitaire_ht: number; remise?: number },
+  signe: 1 | -1 = 1,
+) {
   const remise = ligne.remise ?? 0
+  // prix unitaire reste positif (sert de référence pour la mercuriale et update prix ingrédient).
+  // Seul le montant porte le signe — un avoir aboutit à un montant_ht négatif.
   const prixEffectif = ligne.prix_unitaire_ht * (1 - remise / 100)
-  const montantHt = ligne.quantite * prixEffectif
+  const montantHt = ligne.quantite * prixEffectif * signe
   return { prixEffectif, montantHt, remise }
 }
 
@@ -103,8 +108,9 @@ export async function saveFacture(
   input: SaveFactureInput,
   userId: string
 ) {
-  const { clientId, fournisseur, numeroFacture, dateFacture, statut, lignes, fileBase64, fileMime, forceInsert, tauxTva } = input
+  const { clientId, fournisseur, numeroFacture, dateFacture, statut, lignes: lignesInput, fileBase64, fileMime, forceInsert, tauxTva, montantTva, autoCreateMissing } = input
   const nomFournisseur = fournisseur.trim()
+  const signe: 1 | -1 = statut === 'avoir' ? -1 : 1
 
   // 1. Check duplicate
   if (numeroFacture?.trim() && !forceInsert) {
@@ -122,9 +128,62 @@ export async function saveFacture(
       : Promise.resolve(null),
   ])
 
-  // 3. Calculate total HT
+  // 2bis. Création auto des ingrédients manquants (avant insert lignes).
+  // Pour chaque ligne sans ingredient_id mais avec une designation non vide :
+  //   - on tente d'abord de matcher un ingrédient existant par nom normalisé
+  //   - sinon on le crée avec nom = designation, unite = ligne.unite ?? 'kg',
+  //     prix_kg = prix unitaire de la ligne
+  // Idempotent : si plusieurs lignes partagent la même désignation, un seul
+  // ingrédient est créé et toutes les lignes pointent dessus.
+  let lignes = lignesInput
+  let autoCreatedCount = 0
+  if (autoCreateMissing) {
+    const missing = lignesInput.filter((l) => !l.ingredient_id && l.designation?.trim())
+    if (missing.length > 0) {
+      const norms = [...new Set(missing.map((l) => normDesignation(l.designation)))].filter(Boolean)
+      // Recherche des ingrédients déjà existants pour ces normes (par nom exact normalisé)
+      const { data: existingIngs } = await db
+        .from('ingredients')
+        .select('id, nom, unite, prix_kg')
+        .eq('client_id', clientId)
+      const ingByNorm: Record<string, { id: string }> = {}
+      for (const ing of existingIngs ?? []) {
+        ingByNorm[normDesignation((ing as { nom: string }).nom)] = ing as { id: string }
+      }
+      const idByNorm: Record<string, string> = {}
+      for (const norm of norms) {
+        if (ingByNorm[norm]) {
+          idByNorm[norm] = ingByNorm[norm].id
+          continue
+        }
+        // À créer : prend la 1re ligne qui matche cette norme comme source
+        const src = missing.find((l) => normDesignation(l.designation) === norm)
+        if (!src) continue
+        // Utilise findOrCreateIngredient : retourne l'existant si déjà présent
+        // pour le client, sinon crée. Conflit global → erreur exploitable.
+        const ing = await findOrCreateIngredient(
+          db,
+          clientId,
+          src.designation,
+          src.unite,
+          Number(src.prix_unitaire_ht) || 0,
+        )
+        idByNorm[norm] = ing.id
+        autoCreatedCount++
+      }
+      // Reassign ingredient_id sur les lignes
+      lignes = lignesInput.map((l) => {
+        if (l.ingredient_id || !l.designation?.trim()) return l
+        const norm = normDesignation(l.designation)
+        const id = idByNorm[norm]
+        return id ? { ...l, ingredient_id: id } : l
+      })
+    }
+  }
+
+  // 3. Calculate total HT (négatif pour un avoir)
   const totalHt = lignes.reduce((sum, l) => {
-    const { montantHt } = computeLigneEffective(l)
+    const { montantHt } = computeLigneEffective(l, signe)
     return sum + montantHt
   }, 0)
 
@@ -139,7 +198,9 @@ export async function saveFacture(
       date_facture: dateFacture,
       total_ht: totalHt,
       taux_tva: tauxTva ?? null,
-      statut: statut === 'bl' ? 'bl' : 'facture',
+      // Pour un avoir, le montant TVA suit naturellement le signe (négatif).
+      montant_tva: montantTva != null ? montantTva * signe : null,
+      statut,
       fichier_url: fichierUrl,
     })
     .select()
@@ -149,7 +210,7 @@ export async function saveFacture(
 
   // 5. Insert lines
   const lignesInsert = lignes.map((l) => {
-    const { prixEffectif, montantHt, remise } = computeLigneEffective(l)
+    const { prixEffectif, montantHt, remise } = computeLigneEffective(l, signe)
     return {
       facture_id: facture.id,
       client_id: clientId,
@@ -160,6 +221,7 @@ export async function saveFacture(
       prix_unitaire_ht: prixEffectif,
       remise,
       montant_ht: montantHt,
+      taux_tva: l.taux_tva ?? null,
     }
   })
 
@@ -193,6 +255,7 @@ export async function saveFacture(
         facture_id: facture.id,
         lignes_count: lignes.length,
         prix_maj: toUpdate.length,
+        auto_created_ingredients: autoCreatedCount,
       },
       user_id: userId,
     }),
@@ -216,7 +279,16 @@ export async function saveFacture(
     })(),
   ])
 
-  return { facture_id: facture.id, prix_maj: toUpdate.length }
+  // Le client veut savoir si un fichier était attendu et s'il a été stocké :
+  // permet d'afficher un avertissement quand l'upload Supabase Storage échoue
+  // (non bloquant côté serveur, mais on doit alerter l'utilisateur).
+  const fileExpected = !!(fileBase64 && fileMime)
+  return {
+    facture_id: facture.id,
+    prix_maj: toUpdate.length,
+    auto_created: autoCreatedCount,
+    file_uploaded: fileExpected ? !!fichierUrl : null,
+  }
 }
 
 export async function updateFacture(
@@ -231,6 +303,7 @@ export async function updateFacture(
     dateFacture: 'date_facture',
     statut: 'statut',
     tauxTva: 'taux_tva',
+    montantTva: 'montant_tva',
   }
 
   const dbUpdates: Record<string, unknown> = {}
@@ -248,12 +321,26 @@ export async function updateFacture(
     unite?: string | null
     prix_unitaire_ht: number
     remise?: number
+    taux_tva?: number | null
   }> | undefined
 
   if (lignes) {
+    // Détermine le signe applicable : statut envoyé en update, sinon statut courant
+    let statutEffectif = (dbUpdates.statut as string | undefined) || undefined
+    if (!statutEffectif) {
+      const { data: cur } = await db
+        .from('achats_factures')
+        .select('statut')
+        .eq('id', factureId)
+        .eq('client_id', clientId)
+        .maybeSingle()
+      statutEffectif = (cur?.statut as string) || 'facture'
+    }
+    const signe: 1 | -1 = statutEffectif === 'avoir' ? -1 : 1
+
     // Recalcul du total HT depuis les nouvelles lignes
     const totalHt = lignes.reduce((sum, l) => {
-      const { montantHt } = computeLigneEffective(l)
+      const { montantHt } = computeLigneEffective(l, signe)
       return sum + montantHt
     }, 0)
     dbUpdates.total_ht = totalHt
@@ -269,7 +356,7 @@ export async function updateFacture(
     // Insertion des nouvelles lignes
     if (lignes.length > 0) {
       const lignesInsert = lignes.map((l) => {
-        const { prixEffectif, montantHt, remise } = computeLigneEffective(l)
+        const { prixEffectif, montantHt, remise } = computeLigneEffective(l, signe)
         return {
           facture_id: factureId,
           client_id: clientId,
@@ -280,6 +367,7 @@ export async function updateFacture(
           prix_unitaire_ht: prixEffectif,
           remise,
           montant_ht: montantHt,
+          taux_tva: l.taux_tva ?? null,
         }
       })
       const { error: iErr } = await db.from('achats_lignes').insert(lignesInsert)
@@ -316,6 +404,38 @@ export async function updateFacture(
     throw new ValidationError('Aucun champ à mettre à jour.')
   }
 
+  // Si le statut change vers/depuis 'avoir' SANS que les lignes aient été
+  // re-postées, on bascule le signe des lignes existantes et du total pour
+  // garder la cohérence comptable.
+  const newStatut = dbUpdates.statut as string | undefined
+  if (newStatut && !lignes) {
+    const { data: cur } = await db
+      .from('achats_factures')
+      .select('statut, total_ht, montant_tva')
+      .eq('id', factureId)
+      .eq('client_id', clientId)
+      .maybeSingle()
+    const wasAvoir = cur?.statut === 'avoir'
+    const willBeAvoir = newStatut === 'avoir'
+    if (cur && wasAvoir !== willBeAvoir) {
+      const { data: existingLignes } = await db
+        .from('achats_lignes')
+        .select('id, montant_ht')
+        .eq('facture_id', factureId)
+        .eq('client_id', clientId)
+      for (const l of existingLignes ?? []) {
+        await db
+          .from('achats_lignes')
+          .update({ montant_ht: -Number(l.montant_ht) })
+          .eq('id', l.id)
+      }
+      dbUpdates.total_ht = -Number(cur.total_ht ?? 0)
+      if (cur.montant_tva != null) {
+        dbUpdates.montant_tva = -Number(cur.montant_tva)
+      }
+    }
+  }
+
   const { error } = await db
     .from('achats_factures')
     .update(dbUpdates)
@@ -348,26 +468,61 @@ export async function deleteFacture(
   return { deleted: true, soft: true }
 }
 
-export async function createIngredient(
+/**
+ * Cherche un ingrédient existant pour ce client (par nom case-insensitive),
+ * sinon le crée. Si la création échoue à cause de l'unique global sur `nom`
+ * (la contrainte est sur `nom` seul, pas par client_id), c'est qu'un autre
+ * établissement utilise déjà ce nom — on remonte une ConflictError exploitable.
+ */
+export async function findOrCreateIngredient(
   db: SupabaseClient,
-  input: CreateIngredientInput
+  clientId: string,
+  nom: string,
+  unite?: string | null,
+  prix_kg?: number | null,
 ) {
-  const { clientId, nom, unite, prix_kg } = input
+  // Convention skalcook : tous les noms d'ingrédients en MAJUSCULES.
+  const nomTrim = nom.trim().toUpperCase()
+  if (!nomTrim) throw new ValidationError('Nom d\'ingrédient requis.')
 
-  const { data, error } = await db
+  // 1. Existe pour ce client ?
+  const { data: existing } = await db
+    .from('ingredients')
+    .select('id, nom, unite, prix_kg')
+    .eq('client_id', clientId)
+    .ilike('nom', nomTrim)
+    .maybeSingle()
+  if (existing) return existing
+
+  // 2. Création
+  const { data: created, error } = await db
     .from('ingredients')
     .insert({
       client_id: clientId,
-      nom: nom.trim(),
-      unite,
+      nom: nomTrim,
+      unite: unite || 'kg',
       prix_kg: prix_kg ?? 0,
       est_sous_fiche: false,
     })
     .select('id, nom, unite, prix_kg')
     .single()
 
-  if (error) throw new Error(error.message)
-  return data
+  if (error) {
+    // Conflit unique global → un autre établissement a réservé ce nom
+    if (error.code === '23505' || /duplicate key/i.test(error.message)) {
+      throw new ConflictError(`L'ingrédient "${nomTrim}" est déjà utilisé par un autre établissement. Modifie légèrement le nom.`)
+    }
+    throw new Error(error.message)
+  }
+  return created
+}
+
+export async function createIngredient(
+  db: SupabaseClient,
+  input: CreateIngredientInput
+) {
+  const { clientId, nom, unite, prix_kg } = input
+  return findOrCreateIngredient(db, clientId, nom, unite, prix_kg)
 }
 
 export async function getMercuriale(db: SupabaseClient, clientId: string) {
@@ -493,7 +648,7 @@ export async function getMercuriale(db: SupabaseClient, clientId: string) {
 }
 
 export async function getReconciliationData(db: SupabaseClient, clientId: string) {
-  const [mappingRes, ingredientsRes] = await Promise.all([
+  const [mappingRes, ingredientsRes, lignesRes] = await Promise.all([
     db
       .from('fournisseur_mapping')
       .select('*')
@@ -504,10 +659,33 @@ export async function getReconciliationData(db: SupabaseClient, clientId: string
       .eq('client_id', clientId)
       .eq('est_sous_fiche', false)
       .order('nom'),
+    // Dernier taux_tva utilisé par ingrédient (pour pré-remplissage en saisie).
+    // On prend les 5000 dernières lignes du client, suffisant pour reconstituer
+    // l'historique récent sans faire un coûteux DISTINCT ON par ingrédient.
+    db
+      .from('achats_lignes')
+      .select('ingredient_id, taux_tva, created_at')
+      .eq('client_id', clientId)
+      .not('ingredient_id', 'is', null)
+      .not('taux_tva', 'is', null)
+      .order('created_at', { ascending: false })
+      .limit(5000),
   ])
+
+  // Pour chaque ingrédient, on garde le taux_tva de la ligne la plus récente.
+  const tvaByIngredient: Record<string, number> = {}
+  for (const l of lignesRes.data ?? []) {
+    const id = (l as { ingredient_id?: string | null }).ingredient_id
+    if (!id || id in tvaByIngredient) continue
+    const taux = Number((l as { taux_tva?: number | null }).taux_tva)
+    if (Number.isFinite(taux) && taux >= 0 && taux <= 100) {
+      tvaByIngredient[id] = taux
+    }
+  }
 
   return {
     mappings: mappingRes.data ?? [],
     ingredients: ingredientsRes.data ?? [],
+    tvaByIngredient,
   }
 }

--- a/lib/validators/achats.schema.ts
+++ b/lib/validators/achats.schema.ts
@@ -12,6 +12,9 @@ const ligneFactureSchema = z.object({
   unite:            z.string().nullable().optional(),
   prix_unitaire_ht: z.coerce.number().min(0),
   remise:           z.coerce.number().min(0).max(100).default(0),
+  // Taux de TVA spécifique à la ligne (pour factures multi-taux). Si null,
+  // on retombera sur le taux global de la facture (achats_factures.taux_tva).
+  taux_tva:         z.coerce.number().min(0).max(100).nullable().optional(),
   updatePrice:      z.boolean().optional(),
 })
 
@@ -23,12 +26,17 @@ export const saveFactureSchema = z.object({
   fournisseur:    z.string().min(1, 'Fournisseur requis').max(255),
   numeroFacture:  z.string().max(100).optional().nullable(),
   dateFacture:    z.string().min(1, 'Date requise'),
-  statut:         z.enum(['bl', 'facture']).default('facture'),
+  statut:         z.enum(['bl', 'facture', 'avoir']).default('facture'),
   lignes:         z.array(ligneFactureSchema).min(1, 'Au moins une ligne requise'),
-  fileBase64:     z.string().optional(),
-  fileMime:       z.enum(['application/pdf', 'image/png', 'image/webp', 'image/jpeg']).optional(),
+  // En mode manuel, le client envoie null (pas undefined) → on accepte les deux.
+  fileBase64:     z.string().nullable().optional(),
+  fileMime:       z.enum(['application/pdf', 'image/png', 'image/webp', 'image/jpeg']).nullable().optional(),
   forceInsert:    z.boolean().optional(),
   tauxTva:        z.coerce.number().min(0).max(100).optional(),
+  // Montant TVA total saisi en pied de facture (override). Si fourni, prime
+  // sur le calcul automatique depuis les taux par ligne / le taux global.
+  montantTva:     z.coerce.number().min(0).nullable().optional(),
+  autoCreateMissing: z.boolean().optional(),
 })
 
 export type SaveFactureInput = z.infer<typeof saveFactureSchema>
@@ -40,8 +48,9 @@ export const updateFactureSchema = z.object({
   fournisseur:    z.string().min(1).max(255).optional(),
   numeroFacture:  z.string().max(100).optional().nullable(),
   dateFacture:    z.string().optional(),
-  statut:         z.enum(['bl', 'facture']).optional(),
+  statut:         z.enum(['bl', 'facture', 'avoir']).optional(),
   tauxTva:        z.coerce.number().min(0).max(100).optional(),
+  montantTva:     z.coerce.number().min(0).nullable().optional(),
   lignes:         z.array(ligneFactureSchema).optional(),
 })
 

--- a/supabase/migrations/20260508000000_achats_statut_avoir_fichier_url.sql
+++ b/supabase/migrations/20260508000000_achats_statut_avoir_fichier_url.sql
@@ -1,0 +1,47 @@
+-- ─── achats_factures : capture des colonnes existantes en prod + ajout 'avoir' ──
+--
+-- Contexte : les colonnes `statut` et `fichier_url` étaient utilisées dans le
+-- code (services + UI) mais absentes des migrations. Cette migration les
+-- déclare formellement et étend l'enum statut pour gérer les avoirs.
+
+-- 1. Colonnes (idempotent)
+ALTER TABLE public.achats_factures
+  ADD COLUMN IF NOT EXISTS statut      text,
+  ADD COLUMN IF NOT EXISTS fichier_url text;
+
+-- 2. Backfill : toute ligne sans statut devient 'facture'
+UPDATE public.achats_factures
+   SET statut = 'facture'
+ WHERE statut IS NULL;
+
+-- 3. NOT NULL + DEFAULT
+ALTER TABLE public.achats_factures
+  ALTER COLUMN statut SET DEFAULT 'facture',
+  ALTER COLUMN statut SET NOT NULL;
+
+-- 4. Check constraint : bl | facture | avoir
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'achats_factures_statut_check'
+       AND conrelid = 'public.achats_factures'::regclass
+  ) THEN
+    ALTER TABLE public.achats_factures DROP CONSTRAINT achats_factures_statut_check;
+  END IF;
+END $$;
+
+ALTER TABLE public.achats_factures
+  ADD CONSTRAINT achats_factures_statut_check
+  CHECK (statut IN ('bl', 'facture', 'avoir'));
+
+-- 5. Index sur (client_id, date_facture) pour les filtres et exports
+CREATE INDEX IF NOT EXISTS achats_factures_client_date_idx
+  ON public.achats_factures (client_id, date_facture DESC);
+
+-- 6. Index sur statut pour les filtres
+CREATE INDEX IF NOT EXISTS achats_factures_client_statut_idx
+  ON public.achats_factures (client_id, statut);
+
+-- NOTE : l'unique partiel sur (client_id, numero_facture) est reporté à une
+-- migration ultérieure car il existe au moins 1 doublon en prod à arbitrer.

--- a/supabase/migrations/20260508010000_achats_factures_unique_numero.sql
+++ b/supabase/migrations/20260508010000_achats_factures_unique_numero.sql
@@ -1,0 +1,5 @@
+-- Unicité partielle sur (client_id, numero_facture) hors soft-delete.
+-- Les doublons existants ont été arbitrés (soft-deletés) avant l'ajout.
+CREATE UNIQUE INDEX IF NOT EXISTS achats_factures_client_numero_unique
+  ON public.achats_factures (client_id, numero_facture)
+  WHERE numero_facture IS NOT NULL AND deleted_at IS NULL;

--- a/supabase/migrations/20260508020000_achats_lignes_taux_tva.sql
+++ b/supabase/migrations/20260508020000_achats_lignes_taux_tva.sql
@@ -1,0 +1,4 @@
+-- TVA par ligne pour factures avec plusieurs taux (ex: alimentaire 5,5% + non-alim 20%).
+-- Si NULL, fallback sur achats_factures.taux_tva pour la rétro-compatibilité.
+ALTER TABLE public.achats_lignes
+  ADD COLUMN IF NOT EXISTS taux_tva numeric;

--- a/supabase/migrations/20260509000000_fournisseurs_rls_acces_clients.sql
+++ b/supabase/migrations/20260509000000_fournisseurs_rls_acces_clients.sql
@@ -1,0 +1,22 @@
+-- Aligne les RLS de fournisseurs sur le pattern multi-tenant (user_has_client_access).
+-- Avant : politiques basées sur profils.client_id direct → un superadmin
+-- ne pouvait pas voir les fournisseurs d'un autre client que celui de son profil.
+-- Après : cohérent avec achats_factures / ingredients / etc.
+
+DROP POLICY IF EXISTS fournisseurs_select ON public.fournisseurs;
+DROP POLICY IF EXISTS fournisseurs_insert ON public.fournisseurs;
+DROP POLICY IF EXISTS fournisseurs_update ON public.fournisseurs;
+DROP POLICY IF EXISTS fournisseurs_delete ON public.fournisseurs;
+
+CREATE POLICY fournisseurs_select ON public.fournisseurs
+  FOR SELECT USING (public.user_has_client_access(client_id));
+
+CREATE POLICY fournisseurs_insert ON public.fournisseurs
+  FOR INSERT WITH CHECK (public.user_has_client_access(client_id));
+
+CREATE POLICY fournisseurs_update ON public.fournisseurs
+  FOR UPDATE USING (public.user_has_client_access(client_id))
+              WITH CHECK (public.user_has_client_access(client_id));
+
+CREATE POLICY fournisseurs_delete ON public.fournisseurs
+  FOR DELETE USING (public.user_has_client_access(client_id));

--- a/supabase/migrations/20260509010000_achats_factures_montant_tva.sql
+++ b/supabase/migrations/20260509010000_achats_factures_montant_tva.sql
@@ -1,0 +1,6 @@
+-- Montant TVA total saisi au pied de facture (override). Si NULL, on calcule
+-- la TVA depuis achats_lignes.taux_tva (avec fallback sur achats_factures.taux_tva).
+-- Si NOT NULL, le montant saisi prime sur le calcul (utile quand l'OCR détecte
+-- mal les taux par ligne ou pour les factures multi-taux).
+ALTER TABLE public.achats_factures
+  ADD COLUMN IF NOT EXISTS montant_tva numeric;


### PR DESCRIPTION
## Summary
- Refonte complète du module achats : OCR enrichi, TVA par ligne, statut avoir, cartes fournisseurs
- UI import retravaillée : tableau desktop / cartes mobile + OCR side-by-side, autocomplete ingrédients (React Portal pour échapper au clipping `overflow`)
- Migrations Supabase formalisées (déjà appliquées en prod) : statut/fichier_url/montant_tva sur factures, taux_tva par ligne, RLS fournisseurs alignées multi-tenant, unique partiel sur (client_id, numero_facture)

## Test plan
- [x] vitest : 57/57 passants
- [x] eslint : 0 erreur sur les fichiers touchés
- [x] Migrations vérifiées en prod (colonnes, contraintes, index, policies présents)
- [x] Tests fonctionnels en local (saisie manuelle, OCR, création/lien ingrédient, dropdown autocomplete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)