### PR TITLE
fix(achats): OCR opus-4-7 + sanity-check qty×PU

### DIFF
--- a/app/api/achats/parse-facture/route.ts
+++ b/app/api/achats/parse-facture/route.ts
@@ -23,7 +23,7 @@ const schema = z.object({
   clientId: z.string().uuid(),
 })
 
-const PROMPT_EXTRACTION = `Tu analyses une photo ou scan d'une facture fournisseur de restauration.
+const PROMPT_EXTRACTION = `Tu analyses une photo ou scan d'une facture fournisseur de restauration française.
 Extrais les informations suivantes et retourne UNIQUEMENT du JSON valide, sans markdown, sans texte avant ou après.
 
 Format attendu :
@@ -38,24 +38,32 @@ Format attendu :
       "quantite": 5.0,
       "unite": "kg",
       "prix_unitaire_ht": 2.50,
+      "montant_ht": 12.50,
       "taux_tva": 5.5
     }
   ]
 }
 
-Règles :
-- unite doit être l'unité standard la plus proche (kg, g, L, mL, pièce, carton, etc.)
-- prix_unitaire_ht est le prix HT PAR UNITÉ (pas le total de la ligne)
-- taux_tva est le taux de TVA applicable à la ligne en pourcentage (ex: 5.5 pour 5,5%, 10 pour 10%, 20 pour 20%).
-  Beaucoup de factures alimentaires distinguent plusieurs taux (5,5% pour les denrées,
-  10% pour la restauration sur place, 20% pour le non-alimentaire). Cherche les
-  colonnes "Code TVA", "Taux", "TVA" ou les codes G1/G2/G3 qui renvoient à un
-  tableau récap en pied de page. Si tu ne peux pas le déduire, utilise null.
-- montant_tva_total est le total de la TVA en euros tel qu'il apparaît au pied
-  de la facture (ligne "Montant TVA" ou "Total TVA"). Quand il y a plusieurs
-  taux, c'est la somme des TVA par taux. Pas en pourcentage. Si absent, null.
-- Si une valeur est absente ou illisible, utilise null
-- Ne retourne QUE le JSON, rien d'autre`
+Règles importantes :
+- FORMAT NUMÉRIQUE FRANÇAIS : sur ces factures, la virgule est le séparateur DÉCIMAL.
+  Exemples : "1,610" = 1.61   "3,22" = 3.22   "2,000" = 2.0   "0,18" = 0.18.
+  Renvoie TOUJOURS des nombres JSON avec un point décimal (ex: 1.61, 3.22, 2.0).
+  Le séparateur de milliers est l'espace ou rien (ex: "1 234,56" = 1234.56).
+- unite : utilise l'unité standard la plus proche (kg, g, L, mL, pièce, carton, etc.).
+  Si la facture indique "U" / "Un" / "Unité", utilise "pièce".
+- prix_unitaire_ht : prix HT PAR UNITÉ (colonne "P.U.", "Prix unitaire HT", "PU HT", etc.).
+- montant_ht : total HT de la ligne (colonne "Montant HT", "Total HT", "Total ligne").
+  Permet de cross-vérifier : montant_ht ≈ quantite × prix_unitaire_ht.
+  Si tu lis bien le montant_ht mais pas le P.U., renseigne au moins montant_ht.
+- taux_tva : taux de TVA de la ligne en pourcentage (ex: 5.5 pour 5,5%, 10, 20).
+  Les factures alimentaires distinguent souvent plusieurs taux (5,5% denrées,
+  10% restauration sur place, 20% non-alimentaire). Cherche les colonnes
+  "Code TVA", "Taux", "TVA" ou les codes G1/G2/G3 qui renvoient à un récap
+  en pied de page. Si tu ne peux pas déduire, null.
+- montant_tva_total : total TVA en euros au pied de facture ("Montant TVA"
+  ou "Total TVA"). Pas en pourcentage. Si absent, null.
+- Si une valeur est absente ou illisible, utilise null.
+- Ne retourne QUE le JSON, rien d'autre.`
 
 export const POST = apiHandler({
   schema,
@@ -104,11 +112,20 @@ export const POST = apiHandler({
       .map((l) => {
         const tauxRaw = l.taux_tva
         const taux = tauxRaw == null ? null : Number(tauxRaw)
+        const quantite = Number(l.quantite) || 1
+        const puRaw = Number(l.prix_unitaire_ht)
+        const montantHtRaw = Number(l.montant_ht)
+        const montantHt = Number.isFinite(montantHtRaw) && montantHtRaw > 0 ? montantHtRaw : null
+        // Si l'IA n'a pas réussi à lire le P.U. mais a bien lu le montant HT,
+        // dérive le P.U. : prix_unitaire_ht = montant_ht / quantite.
+        const prixUnitaire = Number.isFinite(puRaw) && puRaw > 0
+          ? puRaw
+          : (montantHt != null && quantite > 0 ? montantHt / quantite : 0)
         return {
           designation: String(l.designation ?? '').trim(),
-          quantite: Number(l.quantite) || 1,
+          quantite,
           unite: String(l.unite ?? '').trim() || null,
-          prix_unitaire_ht: Number(l.prix_unitaire_ht) || 0,
+          prix_unitaire_ht: prixUnitaire,
           taux_tva: taux != null && Number.isFinite(taux) && taux >= 0 && taux <= 100 ? taux : null,
         }
       })

--- a/app/api/achats/parse-facture/route.ts
+++ b/app/api/achats/parse-facture/route.ts
@@ -77,8 +77,8 @@ export const POST = apiHandler({
       : { type: 'image' as const, source: { type: 'base64' as const, media_type: mimeType as 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif', data: fileBase64 } }
 
     const message = await getAnthropic().messages.create({
-      model: 'claude-opus-4-5',
-      max_tokens: 2048,
+      model: 'claude-opus-4-7',
+      max_tokens: 4096,
       messages: [
         {
           role: 'user',
@@ -107,6 +107,25 @@ export const POST = apiHandler({
       )
     }
 
+    // Décide du prix unitaire HT à partir de ce que Claude a renvoyé :
+    //   - prix_unitaire_ht (P.U.) ET/OU montant_ht (total ligne)
+    //
+    // Stratégie :
+    //   1. Si on a montant_ht et quantite > 0, calcule le PU "vérité" = montant_ht / quantite.
+    //   2. Si on a aussi un PU IA :
+    //      - les deux sont cohérents (écart < 5%) → on prend le PU IA (plus précis sur les centimes).
+    //      - sinon (ex: l'IA a lu "1,610" comme 1610 au lieu de 1.61) → on prend le PU "vérité".
+    //   3. Si on n'a que le PU IA → on l'utilise tel quel.
+    //   4. Si on n'a rien → 0.
+    const resolvePrixUnitaire = (puIA: number | null, montantHt: number | null, qte: number) => {
+      const puVerite = montantHt != null && qte > 0 ? montantHt / qte : null
+      if (puIA != null && puVerite != null) {
+        const ecart = Math.abs(puIA - puVerite) / Math.max(puVerite, 0.01)
+        return ecart < 0.05 ? puIA : puVerite
+      }
+      return puIA ?? puVerite ?? 0
+    }
+
     const lignes = ((parsed.lignes as Array<Record<string, unknown>>) || [])
       .filter((l) => l && l.designation)
       .map((l) => {
@@ -115,12 +134,9 @@ export const POST = apiHandler({
         const quantite = Number(l.quantite) || 1
         const puRaw = Number(l.prix_unitaire_ht)
         const montantHtRaw = Number(l.montant_ht)
+        const puIA = Number.isFinite(puRaw) && puRaw > 0 ? puRaw : null
         const montantHt = Number.isFinite(montantHtRaw) && montantHtRaw > 0 ? montantHtRaw : null
-        // Si l'IA n'a pas réussi à lire le P.U. mais a bien lu le montant HT,
-        // dérive le P.U. : prix_unitaire_ht = montant_ht / quantite.
-        const prixUnitaire = Number.isFinite(puRaw) && puRaw > 0
-          ? puRaw
-          : (montantHt != null && quantite > 0 ? montantHt / quantite : 0)
+        const prixUnitaire = resolvePrixUnitaire(puIA, montantHt, quantite)
         return {
           designation: String(l.designation ?? '').trim(),
           quantite,
@@ -129,6 +145,16 @@ export const POST = apiHandler({
           taux_tva: taux != null && Number.isFinite(taux) && taux >= 0 && taux <= 100 ? taux : null,
         }
       })
+
+    // Diagnostic : aide à comprendre les régressions OCR (lignes sans prix).
+    const sansPrix = lignes.filter((l) => !l.prix_unitaire_ht).length
+    if (sansPrix > 0) {
+      console.warn(
+        `[parse-facture] ${sansPrix}/${lignes.length} lignes sans prix.`,
+        'Échantillon brut:',
+        JSON.stringify(((parsed.lignes as unknown[]) || []).slice(0, 3))
+      )
+    }
 
     // Filtre date_facture : on n'accepte que YYYY-MM-DD valide, sinon null
     // (évite que Claude renvoie "hier" ou "2024-13-45" et fasse péter l'insert)

--- a/app/controle-gestion/achats/import/page.js
+++ b/app/controle-gestion/achats/import/page.js
@@ -393,6 +393,9 @@ export default function AchatsImportPage() {
     setLignes(prev => prev.map(l =>
       l._id !== ligne._id ? l : {
         ...l,
+        // Préserve l'override de désignation envoyé par le caller (ex: autocomplete
+        // qui force le nom canonique de l'ingrédient sélectionné).
+        designation:      ligne.designation ?? l.designation,
         prix_unitaire_ht: prixLigneFinal,
         prix_auto:        !userHadOwnPrice,
         taux_tva:         tauxTvaFinal,


### PR DESCRIPTION
## Summary
Le précédent fix OCR (#56) ne suffisait pas sur les factures testées par l'utilisateur : Claude renvoyait toujours \`prix_unitaire_ht=null\` ou des nombres 1000× trop grands (ex: \"1,610\" lu comme 1610).

## Changements
- Modèle OCR : \`claude-opus-4-5\` → \`claude-opus-4-7\` (plus précis sur les formats numériques européens)
- \`max_tokens\` : 2048 → 4096 (factures longues étaient probablement tronquées)
- Sanity-check serveur : si l'IA donne P.U. et montant_ht mais que \`qty × PU\` diverge de plus de 5% du \`montant_ht\`, on recalcule le P.U. depuis montant_ht
- Log diagnostique \`console.warn\` en cas de lignes sans prix

## Test plan
- [x] vitest 57/57
- [x] eslint 0 erreur
- [ ] Re-tester sur la facture VERGERS SAINT EUSTACHE (1 ligne)
- [ ] Re-tester sur la facture KORE (26 lignes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)