### PR TITLE
feat(nav): ajoute Suivi CA + Budgets CA dans le menu Gestion

### DIFF
--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -182,6 +182,8 @@ export default function Navbar({ section = 'cuisine' }) {
             { label: 'Fournisseurs',  path: '/controle-gestion/fournisseurs' },
             { label: 'Mercuriale',    path: '/controle-gestion/mercuriale' },
             ...(role === 'admin' || role === 'directeur' ? [{ label: 'Marges',        path: '/controle-gestion/marges' }] : []),
+            { label: 'Suivi CA',      path: '/controle-gestion/ventes' },
+            { label: 'Budgets CA',    path: '/controle-gestion/ventes/budgets' },
             ...(role === 'admin' ? [{ label: 'Import ventes', path: '/controle-gestion/import' }] : []),
           ]
         }] : []),


### PR DESCRIPTION
Les pages /controle-gestion/ventes et /controle-gestion/ventes/budgets shippées dans #61 n'apparaissaient pas dans le menu Gestion. Ajout des 2 entrées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)