### PR TITLE
fix(achats): OCR extrait totaux pied de facture + champs HT/TTC éditables

### DIFF
--- a/app/api/achats/parse-facture/route.ts
+++ b/app/api/achats/parse-facture/route.ts
@@ -24,14 +24,21 @@ const schema = z.object({
 })
 
 const PROMPT_EXTRACTION = `Tu analyses une photo ou scan d'une facture fournisseur de restauration française.
-Extrais les informations suivantes et retourne UNIQUEMENT du JSON valide, sans markdown, sans texte avant ou après.
+La facture peut faire PLUSIEURS PAGES : les lignes sont sur les premières pages,
+les TOTAUX (HT, TVA, TTC) sont en bas de la DERNIÈRE PAGE. Lis tout le document.
+
+Extrais les informations suivantes et retourne UNIQUEMENT du JSON valide,
+sans markdown, sans texte avant ou après.
 
 Format attendu :
 {
   "fournisseur": "Nom du fournisseur (string ou null)",
   "date_facture": "YYYY-MM-DD (string ou null)",
   "numero_facture": "Numéro ou référence de la facture (string ou null)",
-  "montant_tva_total": 33.50,
+  "total_ht_facture": 726.74,
+  "total_ttc_facture": 784.15,
+  "montant_tva_total": 42.88,
+  "montant_taxes_hors_tva": 14.53,
   "lignes": [
     {
       "designation": "Nom du produit tel qu'il apparaît sur la facture",
@@ -44,26 +51,35 @@ Format attendu :
   ]
 }
 
-Règles importantes :
-- FORMAT NUMÉRIQUE FRANÇAIS : sur ces factures, la virgule est le séparateur DÉCIMAL.
-  Exemples : "1,610" = 1.61   "3,22" = 3.22   "2,000" = 2.0   "0,18" = 0.18.
-  Renvoie TOUJOURS des nombres JSON avec un point décimal (ex: 1.61, 3.22, 2.0).
-  Le séparateur de milliers est l'espace ou rien (ex: "1 234,56" = 1234.56).
-- unite : utilise l'unité standard la plus proche (kg, g, L, mL, pièce, carton, etc.).
-  Si la facture indique "U" / "Un" / "Unité", utilise "pièce".
-- prix_unitaire_ht : prix HT PAR UNITÉ (colonne "P.U.", "Prix unitaire HT", "PU HT", etc.).
-- montant_ht : total HT de la ligne (colonne "Montant HT", "Total HT", "Total ligne").
-  Permet de cross-vérifier : montant_ht ≈ quantite × prix_unitaire_ht.
-  Si tu lis bien le montant_ht mais pas le P.U., renseigne au moins montant_ht.
-- taux_tva : taux de TVA de la ligne en pourcentage (ex: 5.5 pour 5,5%, 10, 20).
-  Les factures alimentaires distinguent souvent plusieurs taux (5,5% denrées,
-  10% restauration sur place, 20% non-alimentaire). Cherche les colonnes
-  "Code TVA", "Taux", "TVA" ou les codes G1/G2/G3 qui renvoient à un récap
-  en pied de page. Si tu ne peux pas déduire, null.
-- montant_tva_total : total TVA en euros au pied de facture ("Montant TVA"
-  ou "Total TVA"). Pas en pourcentage. Si absent, null.
-- Si une valeur est absente ou illisible, utilise null.
-- Ne retourne QUE le JSON, rien d'autre.`
+Règles CRITIQUES :
+
+1. FORMAT NUMÉRIQUE FRANÇAIS : sur ces factures, la virgule est le séparateur DÉCIMAL.
+   Exemples : "1,610" → 1.61   "3,22" → 3.22   "2,000" → 2.0   "0,18" → 0.18.
+   Renvoie TOUJOURS des nombres JSON avec un point décimal (1.61, 3.22, 2.0).
+   Le séparateur de milliers est l'espace ou rien (ex: "1 234,56" → 1234.56).
+   Ne confonds JAMAIS "1,610" (= 1.61) avec 1610.
+
+2. TOTAUX FACTURE (en bas de la dernière page, sous le tableau des lignes) :
+   - total_ht_facture : "Total HT" ou "Montant HT" du pied de facture (avant TVA).
+   - total_ttc_facture : "Total TTC" ou "Net à payer" ou "A payer" du pied.
+   - montant_tva_total : "Total TVA" ou "Montant TVA" en euros (pas en %).
+   - montant_taxes_hors_tva : "Total taxes hors TVA" / éco-contributions /
+     consigne / contributions diverses si présent. Sinon null.
+   Si plusieurs taux de TVA sont récapitulés, montant_tva_total est leur SOMME.
+
+3. LIGNES DE FACTURE (cherche dans tout le tableau, sur toutes les pages) :
+   - designation : nom du produit comme écrit (ex: "MARJOLAINE EN BOTTE (FRANCE)").
+   - quantite : nombre dans la colonne "Qté" / "Quantité".
+   - unite : "kg", "g", "L", "mL", "pièce", "carton", etc. Si "U"/"Un"/"Unité" → "pièce".
+   - prix_unitaire_ht : colonne "P.U." / "Prix unitaire HT" / "PU HT".
+   - montant_ht : colonne "Montant HT" / "Total HT" / "Total ligne" (= qty × P.U.).
+     IMPORTANT : si tu lis bien le montant ligne mais pas le P.U., renseigne
+     quand même montant_ht. Le serveur dérivera le P.U. = montant_ht / quantite.
+   - taux_tva : 5.5 / 10 / 20. Cherche colonnes "Code TVA", "Taux", "TVA" ou
+     codes G1/G2/G3 renvoyant à un récap en pied. Sinon null.
+
+4. Si une valeur est absente ou illisible, utilise null.
+5. Ne retourne QUE le JSON, rien d'autre. Pas de markdown, pas d'explication.`
 
 export const POST = apiHandler({
   schema,
@@ -87,12 +103,16 @@ export const POST = apiHandler({
             { type: 'text', text: PROMPT_EXTRACTION },
           ],
         },
+        // Prefill : force la sortie en JSON pur dès le premier token
+        // (évite que le modèle ouvre par "Voici le JSON :" ou un bloc markdown).
+        { role: 'assistant', content: '{' },
       ],
     })
 
     // Trouve le premier bloc de type 'text' (évite de planter si un thinking block précède)
     const textBlock = message.content.find((b) => b.type === 'text')
-    const rawText = textBlock && 'text' in textBlock ? textBlock.text : ''
+    // Le prefill "{" n'est PAS dans message.content → on le rajoute pour parser.
+    const rawText = '{' + (textBlock && 'text' in textBlock ? textBlock.text : '')
 
     let parsed: Record<string, unknown>
     try {
@@ -163,15 +183,24 @@ export const POST = apiHandler({
       ? rawDate
       : null
 
-    const tvaTotalRaw = parsed.montant_tva_total
-    const tvaTotal = tvaTotalRaw == null ? null : Number(tvaTotalRaw)
-    const montantTvaTotal = tvaTotal != null && Number.isFinite(tvaTotal) && tvaTotal >= 0 ? tvaTotal : null
+    const sanitizeMontant = (v: unknown): number | null => {
+      if (v == null) return null
+      const n = Number(v)
+      return Number.isFinite(n) && n >= 0 ? n : null
+    }
+    const montantTvaTotal = sanitizeMontant(parsed.montant_tva_total)
+    const totalHtFacture = sanitizeMontant(parsed.total_ht_facture)
+    const totalTtcFacture = sanitizeMontant(parsed.total_ttc_facture)
+    const montantTaxesHorsTva = sanitizeMontant(parsed.montant_taxes_hors_tva)
 
     return Response.json({
       fournisseur: (parsed.fournisseur as string) ?? null,
       date_facture: dateFactureValide,
       numero_facture: (parsed.numero_facture as string) ?? null,
       montant_tva_total: montantTvaTotal,
+      total_ht_facture: totalHtFacture,
+      total_ttc_facture: totalTtcFacture,
+      montant_taxes_hors_tva: montantTaxesHorsTva,
       lignes,
     })
   },

--- a/app/api/achats/parse-facture/route.ts
+++ b/app/api/achats/parse-facture/route.ts
@@ -77,8 +77,8 @@ export const POST = apiHandler({
       : { type: 'image' as const, source: { type: 'base64' as const, media_type: mimeType as 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif', data: fileBase64 } }
 
     const message = await getAnthropic().messages.create({
-      model: 'claude-opus-4-5',
-      max_tokens: 2048,
+      model: 'claude-opus-4-7',
+      max_tokens: 4096,
       messages: [
         {
           role: 'user',
@@ -107,6 +107,25 @@ export const POST = apiHandler({
       )
     }
 
+    // Décide du prix unitaire HT à partir de ce que Claude a renvoyé :
+    //   - prix_unitaire_ht (P.U.) ET/OU montant_ht (total ligne)
+    //
+    // Stratégie :
+    //   1. Si on a montant_ht et quantite > 0, calcule le PU "vérité" = montant_ht / quantite.
+    //   2. Si on a aussi un PU IA :
+    //      - les deux sont cohérents (écart < 5%) → on prend le PU IA (plus précis sur les centimes).
+    //      - sinon (ex: l'IA a lu "1,610" comme 1610 au lieu de 1.61) → on prend le PU "vérité".
+    //   3. Si on n'a que le PU IA → on l'utilise tel quel.
+    //   4. Si on n'a rien → 0.
+    const resolvePrixUnitaire = (puIA: number | null, montantHt: number | null, qte: number) => {
+      const puVerite = montantHt != null && qte > 0 ? montantHt / qte : null
+      if (puIA != null && puVerite != null) {
+        const ecart = Math.abs(puIA - puVerite) / Math.max(puVerite, 0.01)
+        return ecart < 0.05 ? puIA : puVerite
+      }
+      return puIA ?? puVerite ?? 0
+    }
+
     const lignes = ((parsed.lignes as Array<Record<string, unknown>>) || [])
       .filter((l) => l && l.designation)
       .map((l) => {
@@ -115,12 +134,9 @@ export const POST = apiHandler({
         const quantite = Number(l.quantite) || 1
         const puRaw = Number(l.prix_unitaire_ht)
         const montantHtRaw = Number(l.montant_ht)
+        const puIA = Number.isFinite(puRaw) && puRaw > 0 ? puRaw : null
         const montantHt = Number.isFinite(montantHtRaw) && montantHtRaw > 0 ? montantHtRaw : null
-        // Si l'IA n'a pas réussi à lire le P.U. mais a bien lu le montant HT,
-        // dérive le P.U. : prix_unitaire_ht = montant_ht / quantite.
-        const prixUnitaire = Number.isFinite(puRaw) && puRaw > 0
-          ? puRaw
-          : (montantHt != null && quantite > 0 ? montantHt / quantite : 0)
+        const prixUnitaire = resolvePrixUnitaire(puIA, montantHt, quantite)
         return {
           designation: String(l.designation ?? '').trim(),
           quantite,
@@ -129,6 +145,16 @@ export const POST = apiHandler({
           taux_tva: taux != null && Number.isFinite(taux) && taux >= 0 && taux <= 100 ? taux : null,
         }
       })
+
+    // Diagnostic : aide à comprendre les régressions OCR (lignes sans prix).
+    const sansPrix = lignes.filter((l) => !l.prix_unitaire_ht).length
+    if (sansPrix > 0) {
+      console.warn(
+        `[parse-facture] ${sansPrix}/${lignes.length} lignes sans prix.`,
+        'Échantillon brut:',
+        JSON.stringify(((parsed.lignes as unknown[]) || []).slice(0, 3))
+      )
+    }
 
     // Filtre date_facture : on n'accepte que YYYY-MM-DD valide, sinon null
     // (évite que Claude renvoie "hier" ou "2024-13-45" et fasse péter l'insert)

--- a/app/controle-gestion/achats/import/page.js
+++ b/app/controle-gestion/achats/import/page.js
@@ -51,8 +51,11 @@ export default function AchatsImportPage() {
   const [numeroFacture, setNumeroFacture] = useState('')
   const [statut, setStatut] = useState('facture')
   const [tauxTva, setTauxTva] = useState(5.5) // % par défaut (alimentaire) — fallback pour les lignes sans taux
-  // Total TVA saisi en pied de facture (override). null = calcul automatique.
+  // Totaux saisis/extraits de la facture (override). null = calcul automatique
+  // depuis les lignes.
+  const [totalHtSaisi, setTotalHtSaisi] = useState(null)
   const [montantTvaSaisi, setMontantTvaSaisi] = useState(null)
+  const [totalTtcSaisi, setTotalTtcSaisi] = useState(null)
 
   // ── Lignes enrichies ──────────────────────────────────────────────────────
   // Chaque ligne : { _id, designation, quantite, unite, prix_unitaire_ht, remise,
@@ -74,13 +77,16 @@ export default function AchatsImportPage() {
   )
 
   // ── Totaux facture (HT / TVA / TTC) ──────────────────────────────────────
-  const totalHtFacture = useMemo(
+  // totalHtCalcule = somme des lignes (qty × P.U. × (1-remise))
+  // totalHtFacture = soit le total HT pied de facture saisi/OCR, soit le calcul.
+  const totalHtCalcule = useMemo(
     () => lignes.reduce((s, l) => {
       const r = Number(l.remise) || 0
       return s + (Number(l.quantite) || 0) * (Number(l.prix_unitaire_ht) || 0) * (1 - r / 100)
     }, 0),
     [lignes]
   )
+  const totalHtFacture = totalHtSaisi != null && totalHtSaisi !== '' ? Number(totalHtSaisi) : totalHtCalcule
   // Si une ligne a son propre taux_tva, il prime ; sinon fallback sur tauxTva global.
   const montantTvaCalcule = useMemo(
     () => lignes.reduce((s, l) => {
@@ -91,9 +97,9 @@ export default function AchatsImportPage() {
     }, 0),
     [lignes, tauxTva]
   )
-  // Si l'utilisateur a saisi un montant TVA en pied, il prime sur le calcul.
   const montantTva = montantTvaSaisi != null && montantTvaSaisi !== '' ? Number(montantTvaSaisi) : montantTvaCalcule
-  const totalTtcFacture = totalHtFacture + montantTva
+  const totalTtcCalcule = totalHtFacture + montantTva
+  const totalTtcFacture = totalTtcSaisi != null && totalTtcSaisi !== '' ? Number(totalTtcSaisi) : totalTtcCalcule
 
   // ── UX ────────────────────────────────────────────────────────────────────
   const [error, setError] = useState('')
@@ -206,10 +212,11 @@ export default function AchatsImportPage() {
       setFournisseur(result.fournisseur || '')
       setDateFacture(result.date_facture || yesterdayIso())
       setNumeroFacture(result.numero_facture || '')
-      // Si l'OCR a détecté le montant TVA en pied, on le préremplit
-      if (result.montant_tva_total != null) {
-        setMontantTvaSaisi(Number(result.montant_tva_total))
-      }
+      // Pré-remplit les totaux extraits du pied de facture (override des
+      // totaux calculés depuis les lignes ; l'utilisateur peut modifier).
+      if (result.total_ht_facture != null) setTotalHtSaisi(Number(result.total_ht_facture))
+      if (result.montant_tva_total != null) setMontantTvaSaisi(Number(result.montant_tva_total))
+      if (result.total_ttc_facture != null) setTotalTtcSaisi(Number(result.total_ttc_facture))
       const enriched = (result.lignes || []).map(l =>
         enrichLigneLocal({
           _id:              makeLigneId(),
@@ -781,14 +788,18 @@ export default function AchatsImportPage() {
                   </label>
                 </div>
 
-                {/* Totaux HT / TVA / TTC */}
+                {/* Totaux HT / TVA / TTC — éditables (override sur le calcul depuis les lignes) */}
                 <div style={{ marginTop: 12, paddingTop: 12, borderTop: `1px solid ${c.bordure}`, display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr 1fr', gap: 10 }}>
                   <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: c.texteMuted }}>
                     Total HT
                     <input
-                      style={{ ...inputS, background: c.fond, fontVariantNumeric: 'tabular-nums' }}
-                      readOnly
-                      value={fmtPrix(totalHtFacture)}
+                      style={inputS}
+                      type="number"
+                      min="0" step="0.01"
+                      value={totalHtSaisi ?? ''}
+                      placeholder={fmtPrix(totalHtCalcule)}
+                      title="Total HT en pied de facture. Pré-rempli par l'OCR. Vide → calcul automatique depuis les lignes."
+                      onChange={e => setTotalHtSaisi(e.target.value === '' ? null : e.target.value)}
                     />
                   </label>
                   <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: c.texteMuted }}>
@@ -799,19 +810,29 @@ export default function AchatsImportPage() {
                       min="0" step="0.01"
                       value={montantTvaSaisi ?? ''}
                       placeholder={fmtPrix(montantTvaCalcule)}
-                      title="Saisissez le total TVA tel qu'il apparaît en pied de facture, ou laissez vide pour calculer automatiquement"
+                      title="Total TVA en pied de facture. Pré-rempli par l'OCR. Vide → calcul automatique depuis les lignes."
                       onChange={e => setMontantTvaSaisi(e.target.value === '' ? null : e.target.value)}
                     />
                   </label>
                   <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: c.texteMuted }}>
                     Total TTC
                     <input
-                      style={{ ...inputS, background: c.fond, fontVariantNumeric: 'tabular-nums', fontWeight: 600 }}
-                      readOnly
-                      value={fmtPrix(totalTtcFacture)}
+                      style={{ ...inputS, fontWeight: 600 }}
+                      type="number"
+                      min="0" step="0.01"
+                      value={totalTtcSaisi ?? ''}
+                      placeholder={fmtPrix(totalTtcCalcule)}
+                      title="Total TTC en pied de facture. Pré-rempli par l'OCR. Vide → HT + TVA."
+                      onChange={e => setTotalTtcSaisi(e.target.value === '' ? null : e.target.value)}
                     />
                   </label>
                 </div>
+                {/* Hint d'incohérence : si la somme des lignes diffère de plus de 1 € ou 2 % du Total HT saisi */}
+                {totalHtSaisi != null && totalHtSaisi !== '' && Math.abs(Number(totalHtSaisi) - totalHtCalcule) > Math.max(1, Number(totalHtSaisi) * 0.02) && (
+                  <div style={{ marginTop: 8, padding: '8px 12px', borderRadius: 6, background: '#FEF3C7', border: '1px solid #F59E0B', fontSize: 12, color: '#92400E' }}>
+                    ⚠ La somme des lignes ({fmtPrix(totalHtCalcule)}) diffère du Total HT facture ({fmtPrix(Number(totalHtSaisi))}). Vérifie les prix unitaires des lignes ci-dessous.
+                  </div>
+                )}
               </div>
 
           {/* ── Lignes (incluses dans la colonne droite en mode side-by-side) ── */}


### PR DESCRIPTION
## Summary
Sur les factures multi-pages (KORE 26 lignes), l'OCR ne récupérait que le total TVA mais pas Total HT ni Total TTC. Quelques lignes mal lues → la somme des lignes ne matche pas la facture, et l'utilisateur n'a pas de moyen rapide de voir l'écart.

## Changements
**OCR (parse-facture)** :
- Prompt enrichi : extrait \`total_ht_facture\`, \`total_ttc_facture\`, \`montant_taxes_hors_tva\` (éco-contributions/consigne)
- Précision multi-pages : \"lis tout le document, les totaux sont sur la dernière page\"
- Prefill assistant turn \`{\` pour forcer du JSON pur dès le 1er token

**UI (import)** :
- Total HT / Total TTC deviennent éditables (étaient readonly)
- Pré-remplissage automatique depuis l'OCR
- Placeholder = somme des lignes ; valeur = override extrait/saisi
- Bandeau ⚠ quand la somme des lignes diverge du Total HT saisi

## Test plan
- [x] vitest 57/57
- [x] eslint 0 erreur
- [ ] Re-tester KORE : Total HT pré-rempli à 726,74 € avec ⚠ si lignes < 726,74
- [ ] Re-tester VERGERS : Total HT pré-rempli à 3,22 €

🤖 Generated with [Claude Code](https://claude.com/claude-code)