### PR TITLE
hotfix(achats): retire prefill JSON qui cassait l'API Anthropic

### DIFF
--- a/app/api/achats/parse-facture/route.ts
+++ b/app/api/achats/parse-facture/route.ts
@@ -103,16 +103,12 @@ export const POST = apiHandler({
             { type: 'text', text: PROMPT_EXTRACTION },
           ],
         },
-        // Prefill : force la sortie en JSON pur dès le premier token
-        // (évite que le modèle ouvre par "Voici le JSON :" ou un bloc markdown).
-        { role: 'assistant', content: '{' },
       ],
     })
 
     // Trouve le premier bloc de type 'text' (évite de planter si un thinking block précède)
     const textBlock = message.content.find((b) => b.type === 'text')
-    // Le prefill "{" n'est PAS dans message.content → on le rajoute pour parser.
-    const rawText = '{' + (textBlock && 'text' in textBlock ? textBlock.text : '')
+    const rawText = textBlock && 'text' in textBlock ? textBlock.text : ''
 
     let parsed: Record<string, unknown>
     try {


### PR DESCRIPTION
## Hotfix urgent

Le prefill \`{ role: 'assistant', content: '{' }\` ajouté dans #59 fait que l'API Anthropic répond en 400 dès qu'on envoie un PDF dans le user turn. Résultat : toutes les extractions OCR cassent en 500 (\"Extraction IA échouée\").

Je retire juste le prefill, le reste de #59 (extraction totaux pied, prompt multi-pages, UI éditable) est conservé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)