### PR TITLE
feat(analyses): squelette page Analyses CA + système widgets

### DIFF
--- a/app/controle-gestion/analyses/page.js
+++ b/app/controle-gestion/analyses/page.js
@@ -1,0 +1,411 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase, getClientId } from '../../../lib/supabase'
+import { useIsMobile } from '../../../lib/useIsMobile'
+import { useTheme } from '../../../lib/useTheme'
+import { useTenant } from '../../../lib/useTenant'
+import { useRole } from '../../../lib/useRole'
+import {
+  getPeriodDates,
+  shiftPeriodByYears,
+  aggregateTotals,
+  aggregateByDay,
+  periodBudgetTotal,
+  fromIsoDate,
+} from '../../../lib/caAnalyses'
+import {
+  WIDGET_BY_ID,
+  DEFAULT_LAYOUT,
+  isWidgetAvailable,
+  getAnalysesLayout,
+  saveAnalysesLayout,
+  resetAnalysesLayout,
+} from '../../../lib/analysesPreferences'
+import Navbar from '../../../components/Navbar'
+import WidgetsCustomizeModal from '../../../components/dashboard/WidgetsCustomizeModal'
+import FilterBar, { COMPARAISON_LABELS } from '../../../components/analyses/FilterBar'
+import KpiCouverts from '../../../components/analyses/widgets/KpiCouverts'
+import KpiCaTtc from '../../../components/analyses/widgets/KpiCaTtc'
+import KpiCaHt from '../../../components/analyses/widgets/KpiCaHt'
+import KpiTm from '../../../components/analyses/widgets/KpiTm'
+import KpiEcartBudgetPct from '../../../components/analyses/widgets/KpiEcartBudgetPct'
+import SectionTableauJourJour from '../../../components/analyses/widgets/SectionTableauJourJour'
+
+const DEFAULT_PERIODE = 'mois-en-cours'
+
+export default function AnalysesPage() {
+  const router = useRouter()
+  const isMobile = useIsMobile()
+  const { c } = useTheme()
+  const { tenant } = useTenant()
+  const { role, loading: roleLoading } = useRole()
+  const modulesActifs = tenant?.modules_actifs || []
+
+  const [authReady, setAuthReady] = useState(false)
+  const [clientId, setClientId] = useState(null)
+
+  // ── Filtres globaux ──────────────────────────────────────────────────────
+  const [periode, setPeriode] = useState(DEFAULT_PERIODE)
+  const initialDates = useMemo(() => getPeriodDates(DEFAULT_PERIODE) || { debut: '', fin: '' }, [])
+  const [dateDebut, setDateDebut] = useState(initialDates.debut)
+  const [dateFin, setDateFin] = useState(initialDates.fin)
+  const [comparaison, setComparaison] = useState('aucune')
+  const [lieuId, setLieuId] = useState('all')
+  const [service, setService] = useState('tout')
+
+  // ── Layout widgets ───────────────────────────────────────────────────────
+  const [layout, setLayout] = useState(null)
+  const [showCustomize, setShowCustomize] = useState(false)
+
+  // ── Données ──────────────────────────────────────────────────────────────
+  const [lieux, setLieux] = useState([])
+  const [rawCa, setRawCa] = useState([])
+  const [rawCaCompare, setRawCaCompare] = useState([])
+  // budgetByYear : { 2026: rows, 2025: rows } pour gérer périodes à cheval.
+  const [budgetByYear, setBudgetByYear] = useState({})
+  const [budgetByYearCompare, setBudgetByYearCompare] = useState({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  // ── Auth + redirect role ─────────────────────────────────────────────────
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const { data: { session } } = await supabase.auth.getSession()
+      if (cancelled) return
+      if (!session) { router.replace('/'); return }
+      setAuthReady(true)
+    })()
+    return () => { cancelled = true }
+  }, [router])
+
+  useEffect(() => {
+    if (roleLoading || !role) return
+    if (role !== 'admin' && role !== 'directeur') router.replace('/dashboard')
+  }, [role, roleLoading, router])
+
+  // ── Récup tenant client_id + lieux + layout (une seule fois) ─────────────
+  useEffect(() => {
+    if (!authReady) return
+    let cancelled = false
+    ;(async () => {
+      const cid = await getClientId()
+      if (!cid || cancelled) return
+      setClientId(cid)
+      const [lieuxRes, layoutRes] = await Promise.all([
+        supabase
+          .from('lieux_service')
+          .select('id, nom, ordre')
+          .eq('client_id', cid)
+          .eq('actif', true)
+          .order('ordre').order('nom'),
+        getAnalysesLayout(),
+      ])
+      if (cancelled) return
+      setLieux(lieuxRes.data || [])
+      setLayout(layoutRes)
+    })()
+    return () => { cancelled = true }
+  }, [authReady])
+
+  // ── Recalcul des dates quand on change de période ────────────────────────
+  function handlePeriode(p) {
+    setPeriode(p)
+    if (p !== 'custom') {
+      const { debut, fin } = getPeriodDates(p) || { debut: dateDebut, fin: dateFin }
+      setDateDebut(debut)
+      setDateFin(fin)
+    }
+  }
+
+  // ── Liste des années couvertes par une plage (pour la query budgets) ─────
+  const yearsCovered = useCallback((debut, fin) => {
+    const y0 = fromIsoDate(debut).getFullYear()
+    const y1 = fromIsoDate(fin).getFullYear()
+    const out = []
+    for (let y = y0; y <= y1; y++) out.push(y)
+    return out
+  }, [])
+
+  // ── Chargement des données pour la période courante ──────────────────────
+  const loadData = useCallback(async () => {
+    if (!clientId || !dateDebut || !dateFin) return
+    setLoading(true)
+    setError('')
+    try {
+      const compareRange = comparaison === 'n-1'
+        ? shiftPeriodByYears({ debut: dateDebut, fin: dateFin }, -1)
+        : null
+
+      const years = yearsCovered(dateDebut, dateFin)
+      const compareYears = compareRange ? yearsCovered(compareRange.debut, compareRange.fin) : []
+
+      const caQuery = supabase
+        .from('ca_journalier')
+        .select('jour, service, lieu_service_id, couverts, ca_food, ca_bev_20, ca_bev_10, ca_autre')
+        .eq('client_id', clientId)
+        .gte('jour', dateDebut)
+        .lte('jour', dateFin)
+
+      const compareCaQuery = compareRange
+        ? supabase
+            .from('ca_journalier')
+            .select('jour, service, lieu_service_id, couverts, ca_food, ca_bev_20, ca_bev_10, ca_autre')
+            .eq('client_id', clientId)
+            .gte('jour', compareRange.debut)
+            .lte('jour', compareRange.fin)
+        : Promise.resolve({ data: [], error: null })
+
+      const budgetQuery = supabase
+        .from('ca_budgets')
+        .select('annee, mois, jour_semaine, lieu_service_id, service, ca_food_cible, ca_bev_20_cible, ca_bev_10_cible, ca_autre_cible')
+        .eq('client_id', clientId)
+        .in('annee', years)
+
+      const compareBudgetQuery = compareYears.length > 0
+        ? supabase
+            .from('ca_budgets')
+            .select('annee, mois, jour_semaine, lieu_service_id, service, ca_food_cible, ca_bev_20_cible, ca_bev_10_cible, ca_autre_cible')
+            .eq('client_id', clientId)
+            .in('annee', compareYears)
+        : Promise.resolve({ data: [], error: null })
+
+      const [caRes, compareCaRes, budgetRes, compareBudgetRes] = await Promise.all([
+        caQuery, compareCaQuery, budgetQuery, compareBudgetQuery,
+      ])
+      if (caRes.error) throw caRes.error
+      if (compareCaRes.error) throw compareCaRes.error
+      if (budgetRes.error) throw budgetRes.error
+      if (compareBudgetRes.error) throw compareBudgetRes.error
+
+      const groupByYear = (rows) => rows.reduce((acc, r) => {
+        ;(acc[r.annee] ||= []).push(r)
+        return acc
+      }, {})
+
+      setRawCa(caRes.data || [])
+      setRawCaCompare(compareCaRes.data || [])
+      setBudgetByYear(groupByYear(budgetRes.data || []))
+      setBudgetByYearCompare(groupByYear(compareBudgetRes.data || []))
+    } catch (e) {
+      setError(e.message || 'Erreur de chargement')
+    } finally {
+      setLoading(false)
+    }
+  }, [clientId, dateDebut, dateFin, comparaison, yearsCovered])
+
+  useEffect(() => {
+    if (clientId && dateDebut && dateFin) loadData()
+  }, [clientId, dateDebut, dateFin, comparaison, loadData])
+
+  // ── Filtrage côté JS sur lieu / service ──────────────────────────────────
+  const filterRows = useCallback((rows) => {
+    return rows.filter((r) => {
+      if (lieuId !== 'all' && r.lieu_service_id !== lieuId) return false
+      if (service !== 'tout' && r.service !== service) return false
+      return true
+    })
+  }, [lieuId, service])
+
+  const filterBudgets = useCallback((budgetRowsByYear) => {
+    const out = {}
+    for (const [annee, rows] of Object.entries(budgetRowsByYear)) {
+      out[annee] = rows.filter((r) => {
+        if (lieuId !== 'all' && r.lieu_service_id !== lieuId) return false
+        if (service !== 'tout' && r.service !== service) return false
+        return true
+      })
+    }
+    return out
+  }, [lieuId, service])
+
+  // ── Totals + days + budget ───────────────────────────────────────────────
+  const filteredRows = useMemo(() => filterRows(rawCa), [rawCa, filterRows])
+  const filteredCompareRows = useMemo(() => filterRows(rawCaCompare), [rawCaCompare, filterRows])
+  const filteredBudgetByYear = useMemo(() => filterBudgets(budgetByYear), [budgetByYear, filterBudgets])
+  const filteredCompareBudgetByYear = useMemo(() => filterBudgets(budgetByYearCompare), [budgetByYearCompare, filterBudgets])
+
+  const totals = useMemo(() => aggregateTotals(filteredRows), [filteredRows])
+  const totalsCompare = useMemo(() => aggregateTotals(filteredCompareRows), [filteredCompareRows])
+  const days = useMemo(() => aggregateByDay(filteredRows, dateDebut, dateFin), [filteredRows, dateDebut, dateFin])
+
+  const periodBudget = useMemo(
+    () => periodBudgetTotal(filteredBudgetByYear, dateDebut, dateFin),
+    [filteredBudgetByYear, dateDebut, dateFin]
+  )
+
+  const compareBudgetRange = useMemo(
+    () => comparaison === 'n-1' ? shiftPeriodByYears({ debut: dateDebut, fin: dateFin }, -1) : null,
+    [comparaison, dateDebut, dateFin]
+  )
+
+  const periodBudgetCompare = useMemo(() => {
+    if (!compareBudgetRange) return 0
+    return periodBudgetTotal(filteredCompareBudgetByYear, compareBudgetRange.debut, compareBudgetRange.fin)
+  }, [filteredCompareBudgetByYear, compareBudgetRange])
+
+  // ── Comparison props injectés dans les KPIs ──────────────────────────────
+  // - 'aucune' → pas de comparaison
+  // - 'n-1' → cible = totaux N-1
+  // - 'budget' → cible = totaux extrapolés depuis le budget de la période
+  //   (on met ca_ttc_cible = budget agrégé, et on laisse les autres champs
+  //   vides → seuls KpiCaTtc + KpiEcartBudgetPct affichent qqch d'utile)
+  const comparisonTotals = useMemo(() => {
+    if (comparaison === 'aucune') return null
+    if (comparaison === 'n-1') return totalsCompare
+    if (comparaison === 'budget') {
+      // Budget ne distingue pas couverts/HT/TM → on n'expose que caTtc.
+      // Les autres KPIs n'affichent pas de comparaison faute de cible utile.
+      return { caTtc: periodBudget, couverts: null, caHt: null, tm: null }
+    }
+    return null
+  }, [comparaison, totalsCompare, periodBudget])
+
+  const comparisonLabel = comparaison === 'aucune' ? '' : (COMPARAISON_LABELS[comparaison] || '')
+
+  // Pour le tableau jour-jour, on injecte le budget journalier dans chaque
+  // jour en réutilisant periodBudgetTotal sur une seule date.
+  const daysWithBudget = useMemo(() => {
+    return days.map((d) => {
+      const budget = periodBudgetTotal(filteredBudgetByYear, d.iso, d.iso)
+      return { ...d, budget }
+    })
+  }, [days, filteredBudgetByYear])
+
+  const tableauTotals = useMemo(() => {
+    let lunchCouverts = 0, dinnerCouverts = 0, budget = 0
+    for (const d of daysWithBudget) {
+      lunchCouverts += d.lunchCouverts
+      dinnerCouverts += d.dinnerCouverts
+      budget += d.budget
+    }
+    return {
+      ...totals,
+      lunchCouverts, dinnerCouverts,
+      bev20: totals.bev20, bev10: totals.bev10,
+      budget,
+    }
+  }, [daysWithBudget, totals])
+
+  // ── Rendu d'un widget par id ─────────────────────────────────────────────
+  const renderWidget = (id) => {
+    const common = { c, isMobile, totals, comparisonTotals, comparisonLabel }
+    switch (id) {
+      case 'kpi-couverts':         return <KpiCouverts {...common} />
+      case 'kpi-ca-ttc':           return <KpiCaTtc {...common} />
+      case 'kpi-ca-ht':            return <KpiCaHt {...common} />
+      case 'kpi-tm':               return <KpiTm {...common} />
+      case 'kpi-ecart-budget-pct': return <KpiEcartBudgetPct c={c} isMobile={isMobile} totals={totals} budget={periodBudget} />
+      case 'section-tableau-jour-jour':
+        return <SectionTableauJourJour c={c} isMobile={isMobile} days={daysWithBudget} totals={tableauTotals} />
+      default: return null
+    }
+  }
+
+  if (!authReady || !layout) {
+    return (
+      <div style={{
+        minHeight: '100vh', background: c.fond,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        color: c.texteMuted, fontSize: 14,
+      }}>
+        Chargement…
+      </div>
+    )
+  }
+
+  // ── Layout splits (KPIs vs sections) ─────────────────────────────────────
+  const visibleLayout = layout.filter((l) => l.visible && WIDGET_BY_ID[l.id] && isWidgetAvailable(WIDGET_BY_ID[l.id], modulesActifs))
+  const kpiLayout = visibleLayout.filter((l) => WIDGET_BY_ID[l.id].size === 'kpi')
+  const sectionLayout = visibleLayout.filter((l) => WIDGET_BY_ID[l.id].size !== 'kpi')
+
+  const kpiCols = isMobile
+    ? Math.min(Math.max(kpiLayout.length, 1), 2)
+    : Math.min(Math.max(kpiLayout.length, 1), 5)
+
+  return (
+    <div style={{ minHeight: '100vh', background: c.fond }}>
+      <Navbar section="cuisine" />
+      <div style={{ padding: isMobile ? 16 : 24, maxWidth: 1300, margin: '0 auto' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, flexWrap: 'wrap', marginBottom: 16 }}>
+          <div>
+            <h1 style={{ margin: '0 0 4px', fontSize: isMobile ? 22 : 26, fontWeight: 600, color: c.texte }}>
+              Analyses CA
+            </h1>
+            <p style={{ margin: 0, fontSize: 14, color: c.texteMuted }}>
+              {humanRange(dateDebut, dateFin)}
+            </p>
+          </div>
+          <button
+            onClick={() => setShowCustomize(true)}
+            title="Personnaliser mes analyses"
+            style={{
+              background: 'transparent', border: `0.5px solid ${c.bordure}`, color: c.texteMuted,
+              borderRadius: 8, padding: '6px 12px', fontSize: 12, cursor: 'pointer',
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+            }}
+          >
+            ⚙{isMobile ? '' : ' Personnaliser'}
+          </button>
+        </div>
+
+        <FilterBar
+          c={c} isMobile={isMobile}
+          periode={periode} onPeriode={handlePeriode}
+          dateDebut={dateDebut} dateFin={dateFin}
+          onDateDebut={setDateDebut} onDateFin={setDateFin}
+          comparaison={comparaison} onComparaison={setComparaison}
+          lieux={lieux} lieuId={lieuId} onLieu={setLieuId}
+          service={service} onService={setService}
+        />
+
+        {error && <p style={{ color: '#B91C1C', fontSize: 14, marginBottom: 16 }}>{error}</p>}
+        {loading && <p style={{ color: c.texteMuted, fontSize: 14 }}>Chargement…</p>}
+
+        {!loading && !error && kpiLayout.length > 0 && (
+          <div style={{
+            display: 'grid', gridTemplateColumns: `repeat(${kpiCols}, 1fr)`,
+            gap: isMobile ? 10 : 16, marginBottom: 24,
+          }}>
+            {kpiLayout.map((l) => <div key={l.id}>{renderWidget(l.id)}</div>)}
+          </div>
+        )}
+
+        {!loading && !error && sectionLayout.map((l) => (
+          <div key={l.id} style={{ marginBottom: isMobile ? 12 : 16 }}>
+            {renderWidget(l.id)}
+          </div>
+        ))}
+
+        {showCustomize && (
+          <WidgetsCustomizeModal
+            c={c}
+            initialLayout={layout}
+            modulesActifs={modulesActifs}
+            widgetById={WIDGET_BY_ID}
+            defaultLayout={DEFAULT_LAYOUT}
+            saveLayout={saveAnalysesLayout}
+            resetLayout={resetAnalysesLayout}
+            isWidgetAvailable={isWidgetAvailable}
+            title="Personnaliser ma page Analyses"
+            onClose={() => setShowCustomize(false)}
+            onSaved={(next) => { setLayout(next); setShowCustomize(false) }}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function humanRange(debut, fin) {
+  if (!debut || !fin) return ''
+  if (debut === fin) return formatDate(debut)
+  return `${formatDate(debut)} → ${formatDate(fin)}`
+}
+
+function formatDate(iso) {
+  const d = fromIsoDate(iso)
+  return d.toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric' })
+}

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -202,6 +202,7 @@ export default function Navbar({ section = 'cuisine' }) {
             { label: 'Achats',        path: '/controle-gestion/achats' },
             { label: 'Fournisseurs',  path: '/controle-gestion/fournisseurs' },
             { label: 'Mercuriale',    path: '/controle-gestion/mercuriale' },
+            ...(role === 'admin' || role === 'directeur' ? [{ label: 'Analyses',      path: '/controle-gestion/analyses' }] : []),
             ...(role === 'admin' || role === 'directeur' ? [{ label: 'Marges',        path: '/controle-gestion/marges' }] : []),
             { label: 'Suivi CA',      path: '/controle-gestion/ventes' },
             { label: 'Budgets CA',    path: '/controle-gestion/ventes/budgets' },

--- a/components/analyses/FilterBar.js
+++ b/components/analyses/FilterBar.js
@@ -1,0 +1,106 @@
+'use client'
+
+const PERIODES = [
+  { code: 'aujourdhui',     label: "Aujourd'hui" },
+  { code: '7j',             label: '7 j' },
+  { code: '30j',            label: '30 j' },
+  { code: 'mois-en-cours',  label: 'Mois en cours' },
+  { code: 'mois-precedent', label: 'Mois préc.' },
+  { code: 'trimestre',      label: 'Trimestre' },
+  { code: 'annee',          label: 'Année' },
+  { code: 'custom',         label: 'Personnalisé' },
+]
+
+const COMPARAISONS = [
+  { code: 'aucune',  label: 'Aucune comparaison' },
+  { code: 'n-1',     label: 'vs même période N-1' },
+  { code: 'budget',  label: 'vs Budget' },
+]
+
+const SERVICES = [
+  { code: 'tout',   label: 'Tous services' },
+  { code: 'lunch',  label: 'Déjeuner' },
+  { code: 'dinner', label: 'Dîner' },
+]
+
+export default function FilterBar({
+  c, isMobile,
+  periode, onPeriode,
+  dateDebut, dateFin, onDateDebut, onDateFin,
+  comparaison, onComparaison,
+  lieux, lieuId, onLieu,
+  service, onService,
+}) {
+  const btn = (active) => ({
+    padding: '7px 12px', borderRadius: 8, fontSize: 13,
+    border: `1px solid ${active ? c.accent : c.bordure}`,
+    background: active ? c.accent : c.blanc,
+    color: active ? c.texte : c.texteMuted,
+    cursor: 'pointer', fontWeight: active ? 600 : 500,
+    whiteSpace: 'nowrap',
+  })
+
+  const select = {
+    padding: '7px 10px', borderRadius: 8, fontSize: 13,
+    border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte,
+  }
+
+  const dateInput = {
+    padding: '7px 10px', borderRadius: 8, fontSize: 13,
+    border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte,
+  }
+
+  return (
+    <div style={{
+      background: c.blanc, border: `0.5px solid ${c.bordure}`, borderRadius: 12,
+      padding: isMobile ? 12 : 16, marginBottom: 20,
+      display: 'flex', flexDirection: 'column', gap: 10,
+    }}>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+        {PERIODES.map((p) => (
+          <button key={p.code} onClick={() => onPeriode(p.code)} style={btn(p.code === periode)}>
+            {p.label}
+          </button>
+        ))}
+      </div>
+
+      {periode === 'custom' && (
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          <span style={{ fontSize: 12, color: c.texteMuted }}>Du</span>
+          <input type="date" value={dateDebut} onChange={(e) => onDateDebut(e.target.value)} style={dateInput} />
+          <span style={{ fontSize: 12, color: c.texteMuted }}>au</span>
+          <input type="date" value={dateFin} onChange={(e) => onDateFin(e.target.value)} style={dateInput} />
+        </div>
+      )}
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, alignItems: 'center' }}>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: c.texteMuted }}>
+          Comparaison
+          <select value={comparaison} onChange={(e) => onComparaison(e.target.value)} style={select}>
+            {COMPARAISONS.map((c2) => <option key={c2.code} value={c2.code}>{c2.label}</option>)}
+          </select>
+        </label>
+
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: c.texteMuted }}>
+          Lieu
+          <select value={lieuId} onChange={(e) => onLieu(e.target.value)} style={select}>
+            <option value="all">Tous lieux</option>
+            {lieux.map((l) => <option key={l.id} value={l.id}>{l.nom}</option>)}
+          </select>
+        </label>
+
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: c.texteMuted }}>
+          Service
+          <select value={service} onChange={(e) => onService(e.target.value)} style={select}>
+            {SERVICES.map((s) => <option key={s.code} value={s.code}>{s.label}</option>)}
+          </select>
+        </label>
+      </div>
+    </div>
+  )
+}
+
+export const COMPARAISON_LABELS = {
+  'n-1':    'vs même période N-1',
+  'budget': 'vs Budget',
+}

--- a/components/analyses/widgets/KpiCaHt.js
+++ b/components/analyses/widgets/KpiCaHt.js
@@ -1,0 +1,24 @@
+import KpiCard from './KpiCard'
+import { buildComparison, formatEur, formatDeltaEur } from '../../../lib/caAnalyses'
+
+export default function KpiCaHt({ c, isMobile, totals, comparisonTotals, comparisonLabel }) {
+  const value = totals ? formatEur(totals.caHt) : '—'
+  const comparison = comparisonTotals && totals
+    ? buildComparison({
+        current: totals.caHt,
+        target: comparisonTotals.caHt,
+        formatDelta: formatDeltaEur,
+        label: comparisonLabel,
+      })
+    : null
+  return (
+    <KpiCard
+      c={c}
+      isMobile={isMobile}
+      label="CA HT"
+      value={value}
+      hint={comparison ? null : 'Net de TVA (10 % Food/Soft, 20 % Alcool)'}
+      comparison={comparison}
+    />
+  )
+}

--- a/components/analyses/widgets/KpiCaTtc.js
+++ b/components/analyses/widgets/KpiCaTtc.js
@@ -1,0 +1,24 @@
+import KpiCard from './KpiCard'
+import { buildComparison, formatEur, formatDeltaEur } from '../../../lib/caAnalyses'
+
+export default function KpiCaTtc({ c, isMobile, totals, comparisonTotals, comparisonLabel }) {
+  const value = totals ? formatEur(totals.caTtc) : '—'
+  const comparison = comparisonTotals && totals
+    ? buildComparison({
+        current: totals.caTtc,
+        target: comparisonTotals.caTtc,
+        formatDelta: formatDeltaEur,
+        label: comparisonLabel,
+      })
+    : null
+  return (
+    <KpiCard
+      c={c}
+      isMobile={isMobile}
+      label="CA TTC"
+      value={value}
+      hint={comparison ? null : 'Total Food + Boissons + Autres sur la période'}
+      comparison={comparison}
+    />
+  )
+}

--- a/components/analyses/widgets/KpiCard.js
+++ b/components/analyses/widgets/KpiCard.js
@@ -1,0 +1,40 @@
+// Bloc visuel commun aux KPIs Analyses (couverts, CA TTC, CA HT, TM, écart budget).
+// Pas de fetch ici — la valeur et la comparaison viennent du parent.
+//
+// `comparison` (optionnel) :
+//   { delta: number|null, deltaLabel: string, mode: 'success'|'danger'|'neutral'|'none' }
+//
+// La page passe `null` quand l'user a sélectionné "Aucune comparaison".
+export default function KpiCard({ c, isMobile, label, value, hint, comparison }) {
+  return (
+    <div style={{
+      background: c.blanc, borderRadius: '12px',
+      padding: isMobile ? '14px' : '20px',
+      border: `0.5px solid ${c.bordure}`,
+    }}>
+      <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: '8px' }}>
+        {label}
+      </div>
+      <div className="sk-stat-value" style={{ fontSize: isMobile ? '22px' : '28px', color: c.texte }}>
+        {value}
+      </div>
+      {comparison ? (
+        <ComparisonLine c={c} comparison={comparison} />
+      ) : hint ? (
+        <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '6px' }}>{hint}</div>
+      ) : null}
+    </div>
+  )
+}
+
+function ComparisonLine({ c, comparison }) {
+  const color = comparison.mode === 'success' ? c.vert
+    : comparison.mode === 'danger' ? c.rouge
+    : comparison.mode === 'neutral' ? c.orange
+    : c.texteMuted
+  return (
+    <div style={{ fontSize: '11px', color, marginTop: '6px', fontWeight: 600 }}>
+      {comparison.deltaLabel}
+    </div>
+  )
+}

--- a/components/analyses/widgets/KpiCouverts.js
+++ b/components/analyses/widgets/KpiCouverts.js
@@ -1,0 +1,24 @@
+import KpiCard from './KpiCard'
+import { buildComparison, formatNombre } from '../../../lib/caAnalyses'
+
+export default function KpiCouverts({ c, isMobile, totals, comparisonTotals, comparisonLabel }) {
+  const value = totals ? formatNombre(totals.couverts) : '—'
+  const comparison = comparisonTotals && totals
+    ? buildComparison({
+        current: totals.couverts,
+        target: comparisonTotals.couverts,
+        formatDelta: (d) => `${d >= 0 ? '+' : ''}${formatNombre(d)}`,
+        label: comparisonLabel,
+      })
+    : null
+  return (
+    <KpiCard
+      c={c}
+      isMobile={isMobile}
+      label="Couverts"
+      value={value}
+      hint={comparison ? null : 'Sur la période'}
+      comparison={comparison}
+    />
+  )
+}

--- a/components/analyses/widgets/KpiEcartBudgetPct.js
+++ b/components/analyses/widgets/KpiEcartBudgetPct.js
@@ -1,0 +1,37 @@
+import KpiCard from './KpiCard'
+import { formatDeltaPct, formatEur } from '../../../lib/caAnalyses'
+
+// Écart en % entre le CA TTC réel et le budget cumulé sur la période.
+// Positif = au-dessus du budget (vert), < -5 % = rouge, sinon orange.
+// Affiche systématiquement la valeur, indépendamment du sélecteur
+// "Comparaison" (qui ne pilote que les KPIs Couverts/CA/TM).
+export default function KpiEcartBudgetPct({ c, isMobile, totals, budget }) {
+  const real = totals?.caTtc ?? 0
+  const noBudget = !budget || budget === 0
+  const ratioPct = noBudget ? null : ((real - budget) / budget) * 100
+
+  const valueColor = noBudget ? c.texteMuted
+    : ratioPct >= 0 ? c.vert
+    : ratioPct < -5 ? c.rouge
+    : c.orange
+
+  return (
+    <div style={{
+      background: c.blanc, borderRadius: '12px',
+      padding: isMobile ? '14px' : '20px',
+      border: `0.5px solid ${c.bordure}`,
+    }}>
+      <div className="sk-label-muted" style={{ color: c.texteMuted, marginBottom: '8px' }}>
+        Écart vs Budget
+      </div>
+      <div className="sk-stat-value" style={{ fontSize: isMobile ? '22px' : '28px', color: valueColor }}>
+        {noBudget ? '—' : formatDeltaPct(ratioPct)}
+      </div>
+      <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '6px' }}>
+        {noBudget
+          ? 'Pas de budget cible défini sur cette période'
+          : `Réel ${formatEur(real)} / Budget ${formatEur(budget)}`}
+      </div>
+    </div>
+  )
+}

--- a/components/analyses/widgets/KpiTm.js
+++ b/components/analyses/widgets/KpiTm.js
@@ -1,0 +1,24 @@
+import KpiCard from './KpiCard'
+import { buildComparison, formatEur2, formatDeltaEur } from '../../../lib/caAnalyses'
+
+export default function KpiTm({ c, isMobile, totals, comparisonTotals, comparisonLabel }) {
+  const value = totals && totals.tm != null ? formatEur2(totals.tm) : '—'
+  const comparison = comparisonTotals && comparisonTotals.tm != null && totals && totals.tm != null
+    ? buildComparison({
+        current: totals.tm,
+        target: comparisonTotals.tm,
+        formatDelta: (d) => formatDeltaEur(d),
+        label: comparisonLabel,
+      })
+    : null
+  return (
+    <KpiCard
+      c={c}
+      isMobile={isMobile}
+      label="Ticket moyen"
+      value={value}
+      hint={comparison ? null : 'CA TTC / couverts'}
+      comparison={comparison}
+    />
+  )
+}

--- a/components/analyses/widgets/SectionTableauJourJour.js
+++ b/components/analyses/widgets/SectionTableauJourJour.js
@@ -1,0 +1,170 @@
+import Link from 'next/link'
+import { formatEur, formatEur2, formatDeltaEur } from '../../../lib/caAnalyses'
+
+const JOURS_FR = ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi']
+
+// Tableau dense jour par jour pour la période sélectionnée. Reprend le format
+// de la vue mensuelle /controle-gestion/ventes (couv midi/soir + CA Food /
+// Alcool / Soft / Autres + total + Δ Budget coloré + TM) mais agnostique
+// quant aux dates (on consomme `days` déjà calculé par la page).
+//
+// `days` : sortie de aggregateByDay() + un champ `budget` ajouté par la page
+// (somme des budgets journaliers pour ce jour-de-semaine).
+export default function SectionTableauJourJour({ c, isMobile, days, totals }) {
+  const cellPad = isMobile ? '8px 6px' : '10px 12px'
+  const headPad = isMobile ? '10px 6px' : '12px 12px'
+  const baseFont = isMobile ? 12 : 13
+
+  const head = {
+    padding: headPad, fontSize: baseFont - 1, fontWeight: 600,
+    color: c.texteMuted, textTransform: 'uppercase', letterSpacing: 0.4,
+    textAlign: 'right', background: c.fond,
+    borderBottom: `1px solid ${c.bordure}`, whiteSpace: 'nowrap',
+  }
+  const cell = {
+    padding: cellPad, fontSize: baseFont, color: c.texte,
+    textAlign: 'right', borderBottom: `1px solid ${c.bordure}`,
+    whiteSpace: 'nowrap',
+  }
+
+  return (
+    <div style={{
+      background: c.blanc, borderRadius: '12px',
+      border: `0.5px solid ${c.bordure}`, overflow: 'hidden',
+    }}>
+      <div style={{ padding: isMobile ? '12px 14px' : '16px 20px', borderBottom: `0.5px solid ${c.bordure}` }}>
+        <div style={{ fontSize: 14, fontWeight: 600, color: c.texte }}>Détail jour par jour</div>
+        <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 2 }}>
+          {days.length} jour{days.length > 1 ? 's' : ''} sur la période sélectionnée
+        </div>
+      </div>
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 760 }}>
+          <thead>
+            <tr>
+              <th style={{ ...head, textAlign: 'left' }}>Date</th>
+              <th style={{ ...head, textAlign: 'left' }}>Jour</th>
+              <th style={head}>Couv. midi</th>
+              <th style={head}>Couv. soir</th>
+              <th style={head}>CA Food</th>
+              <th style={head}>CA Alcool</th>
+              <th style={head}>CA Soft</th>
+              <th style={head}>Autres</th>
+              <th style={head}>CA Total</th>
+              <th style={head}>Δ Budget</th>
+              <th style={head}>TM</th>
+              <th style={head}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {days.map((d) => (
+              <tr
+                key={d.iso}
+                style={{
+                  background: d.jsWeekday === 0 || d.jsWeekday === 6 ? c.fond : 'transparent',
+                  opacity: d.hasData ? 1 : 0.55,
+                }}
+              >
+                <td style={{ ...cell, textAlign: 'left', fontWeight: 500 }}>{d.iso.slice(8)}/{d.iso.slice(5, 7)}</td>
+                <td style={{ ...cell, textAlign: 'left', color: c.texteMuted }}>{JOURS_FR[d.jsWeekday].slice(0, 3)}</td>
+                <td style={cell}>{d.lunchCouverts || '—'}</td>
+                <td style={cell}>{d.dinnerCouverts || '—'}</td>
+                <td style={cell}>{formatEur(d.food)}</td>
+                <td style={cell}>{formatEur(d.bev_20)}</td>
+                <td style={cell}>{formatEur(d.bev_10)}</td>
+                <td style={cell}>{formatEur(d.autre)}</td>
+                <td style={{ ...cell, fontWeight: 600 }}>{formatEur(d.caTot)}</td>
+                <td style={budgetCellStyle(d, cell, c)} title={budgetCellTitle(d)}>
+                  {budgetCellLabel(d)}
+                </td>
+                <td style={cell}>{formatEur2(d.tm)}</td>
+                <td style={{ ...cell, padding: '4px 8px' }}>
+                  <Link
+                    href={`/controle-gestion/ventes/saisie?date=${d.iso}`}
+                    style={{
+                      fontSize: baseFont - 1, color: c.texteMuted,
+                      textDecoration: 'none', padding: '4px 8px',
+                      borderRadius: 6, border: `1px solid ${c.bordure}`,
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {d.hasData ? 'Modifier' : 'Saisir'}
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+          {totals && (
+            <tfoot>
+              <tr style={{ background: c.fond, fontWeight: 600 }}>
+                <td style={{ ...cell, textAlign: 'left' }} colSpan={2}>Total période</td>
+                <td style={cell}>{totals.lunchCouverts || '—'}</td>
+                <td style={cell}>{totals.dinnerCouverts || '—'}</td>
+                <td style={cell}>{formatEur(totals.food)}</td>
+                <td style={cell}>{formatEur(totals.bev20)}</td>
+                <td style={cell}>{formatEur(totals.bev10)}</td>
+                <td style={cell}>{formatEur(totals.autre)}</td>
+                <td style={{ ...cell, fontWeight: 700 }}>{formatEur(totals.caTtc)}</td>
+                <td style={totalBudgetCellStyle(totals, cell, c)} title={totalBudgetCellTitle(totals)}>
+                  {totalBudgetCellLabel(totals)}
+                </td>
+                <td style={cell}>{formatEur2(totals.tm)}</td>
+                <td style={cell}></td>
+              </tr>
+            </tfoot>
+          )}
+        </table>
+      </div>
+    </div>
+  )
+}
+
+// ── Helpers Δ Budget (mêmes règles que /controle-gestion/ventes) ────────────
+function budgetTone(real, budget, hasData) {
+  if (!budget) return 'none'
+  if (!hasData) return 'none'
+  if (real >= budget) return 'success'
+  if (real < budget * 0.95) return 'danger'
+  return 'warning'
+}
+
+function tonePalette(tone, c) {
+  if (tone === 'success') return { color: c.vert, bg: c.vertClair }
+  if (tone === 'danger') return { color: c.rouge, bg: c.rougeClair }
+  if (tone === 'warning') return { color: c.orange, bg: c.orangeClair }
+  return { color: c.texteMuted, bg: 'transparent' }
+}
+
+function budgetCellStyle(d, base, c) {
+  const tone = budgetTone(d.caTot, d.budget, d.hasData)
+  const { color, bg } = tonePalette(tone, c)
+  return { ...base, color, background: bg, fontWeight: tone === 'none' ? 400 : 600 }
+}
+
+function budgetCellLabel(d) {
+  if (!d.budget || !d.hasData) return '—'
+  return formatDeltaEur(d.caTot - d.budget)
+}
+
+function budgetCellTitle(d) {
+  if (!d.budget) return 'Pas de budget cible pour ce jour de la semaine'
+  const ratio = d.caTot > 0 ? (d.caTot / d.budget) * 100 : 0
+  return `Réel ${formatEur(d.caTot)} / Budget ${formatEur(d.budget)} (${ratio.toFixed(0)} %)`
+}
+
+function totalBudgetCellStyle(totals, base, c) {
+  const tone = budgetTone(totals.caTtc, totals.budget, totals.caTtc > 0)
+  const { color, bg } = tonePalette(tone, c)
+  return { ...base, color, background: bg, fontWeight: tone === 'none' ? 600 : 700 }
+}
+
+function totalBudgetCellLabel(totals) {
+  if (!totals.budget || totals.caTtc === 0) return '—'
+  return formatDeltaEur(totals.caTtc - totals.budget)
+}
+
+function totalBudgetCellTitle(totals) {
+  if (!totals.budget) return 'Aucun budget cible défini sur la période'
+  const ratio = totals.caTtc > 0 ? (totals.caTtc / totals.budget) * 100 : 0
+  return `Réel ${formatEur(totals.caTtc)} / Budget ${formatEur(totals.budget)} (${ratio.toFixed(0)} %)`
+}

--- a/components/dashboard/DashboardCustomizeModal.js
+++ b/components/dashboard/DashboardCustomizeModal.js
@@ -1,255 +1,30 @@
 'use client'
-import { useEffect, useState } from 'react'
-import { WIDGET_BY_ID, DEFAULT_LAYOUT, saveDashboardLayout, resetDashboardLayout, isWidgetAvailable } from '../../lib/dashboardPreferences'
+import {
+  WIDGET_BY_ID,
+  DEFAULT_LAYOUT,
+  saveDashboardLayout,
+  resetDashboardLayout,
+  isWidgetAvailable,
+} from '../../lib/dashboardPreferences'
+import WidgetsCustomizeModal from './WidgetsCustomizeModal'
 
-// Le layout est un array plat, mais l'UI regroupe visuellement les
-// widgets par type (KPIs vs sections) pour que l'user comprenne que
-// les KPIs sont toujours rendus avant les sections.
-// On filtre aussi les widgets dont le module est désactivé sur ce tenant.
-function splitByGroup(layout, modulesActifs) {
-  const kpis = []
-  const sections = []
-  for (const entry of layout) {
-    const widget = WIDGET_BY_ID[entry.id]
-    if (!widget) continue
-    if (!isWidgetAvailable(widget, modulesActifs)) continue
-    if (widget.size === 'kpi') kpis.push(entry)
-    else sections.push(entry)
-  }
-  return { kpis, sections }
-}
-
-function mergeGroups(kpis, sections) {
-  return [...kpis, ...sections]
-}
-
-function moveItem(list, index, direction) {
-  const target = index + direction
-  if (target < 0 || target >= list.length) return list
-  const copy = [...list]
-  ;[copy[index], copy[target]] = [copy[target], copy[index]]
-  return copy
-}
-
+// Wrapper rétro-compatible : la page /dashboard continue de monter
+// <DashboardCustomizeModal …/> tel quel ; on injecte ici le catalogue,
+// le layout par défaut et les fonctions save/reset propres au dashboard.
 export default function DashboardCustomizeModal({ c, initialLayout, modulesActifs = [], onClose, onSaved }) {
-  const [draft, setDraft] = useState(initialLayout)
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState(null)
-
-  useEffect(() => {
-    const onKey = (e) => { if (e.key === 'Escape') onClose() }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [onClose])
-
-  const { kpis, sections } = splitByGroup(draft, modulesActifs)
-
-  const toggleVisible = (id) => {
-    setDraft(draft.map((l) => (l.id === id ? { ...l, visible: !l.visible } : l)))
-  }
-
-  // Le réordonnancement doit préserver la position des widgets filtrés
-  // (modules désactivés) dans le layout stocké. On ne déplace les items
-  // que dans le sous-ensemble visible et on réinjecte les masqués à leur
-  // position d'origine.
-  const move = (id, direction) => {
-    const visibleIds = new Set([...kpis, ...sections].map((e) => e.id))
-    const visibleOrder = draft.filter((e) => visibleIds.has(e.id))
-    const { kpis: visibleKpis, sections: visibleSections } = splitByGroup(visibleOrder, modulesActifs)
-
-    let nextVisible
-    const inKpis = visibleKpis.findIndex((l) => l.id === id)
-    if (inKpis >= 0) {
-      nextVisible = mergeGroups(moveItem(visibleKpis, inKpis, direction), visibleSections)
-    } else {
-      const inSections = visibleSections.findIndex((l) => l.id === id)
-      if (inSections < 0) return
-      nextVisible = mergeGroups(visibleKpis, moveItem(visibleSections, inSections, direction))
-    }
-
-    const result = []
-    let vi = 0
-    for (const entry of draft) {
-      if (visibleIds.has(entry.id)) {
-        result.push(nextVisible[vi])
-        vi += 1
-      } else {
-        result.push(entry)
-      }
-    }
-    setDraft(result)
-  }
-
-  const handleSave = async () => {
-    setSaving(true)
-    setError(null)
-    try {
-      const clean = await saveDashboardLayout(draft)
-      onSaved(clean)
-    } catch (err) {
-      setError(err?.message || 'Erreur lors de la sauvegarde')
-      setSaving(false)
-    }
-  }
-
-  const handleReset = async () => {
-    setSaving(true)
-    setError(null)
-    try {
-      await resetDashboardLayout()
-      setDraft(DEFAULT_LAYOUT)
-      onSaved(DEFAULT_LAYOUT)
-    } catch (err) {
-      setError(err?.message || 'Erreur lors de la remise à zéro')
-      setSaving(false)
-    }
-  }
-
   return (
-    <div
-      className="sk-dashboard-modal-backdrop"
-      onClick={onClose}
-      style={{
-        position: 'fixed', inset: 0, zIndex: 200,
-        background: 'rgba(9,9,11,0.45)',
-        display: 'flex', alignItems: 'center', justifyContent: 'center',
-        padding: '16px',
-      }}
-    >
-      <div
-        onClick={(e) => e.stopPropagation()}
-        style={{
-          width: '100%', maxWidth: '520px', maxHeight: '90vh', overflowY: 'auto',
-          background: c.blanc, borderRadius: '14px',
-          border: `0.5px solid ${c.bordure}`, boxShadow: '0 20px 40px rgba(0,0,0,0.2)',
-          padding: '20px',
-        }}
-      >
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '6px' }}>
-          <div style={{ fontSize: '17px', fontWeight: '600', color: c.texte }}>Personnaliser mon tableau de bord</div>
-          <button
-            onClick={onClose}
-            aria-label="Fermer"
-            style={{ background: 'transparent', border: 'none', fontSize: '20px', color: c.texteMuted, cursor: 'pointer', lineHeight: 1 }}
-          >
-            ×
-          </button>
-        </div>
-        <div style={{ fontSize: '12px', color: c.texteMuted, marginBottom: '16px' }}>
-          Activez/désactivez les widgets et choisissez leur ordre d'affichage.
-        </div>
-
-        <WidgetList c={c} title="KPIs" entries={kpis} onToggle={toggleVisible} onMove={move} />
-        <WidgetList c={c} title="Sections" entries={sections} onToggle={toggleVisible} onMove={move} />
-
-        {error && (
-          <div style={{ marginTop: '12px', padding: '10px 12px', background: '#FCEBEB', color: '#A32D2D', borderRadius: '8px', fontSize: '12px' }}>
-            {error}
-          </div>
-        )}
-
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px', marginTop: '18px', flexWrap: 'wrap' }}>
-          <button
-            onClick={handleReset}
-            disabled={saving}
-            style={{
-              background: 'transparent', color: c.texteMuted, border: `0.5px solid ${c.bordure}`,
-              borderRadius: '8px', padding: '8px 12px', fontSize: '12px',
-              cursor: saving ? 'not-allowed' : 'pointer', opacity: saving ? 0.6 : 1,
-            }}
-          >
-            ↺ Rétablir les valeurs par défaut
-          </button>
-          <div style={{ display: 'flex', gap: '10px' }}>
-            <button
-              onClick={onClose}
-              disabled={saving}
-              style={{
-                background: c.blanc, color: c.texteMuted, border: `0.5px solid ${c.bordure}`,
-                borderRadius: '8px', padding: '10px 14px', fontSize: '13px',
-                cursor: saving ? 'not-allowed' : 'pointer', opacity: saving ? 0.6 : 1,
-              }}
-            >
-              Annuler
-            </button>
-            <button
-              onClick={handleSave}
-              disabled={saving}
-              style={{
-                background: c.accent, color: c.principal, border: 'none',
-                borderRadius: '8px', padding: '10px 14px', fontSize: '13px', fontWeight: '600',
-                cursor: saving ? 'not-allowed' : 'pointer', opacity: saving ? 0.6 : 1,
-              }}
-            >
-              {saving ? 'Enregistrement…' : 'Enregistrer'}
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function WidgetList({ c, title, entries, onToggle, onMove }) {
-  if (entries.length === 0) return null
-  return (
-    <div style={{ marginBottom: '12px' }}>
-      <div style={{ fontSize: '11px', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.05em', fontWeight: '500', marginBottom: '8px' }}>
-        {title}
-      </div>
-      <div style={{ border: `0.5px solid ${c.bordure}`, borderRadius: '10px', overflow: 'hidden' }}>
-        {entries.map((entry, i) => {
-          const widget = WIDGET_BY_ID[entry.id]
-          if (!widget) return null
-          return (
-            <div
-              key={entry.id}
-              style={{
-                display: 'flex', alignItems: 'center', gap: '10px',
-                padding: '10px 12px',
-                borderBottom: i < entries.length - 1 ? `0.5px solid ${c.bordure}` : 'none',
-                background: c.blanc,
-                opacity: entry.visible ? 1 : 0.55,
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={entry.visible}
-                onChange={() => onToggle(entry.id)}
-                style={{ cursor: 'pointer' }}
-              />
-              <div style={{ flex: 1, fontSize: '13px', color: c.texte }}>{widget.label}</div>
-              <button
-                onClick={() => onMove(entry.id, -1)}
-                disabled={i === 0}
-                aria-label="Monter"
-                style={{
-                  background: 'transparent', border: `0.5px solid ${c.bordure}`,
-                  borderRadius: '6px', padding: '4px 8px', color: c.texte,
-                  cursor: i === 0 ? 'not-allowed' : 'pointer', opacity: i === 0 ? 0.4 : 1,
-                  fontSize: '12px',
-                }}
-              >
-                ↑
-              </button>
-              <button
-                onClick={() => onMove(entry.id, 1)}
-                disabled={i === entries.length - 1}
-                aria-label="Descendre"
-                style={{
-                  background: 'transparent', border: `0.5px solid ${c.bordure}`,
-                  borderRadius: '6px', padding: '4px 8px', color: c.texte,
-                  cursor: i === entries.length - 1 ? 'not-allowed' : 'pointer',
-                  opacity: i === entries.length - 1 ? 0.4 : 1,
-                  fontSize: '12px',
-                }}
-              >
-                ↓
-              </button>
-            </div>
-          )
-        })}
-      </div>
-    </div>
+    <WidgetsCustomizeModal
+      c={c}
+      initialLayout={initialLayout}
+      modulesActifs={modulesActifs}
+      widgetById={WIDGET_BY_ID}
+      defaultLayout={DEFAULT_LAYOUT}
+      saveLayout={saveDashboardLayout}
+      resetLayout={resetDashboardLayout}
+      isWidgetAvailable={isWidgetAvailable}
+      title="Personnaliser mon tableau de bord"
+      onClose={onClose}
+      onSaved={onSaved}
+    />
   )
 }

--- a/components/dashboard/WidgetsCustomizeModal.js
+++ b/components/dashboard/WidgetsCustomizeModal.js
@@ -1,0 +1,273 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+// Modal de personnalisation des widgets, partagée entre les écrans à widgets
+// (dashboard cuisine, page Analyses, …). Le catalogue, le layout par défaut
+// et les fonctions save/reset sont injectés en props pour rester découplés
+// de la source de vérité de chaque page.
+//
+// Le layout est un array plat, mais l'UI regroupe visuellement les widgets
+// par type (KPIs vs sections) pour que l'user comprenne que les KPIs sont
+// toujours rendus avant les sections. On filtre aussi les widgets dont le
+// module est désactivé sur ce tenant.
+function splitByGroup(layout, widgetById, modulesActifs, isWidgetAvailable) {
+  const kpis = []
+  const sections = []
+  for (const entry of layout) {
+    const widget = widgetById[entry.id]
+    if (!widget) continue
+    if (!isWidgetAvailable(widget, modulesActifs)) continue
+    if (widget.size === 'kpi') kpis.push(entry)
+    else sections.push(entry)
+  }
+  return { kpis, sections }
+}
+
+function mergeGroups(kpis, sections) {
+  return [...kpis, ...sections]
+}
+
+function moveItem(list, index, direction) {
+  const target = index + direction
+  if (target < 0 || target >= list.length) return list
+  const copy = [...list]
+  ;[copy[index], copy[target]] = [copy[target], copy[index]]
+  return copy
+}
+
+export default function WidgetsCustomizeModal({
+  c,
+  initialLayout,
+  modulesActifs = [],
+  widgetById,
+  defaultLayout,
+  saveLayout,
+  resetLayout,
+  isWidgetAvailable,
+  title = 'Personnaliser mes widgets',
+  onClose,
+  onSaved,
+}) {
+  const [draft, setDraft] = useState(initialLayout)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const { kpis, sections } = splitByGroup(draft, widgetById, modulesActifs, isWidgetAvailable)
+
+  const toggleVisible = (id) => {
+    setDraft(draft.map((l) => (l.id === id ? { ...l, visible: !l.visible } : l)))
+  }
+
+  // Le réordonnancement doit préserver la position des widgets filtrés
+  // (modules désactivés) dans le layout stocké. On ne déplace les items
+  // que dans le sous-ensemble visible et on réinjecte les masqués à leur
+  // position d'origine.
+  const move = (id, direction) => {
+    const visibleIds = new Set([...kpis, ...sections].map((e) => e.id))
+    const visibleOrder = draft.filter((e) => visibleIds.has(e.id))
+    const { kpis: visibleKpis, sections: visibleSections } = splitByGroup(
+      visibleOrder, widgetById, modulesActifs, isWidgetAvailable
+    )
+
+    let nextVisible
+    const inKpis = visibleKpis.findIndex((l) => l.id === id)
+    if (inKpis >= 0) {
+      nextVisible = mergeGroups(moveItem(visibleKpis, inKpis, direction), visibleSections)
+    } else {
+      const inSections = visibleSections.findIndex((l) => l.id === id)
+      if (inSections < 0) return
+      nextVisible = mergeGroups(visibleKpis, moveItem(visibleSections, inSections, direction))
+    }
+
+    const result = []
+    let vi = 0
+    for (const entry of draft) {
+      if (visibleIds.has(entry.id)) {
+        result.push(nextVisible[vi])
+        vi += 1
+      } else {
+        result.push(entry)
+      }
+    }
+    setDraft(result)
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      const clean = await saveLayout(draft)
+      onSaved(clean)
+    } catch (err) {
+      setError(err?.message || 'Erreur lors de la sauvegarde')
+      setSaving(false)
+    }
+  }
+
+  const handleReset = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      await resetLayout()
+      setDraft(defaultLayout)
+      onSaved(defaultLayout)
+    } catch (err) {
+      setError(err?.message || 'Erreur lors de la remise à zéro')
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      className="sk-dashboard-modal-backdrop"
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0, zIndex: 200,
+        background: 'rgba(9,9,11,0.45)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        padding: '16px',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: '100%', maxWidth: '520px', maxHeight: '90vh', overflowY: 'auto',
+          background: c.blanc, borderRadius: '14px',
+          border: `0.5px solid ${c.bordure}`, boxShadow: '0 20px 40px rgba(0,0,0,0.2)',
+          padding: '20px',
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '6px' }}>
+          <div style={{ fontSize: '17px', fontWeight: '600', color: c.texte }}>{title}</div>
+          <button
+            onClick={onClose}
+            aria-label="Fermer"
+            style={{ background: 'transparent', border: 'none', fontSize: '20px', color: c.texteMuted, cursor: 'pointer', lineHeight: 1 }}
+          >
+            ×
+          </button>
+        </div>
+        <div style={{ fontSize: '12px', color: c.texteMuted, marginBottom: '16px' }}>
+          Activez/désactivez les widgets et choisissez leur ordre d&apos;affichage.
+        </div>
+
+        <WidgetList c={c} title="KPIs" entries={kpis} widgetById={widgetById} onToggle={toggleVisible} onMove={move} />
+        <WidgetList c={c} title="Sections" entries={sections} widgetById={widgetById} onToggle={toggleVisible} onMove={move} />
+
+        {error && (
+          <div style={{ marginTop: '12px', padding: '10px 12px', background: '#FCEBEB', color: '#A32D2D', borderRadius: '8px', fontSize: '12px' }}>
+            {error}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px', marginTop: '18px', flexWrap: 'wrap' }}>
+          <button
+            onClick={handleReset}
+            disabled={saving}
+            style={{
+              background: 'transparent', color: c.texteMuted, border: `0.5px solid ${c.bordure}`,
+              borderRadius: '8px', padding: '8px 12px', fontSize: '12px',
+              cursor: saving ? 'not-allowed' : 'pointer', opacity: saving ? 0.6 : 1,
+            }}
+          >
+            ↺ Rétablir les valeurs par défaut
+          </button>
+          <div style={{ display: 'flex', gap: '10px' }}>
+            <button
+              onClick={onClose}
+              disabled={saving}
+              style={{
+                background: c.blanc, color: c.texteMuted, border: `0.5px solid ${c.bordure}`,
+                borderRadius: '8px', padding: '10px 14px', fontSize: '13px',
+                cursor: saving ? 'not-allowed' : 'pointer', opacity: saving ? 0.6 : 1,
+              }}
+            >
+              Annuler
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              style={{
+                background: c.accent, color: c.texte, border: 'none',
+                borderRadius: '8px', padding: '10px 14px', fontSize: '13px', fontWeight: '600',
+                cursor: saving ? 'not-allowed' : 'pointer', opacity: saving ? 0.6 : 1,
+              }}
+            >
+              {saving ? 'Enregistrement…' : 'Enregistrer'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function WidgetList({ c, title, entries, widgetById, onToggle, onMove }) {
+  if (entries.length === 0) return null
+  return (
+    <div style={{ marginBottom: '12px' }}>
+      <div style={{ fontSize: '11px', color: c.texteMuted, textTransform: 'uppercase', letterSpacing: '0.05em', fontWeight: '500', marginBottom: '8px' }}>
+        {title}
+      </div>
+      <div style={{ border: `0.5px solid ${c.bordure}`, borderRadius: '10px', overflow: 'hidden' }}>
+        {entries.map((entry, i) => {
+          const widget = widgetById[entry.id]
+          if (!widget) return null
+          return (
+            <div
+              key={entry.id}
+              style={{
+                display: 'flex', alignItems: 'center', gap: '10px',
+                padding: '10px 12px',
+                borderBottom: i < entries.length - 1 ? `0.5px solid ${c.bordure}` : 'none',
+                background: c.blanc,
+                opacity: entry.visible ? 1 : 0.55,
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={entry.visible}
+                onChange={() => onToggle(entry.id)}
+                style={{ cursor: 'pointer' }}
+              />
+              <div style={{ flex: 1, fontSize: '13px', color: c.texte }}>{widget.label}</div>
+              <button
+                onClick={() => onMove(entry.id, -1)}
+                disabled={i === 0}
+                aria-label="Monter"
+                style={{
+                  background: 'transparent', border: `0.5px solid ${c.bordure}`,
+                  borderRadius: '6px', padding: '4px 8px', color: c.texte,
+                  cursor: i === 0 ? 'not-allowed' : 'pointer', opacity: i === 0 ? 0.4 : 1,
+                  fontSize: '12px',
+                }}
+              >
+                ↑
+              </button>
+              <button
+                onClick={() => onMove(entry.id, 1)}
+                disabled={i === entries.length - 1}
+                aria-label="Descendre"
+                style={{
+                  background: 'transparent', border: `0.5px solid ${c.bordure}`,
+                  borderRadius: '6px', padding: '4px 8px', color: c.texte,
+                  cursor: i === entries.length - 1 ? 'not-allowed' : 'pointer',
+                  opacity: i === entries.length - 1 ? 0.4 : 1,
+                  fontSize: '12px',
+                }}
+              >
+                ↓
+              </button>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/lib/__tests__/caAnalyses.test.ts
+++ b/lib/__tests__/caAnalyses.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getPeriodDates,
+  shiftPeriodByYears,
+  aggregateTotals,
+  aggregateByDay,
+  budgetByIsoJdsForMonth,
+  periodBudgetTotal,
+  TVA_FOOD,
+  TVA_BEV_20,
+} from '../caAnalyses'
+
+const TODAY = new Date(2026, 4, 9) // 2026-05-09 (jeudi)
+
+describe('getPeriodDates', () => {
+  it('aujourdhui = today → today', () => {
+    expect(getPeriodDates('aujourdhui', TODAY)).toEqual({ debut: '2026-05-09', fin: '2026-05-09' })
+  })
+
+  it('7j = today-6 → today (incluant aujourdhui)', () => {
+    expect(getPeriodDates('7j', TODAY)).toEqual({ debut: '2026-05-03', fin: '2026-05-09' })
+  })
+
+  it('30j = today-29 → today', () => {
+    expect(getPeriodDates('30j', TODAY)).toEqual({ debut: '2026-04-10', fin: '2026-05-09' })
+  })
+
+  it('mois-en-cours = 1er du mois → today (période ouverte)', () => {
+    expect(getPeriodDates('mois-en-cours', TODAY)).toEqual({ debut: '2026-05-01', fin: '2026-05-09' })
+  })
+
+  it('mois-precedent = mois entier précédent', () => {
+    expect(getPeriodDates('mois-precedent', TODAY)).toEqual({ debut: '2026-04-01', fin: '2026-04-30' })
+  })
+
+  it('trimestre = 1er du trimestre → today (mai → Q2)', () => {
+    expect(getPeriodDates('trimestre', TODAY)).toEqual({ debut: '2026-04-01', fin: '2026-05-09' })
+  })
+
+  it('annee = 1er janvier → today', () => {
+    expect(getPeriodDates('annee', TODAY)).toEqual({ debut: '2026-01-01', fin: '2026-05-09' })
+  })
+
+  it('mois-precedent en début d\'année passe à décembre N-1', () => {
+    const jan15 = new Date(2026, 0, 15)
+    expect(getPeriodDates('mois-precedent', jan15)).toEqual({ debut: '2025-12-01', fin: '2025-12-31' })
+  })
+})
+
+describe('shiftPeriodByYears', () => {
+  it('décale d\'un an dans le passé', () => {
+    expect(shiftPeriodByYears({ debut: '2026-05-01', fin: '2026-05-09' }, -1))
+      .toEqual({ debut: '2025-05-01', fin: '2025-05-09' })
+  })
+})
+
+describe('aggregateTotals', () => {
+  it('somme couverts et CA, calcule TM et HT par catégorie', () => {
+    const rows = [
+      { couverts: 10, ca_food: 110, ca_bev_20: 60, ca_bev_10: 11, ca_autre: 0 },
+      { couverts: 5,  ca_food: 0,   ca_bev_20: 0,  ca_bev_10: 0,  ca_autre: 22 },
+    ]
+    const t = aggregateTotals(rows)
+    expect(t.couverts).toBe(15)
+    expect(t.food).toBe(110)
+    expect(t.bev20).toBe(60)
+    expect(t.bev10).toBe(11)
+    expect(t.autre).toBe(22)
+    expect(t.caTtc).toBe(203)
+    // CAHT = 110/1.10 + 60/1.20 + 11/1.10 + 22/1.10 = 100 + 50 + 10 + 20 = 180
+    expect(t.caHt).toBeCloseTo(180, 5)
+    expect(t.tm).toBeCloseTo(203 / 15, 5)
+  })
+
+  it('TM = null si pas de couverts', () => {
+    expect(aggregateTotals([]).tm).toBeNull()
+  })
+
+  it('utilise les bons taux de TVA', () => {
+    const t = aggregateTotals([{ couverts: 1, ca_food: 110, ca_bev_20: 120, ca_bev_10: 0, ca_autre: 0 }])
+    expect(t.caHt).toBeCloseTo(110 / TVA_FOOD + 120 / TVA_BEV_20, 5)
+  })
+})
+
+describe('aggregateByDay', () => {
+  it('produit une ligne par jour de la période, même sans data', () => {
+    const days = aggregateByDay([], '2026-05-01', '2026-05-03')
+    expect(days).toHaveLength(3)
+    expect(days[0].iso).toBe('2026-05-01')
+    expect(days[2].iso).toBe('2026-05-03')
+    expect(days[0].hasData).toBe(false)
+  })
+
+  it('regroupe lunch et dinner par jour', () => {
+    const rows = [
+      { jour: '2026-05-01', service: 'lunch', couverts: 10, ca_food: 100, ca_bev_20: 0, ca_bev_10: 0, ca_autre: 0 },
+      { jour: '2026-05-01', service: 'dinner', couverts: 20, ca_food: 200, ca_bev_20: 50, ca_bev_10: 0, ca_autre: 0 },
+    ]
+    const days = aggregateByDay(rows, '2026-05-01', '2026-05-01')
+    expect(days[0].lunchCouverts).toBe(10)
+    expect(days[0].dinnerCouverts).toBe(20)
+    expect(days[0].couvertsTot).toBe(30)
+    expect(days[0].caTot).toBe(350)
+    expect(days[0].hasData).toBe(true)
+  })
+})
+
+describe('budgetByIsoJdsForMonth', () => {
+  // jds 4 = jeudi (mai 2026). Trois lieux × 2 services = 6 cellules potentielles.
+  it('override mensuel prioritaire sur défaut (mois NULL)', () => {
+    const rows = [
+      { jour_semaine: 4, lieu_service_id: 'L1', service: 'lunch',  mois: null, ca_food_cible: 100, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+      { jour_semaine: 4, lieu_service_id: 'L1', service: 'lunch',  mois: 5,    ca_food_cible: 200, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+      { jour_semaine: 4, lieu_service_id: 'L1', service: 'dinner', mois: null, ca_food_cible: 50,  ca_bev_20_cible: 10, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+    ]
+    const map = budgetByIsoJdsForMonth(rows, 5)
+    // L1 lunch = 200 (override), L1 dinner = 60 (default) → total 260 pour jds 4
+    expect(map.get(4)).toBe(260)
+  })
+
+  it('rien pour ce jour-de-semaine si pas de budget', () => {
+    const map = budgetByIsoJdsForMonth([], 5)
+    expect(map.get(1)).toBeUndefined()
+  })
+
+  it('agrège par jour-de-semaine indépendamment des cellules', () => {
+    const rows = [
+      { jour_semaine: 1, lieu_service_id: 'L1', service: 'lunch', mois: null, ca_food_cible: 50, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+      { jour_semaine: 1, lieu_service_id: 'L2', service: 'lunch', mois: null, ca_food_cible: 80, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+    ]
+    expect(budgetByIsoJdsForMonth(rows, 5).get(1)).toBe(130)
+  })
+})
+
+describe('periodBudgetTotal', () => {
+  it('somme correctement sur une période en agrégeant par jour-de-semaine', () => {
+    // Période : 2026-05-04 (lundi) → 2026-05-06 (mercredi) = 3 jours
+    // Budget : lundi=100, mardi=200, mercredi=300
+    const rows = [
+      { jour_semaine: 1, lieu_service_id: 'L1', service: 'lunch', mois: null, ca_food_cible: 100, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+      { jour_semaine: 2, lieu_service_id: 'L1', service: 'lunch', mois: null, ca_food_cible: 200, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+      { jour_semaine: 3, lieu_service_id: 'L1', service: 'lunch', mois: null, ca_food_cible: 300, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+    ]
+    const total = periodBudgetTotal({ 2026: rows }, '2026-05-04', '2026-05-06')
+    expect(total).toBe(600)
+  })
+
+  it('gère les périodes à cheval sur deux années', () => {
+    // Période : 2025-12-31 (mercredi) → 2026-01-01 (jeudi)
+    const rows2025 = [
+      { jour_semaine: 3, lieu_service_id: 'L1', service: 'lunch', mois: null, ca_food_cible: 100, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+    ]
+    const rows2026 = [
+      { jour_semaine: 4, lieu_service_id: 'L1', service: 'lunch', mois: null, ca_food_cible: 200, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+    ]
+    const total = periodBudgetTotal({ 2025: rows2025, 2026: rows2026 }, '2025-12-31', '2026-01-01')
+    expect(total).toBe(300)
+  })
+})

--- a/lib/analysesPreferences.js
+++ b/lib/analysesPreferences.js
@@ -1,0 +1,85 @@
+import {
+  loadLayoutForPage,
+  persistLayoutForPage,
+  clearLayoutForPage,
+} from './dashboardPreferences'
+
+// Source de vérité des widgets de la page Analyses CA
+// (/controle-gestion/analyses). Mirror du pattern dashboard cuisine, mais
+// avec son propre catalogue et son propre layout en base
+// (user_dashboard_preferences.page = 'analyses').
+//
+// `size`:
+//   - 'kpi'  → cellule dans la grille KPI (rangée du haut)
+//   - 'half' → demi-largeur, paire avec une autre 'half' consécutive visible
+//   - 'full' → pleine largeur
+//
+// `requiresModule`: id de module (clients.modules_actifs) nécessaire ;
+//   absent = widget toujours disponible.
+//
+// PR 2 livre les KPIs CA + le tableau jour/jour. Les charts arrivent en
+// PR 3, l'export & impression en PR 4, les widgets marges rapatriés en PR 5.
+export const WIDGET_CATALOG = [
+  // ── KPIs CA ────────────────────────────────────────────────────────────────
+  { id: 'kpi-couverts',        label: 'KPI — Couverts',           size: 'kpi',  defaultVisible: true },
+  { id: 'kpi-ca-ttc',          label: 'KPI — CA TTC',             size: 'kpi',  defaultVisible: true },
+  { id: 'kpi-ca-ht',           label: 'KPI — CA HT',              size: 'kpi',  defaultVisible: true },
+  { id: 'kpi-tm',              label: 'KPI — Ticket moyen',       size: 'kpi',  defaultVisible: true },
+  { id: 'kpi-ecart-budget-pct',label: 'KPI — Écart budget (%)',   size: 'kpi',  defaultVisible: true },
+
+  // ── Sections ──────────────────────────────────────────────────────────────
+  { id: 'section-tableau-jour-jour', label: 'Tableau jour par jour', size: 'full', defaultVisible: true },
+]
+
+export const WIDGET_BY_ID = Object.fromEntries(WIDGET_CATALOG.map((w) => [w.id, w]))
+
+export const WIDGET_IDS = WIDGET_CATALOG.map((w) => w.id)
+
+export const DEFAULT_LAYOUT = WIDGET_CATALOG.map((w) => ({
+  id: w.id,
+  visible: w.defaultVisible,
+}))
+
+export function isWidgetAvailable(widget, modulesActifs) {
+  if (!widget?.requiresModule) return true
+  return Array.isArray(modulesActifs) && modulesActifs.includes(widget.requiresModule)
+}
+
+// Fusion d'un layout stocké avec le catalog : on jette les ids inconnus
+// (widget supprimé du catalog) et on ajoute à la fin les widgets du catalog
+// pas encore connus (nouveau widget livré après que l'user a sauvegardé).
+export function reconcileLayout(storedLayout) {
+  const known = new Set(WIDGET_IDS)
+  const seen = new Set()
+  const merged = []
+
+  if (Array.isArray(storedLayout)) {
+    for (const entry of storedLayout) {
+      if (!entry || typeof entry.id !== 'string') continue
+      if (!known.has(entry.id) || seen.has(entry.id)) continue
+      merged.push({ id: entry.id, visible: entry.visible !== false })
+      seen.add(entry.id)
+    }
+  }
+
+  for (const w of WIDGET_CATALOG) {
+    if (seen.has(w.id)) continue
+    merged.push({ id: w.id, visible: w.defaultVisible })
+  }
+
+  return merged
+}
+
+const PAGE_KEY = 'analyses'
+
+export async function getAnalysesLayout() {
+  return loadLayoutForPage(PAGE_KEY, reconcileLayout)
+}
+
+export async function saveAnalysesLayout(layout) {
+  return persistLayoutForPage(PAGE_KEY, reconcileLayout, layout)
+}
+
+export async function resetAnalysesLayout() {
+  return clearLayoutForPage(PAGE_KEY)
+}

--- a/lib/caAnalyses.js
+++ b/lib/caAnalyses.js
@@ -1,0 +1,268 @@
+// Helpers purs pour la page /controle-gestion/analyses :
+// - calcul des bornes de période ("mois en cours", "7j", etc.)
+// - agrégation de lignes ca_journalier en totaux (TTC + HT + TM)
+// - calcul du budget agrégé sur une plage de dates depuis ca_budgets
+//
+// Tout est testable sans Supabase ni React : les fonctions prennent les rows
+// en entrée et renvoient des objets dérivés.
+
+// ── Constantes ─────────────────────────────────────────────────────────────
+// Conversion TTC → HT par catégorie. TVA Food/Soft 10 %, TVA Alcool 20 %.
+// "Autre" : TVA inconnue → on assume 10 % (catégorie boutique/divers, le
+// plus souvent restauration). Validé pragmatique avec l'utilisateur.
+export const TVA_FOOD = 1.10
+export const TVA_BEV_20 = 1.20
+export const TVA_BEV_10 = 1.10
+export const TVA_AUTRE = 1.10
+
+// ── Périodes ────────────────────────────────────────────────────────────────
+
+export function toIsoDate(d) {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+export function fromIsoDate(iso) {
+  const [y, m, d] = iso.split('-').map(Number)
+  return new Date(y, m - 1, d)
+}
+
+// Renvoie { debut, fin } en ISO (YYYY-MM-DD) pour un identifiant de période.
+// Périodes ouvertes (mois-en-cours, trimestre, annee) : finissent à `today`
+// (le futur n'existe pas en BDD, et ça donne une comparaison budget juste).
+// Périodes fermées (mois-precedent) : couvrent l'intégralité du mois.
+export function getPeriodDates(periode, today = new Date()) {
+  const t = today
+  if (periode === 'aujourdhui') {
+    return { debut: toIsoDate(t), fin: toIsoDate(t) }
+  }
+  if (periode === '7j') {
+    const start = new Date(t)
+    start.setDate(start.getDate() - 6)
+    return { debut: toIsoDate(start), fin: toIsoDate(t) }
+  }
+  if (periode === '30j') {
+    const start = new Date(t)
+    start.setDate(start.getDate() - 29)
+    return { debut: toIsoDate(start), fin: toIsoDate(t) }
+  }
+  if (periode === 'mois-en-cours') {
+    const start = new Date(t.getFullYear(), t.getMonth(), 1)
+    return { debut: toIsoDate(start), fin: toIsoDate(t) }
+  }
+  if (periode === 'mois-precedent') {
+    const firstOfThisMonth = new Date(t.getFullYear(), t.getMonth(), 1)
+    const lastOfPrevMonth = new Date(firstOfThisMonth.getTime() - 24 * 60 * 60 * 1000)
+    const firstOfPrevMonth = new Date(lastOfPrevMonth.getFullYear(), lastOfPrevMonth.getMonth(), 1)
+    return { debut: toIsoDate(firstOfPrevMonth), fin: toIsoDate(lastOfPrevMonth) }
+  }
+  if (periode === 'trimestre') {
+    const q = Math.floor(t.getMonth() / 3)
+    const start = new Date(t.getFullYear(), q * 3, 1)
+    return { debut: toIsoDate(start), fin: toIsoDate(t) }
+  }
+  if (periode === 'annee') {
+    const start = new Date(t.getFullYear(), 0, 1)
+    return { debut: toIsoDate(start), fin: toIsoDate(t) }
+  }
+  // 'custom' : géré par l'appelant (les dates viennent du form)
+  return null
+}
+
+// Décale une plage de dates d'un nombre d'années (négatif = passé).
+export function shiftPeriodByYears({ debut, fin }, years) {
+  const shift = (iso) => {
+    const d = fromIsoDate(iso)
+    d.setFullYear(d.getFullYear() + years)
+    return toIsoDate(d)
+  }
+  return { debut: shift(debut), fin: shift(fin) }
+}
+
+// Itère chaque jour ISO de [debut, fin] inclus.
+export function* eachDayIso(debut, fin) {
+  const start = fromIsoDate(debut)
+  const end = fromIsoDate(fin)
+  const cur = new Date(start)
+  while (cur <= end) {
+    yield {
+      iso: toIsoDate(cur),
+      jsWeekday: cur.getDay(),
+      isoJds: cur.getDay() === 0 ? 7 : cur.getDay(),
+    }
+    cur.setDate(cur.getDate() + 1)
+  }
+}
+
+// ── Agrégation des ventes ───────────────────────────────────────────────────
+
+// rows : lignes ca_journalier filtrées (par lieu/service côté SQL ou JS).
+// Chaque ligne a couverts, ca_food, ca_bev_20, ca_bev_10, ca_autre.
+export function aggregateTotals(rows) {
+  let couverts = 0, food = 0, bev20 = 0, bev10 = 0, autre = 0
+  for (const r of rows) {
+    couverts += Number(r.couverts || 0)
+    food += Number(r.ca_food || 0)
+    bev20 += Number(r.ca_bev_20 || 0)
+    bev10 += Number(r.ca_bev_10 || 0)
+    autre += Number(r.ca_autre || 0)
+  }
+  const caTtc = food + bev20 + bev10 + autre
+  const caHt = food / TVA_FOOD + bev20 / TVA_BEV_20 + bev10 / TVA_BEV_10 + autre / TVA_AUTRE
+  const tm = couverts > 0 ? caTtc / couverts : null
+  return { couverts, food, bev20, bev10, autre, caTtc, caHt, tm }
+}
+
+// ── Agrégation par jour pour le tableau jour-par-jour ───────────────────────
+
+export function aggregateByDay(rows, debut, fin) {
+  const byDay = new Map()
+  for (const r of rows) {
+    const key = r.jour
+    if (!byDay.has(key)) {
+      byDay.set(key, {
+        lunchCouverts: 0, dinnerCouverts: 0,
+        food: 0, bev_20: 0, bev_10: 0, autre: 0,
+      })
+    }
+    const acc = byDay.get(key)
+    const cv = Number(r.couverts || 0)
+    if (r.service === 'lunch') acc.lunchCouverts += cv
+    else acc.dinnerCouverts += cv
+    acc.food += Number(r.ca_food || 0)
+    acc.bev_20 += Number(r.ca_bev_20 || 0)
+    acc.bev_10 += Number(r.ca_bev_10 || 0)
+    acc.autre += Number(r.ca_autre || 0)
+  }
+  const result = []
+  for (const d of eachDayIso(debut, fin)) {
+    const agg = byDay.get(d.iso) || {
+      lunchCouverts: 0, dinnerCouverts: 0,
+      food: 0, bev_20: 0, bev_10: 0, autre: 0,
+    }
+    const couvertsTot = agg.lunchCouverts + agg.dinnerCouverts
+    const caTot = agg.food + agg.bev_20 + agg.bev_10 + agg.autre
+    result.push({
+      iso: d.iso,
+      jsWeekday: d.jsWeekday,
+      isoJds: d.isoJds,
+      ...agg,
+      couvertsTot,
+      caTot,
+      tm: couvertsTot > 0 ? caTot / couvertsTot : null,
+      hasData: caTot > 0 || couvertsTot > 0,
+    })
+  }
+  return result
+}
+
+// ── Budget ──────────────────────────────────────────────────────────────────
+
+// budgetRows : ca_budgets sur l'année concernée, filtrés (par lieu/service
+// côté SQL ou JS), avec mois NULL (défaut) ou mois = monthNum (override).
+//
+// Renvoie un Map<isoJds (1..7), totalBudgetCible> calculé pour `monthNum`.
+// Override prioritaire sur défaut au niveau (jds, lieu, service).
+export function budgetByIsoJdsForMonth(budgetRows, monthNum) {
+  const cellMap = new Map() // key = `${jds}_${lieu}_${svc}`
+  for (const b of budgetRows) {
+    const key = `${b.jour_semaine}_${b.lieu_service_id}_${b.service}`
+    if (b.mois === monthNum) {
+      cellMap.set(key, b)
+    } else if (!cellMap.has(key)) {
+      cellMap.set(key, b)
+    }
+  }
+  const out = new Map()
+  for (const cell of cellMap.values()) {
+    const total =
+      Number(cell.ca_food_cible || 0) +
+      Number(cell.ca_bev_20_cible || 0) +
+      Number(cell.ca_bev_10_cible || 0) +
+      Number(cell.ca_autre_cible || 0)
+    out.set(cell.jour_semaine, (out.get(cell.jour_semaine) || 0) + total)
+  }
+  return out
+}
+
+// Somme des budgets journaliers sur la période [debut, fin].
+// budgetRowsByYear : map { [annee]: rows[] } pour gérer les périodes
+// chevauchant deux années (ex: décembre → janvier).
+export function periodBudgetTotal(budgetRowsByYear, debut, fin) {
+  // Cache du Map par (annee, mois) pour éviter de recalculer à chaque jour
+  const cache = new Map()
+  const getMap = (annee, mois) => {
+    const key = `${annee}_${mois}`
+    if (!cache.has(key)) {
+      cache.set(key, budgetByIsoJdsForMonth(budgetRowsByYear[annee] || [], mois))
+    }
+    return cache.get(key)
+  }
+  let total = 0
+  for (const d of eachDayIso(debut, fin)) {
+    const date = fromIsoDate(d.iso)
+    const annee = date.getFullYear()
+    const mois = date.getMonth() + 1
+    const map = getMap(annee, mois)
+    total += map.get(d.isoJds) || 0
+  }
+  return total
+}
+
+// ── Formatters partagés ─────────────────────────────────────────────────────
+
+export function formatEur(n) {
+  if (n == null || isNaN(n) || n === 0) return '—'
+  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 }).format(n)
+}
+
+export function formatEur2(n) {
+  if (n == null || isNaN(n) || n === 0) return '—'
+  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(n)
+}
+
+export function formatDeltaEur(n) {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'currency', currency: 'EUR',
+    maximumFractionDigits: 0, signDisplay: 'always',
+  }).format(n)
+}
+
+export function formatDeltaPct(pct) {
+  if (pct == null || !isFinite(pct)) return '—'
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'percent', maximumFractionDigits: 1, signDisplay: 'always',
+  }).format(pct / 100)
+}
+
+export function formatNombre(n) {
+  if (n == null || isNaN(n)) return '—'
+  return new Intl.NumberFormat('fr-FR', { maximumFractionDigits: 0 }).format(n)
+}
+
+// ── Construction des objets `comparison` consommés par <KpiCard /> ──────────
+// `mode` :
+//   - 'success'  → delta favorable (au-dessus de la cible) → vert
+//   - 'danger'   → delta défavorable → rouge
+//   - 'neutral'  → delta légèrement en-dessous (zone orange)
+//   - 'none'     → équivalent / pas d'info → gris
+export function buildComparison({ current, target, formatValue, formatDelta, label, higherIsBetter = true }) {
+  if (target == null || current == null) return null
+  const delta = current - target
+  let pct = null
+  if (target !== 0) pct = (delta / target) * 100
+  const better = higherIsBetter ? delta > 0 : delta < 0
+  const worse = higherIsBetter ? delta < 0 : delta > 0
+  let mode = 'none'
+  if (better) mode = 'success'
+  else if (worse) mode = pct != null && pct < -5 ? 'danger' : 'neutral'
+
+  const deltaText = formatDelta(delta)
+  const pctText = pct == null ? '' : ` (${formatDeltaPct(pct)})`
+  return {
+    delta,
+    pct,
+    deltaLabel: `${deltaText}${pctText} ${label}`,
+    mode,
+    formattedValue: formatValue ? formatValue(target) : null,
+  }
+}

--- a/lib/dashboardPreferences.js
+++ b/lib/dashboardPreferences.js
@@ -66,26 +66,46 @@ export function reconcileLayout(storedLayout) {
 // Récupère le layout réconcilié pour l'user courant sur le tenant courant.
 // Retourne toujours un array valide (jamais null) grâce à reconcileLayout.
 export async function getDashboardLayout() {
+  return loadLayoutForPage('dashboard', reconcileLayout)
+}
+
+// Upsert du layout. On ne stocke que des entrées valides (ids du catalog).
+export async function saveDashboardLayout(layout) {
+  return persistLayoutForPage('dashboard', reconcileLayout, layout)
+}
+
+// Remise aux valeurs par défaut : on supprime la ligne.
+// Au prochain load, getDashboardLayout() retournera DEFAULT_LAYOUT.
+export async function resetDashboardLayout() {
+  return clearLayoutForPage('dashboard')
+}
+
+// ─── Helpers internes mutualisés pour les autres pages à widgets (analyses, …)
+// La table user_dashboard_preferences porte une colonne `page` pour indexer
+// plusieurs layouts par (user, tenant). Ces helpers sont consommés par les
+// modules de préférences spécifiques (ex: lib/analysesPreferences.js).
+
+export async function loadLayoutForPage(page, reconcileFn) {
   const clientId = await getClientId()
-  if (!clientId) return reconcileLayout(null)
+  if (!clientId) return reconcileFn(null)
 
   const { data: userData } = await supabase.auth.getUser()
   const userId = userData?.user?.id
-  if (!userId) return reconcileLayout(null)
+  if (!userId) return reconcileFn(null)
 
   const { data, error } = await supabase
     .from('user_dashboard_preferences')
     .select('layout')
     .eq('user_id', userId)
     .eq('client_id', clientId)
+    .eq('page', page)
     .maybeSingle()
 
-  if (error || !data) return reconcileLayout(null)
-  return reconcileLayout(data.layout)
+  if (error || !data) return reconcileFn(null)
+  return reconcileFn(data.layout)
 }
 
-// Upsert du layout. On ne stocke que des entrées valides (ids du catalog).
-export async function saveDashboardLayout(layout) {
+export async function persistLayoutForPage(page, reconcileFn, layout) {
   const clientId = await getClientId()
   if (!clientId) throw new Error('Aucun établissement actif')
 
@@ -93,22 +113,20 @@ export async function saveDashboardLayout(layout) {
   const userId = userData?.user?.id
   if (!userId) throw new Error('Utilisateur non authentifié')
 
-  const clean = reconcileLayout(layout)
+  const clean = reconcileFn(layout)
 
   const { error } = await supabase
     .from('user_dashboard_preferences')
     .upsert(
-      { user_id: userId, client_id: clientId, layout: clean },
-      { onConflict: 'user_id,client_id' }
+      { user_id: userId, client_id: clientId, page, layout: clean },
+      { onConflict: 'user_id,client_id,page' }
     )
 
   if (error) throw error
   return clean
 }
 
-// Remise aux valeurs par défaut : on supprime la ligne.
-// Au prochain load, getDashboardLayout() retournera DEFAULT_LAYOUT.
-export async function resetDashboardLayout() {
+export async function clearLayoutForPage(page) {
   const clientId = await getClientId()
   if (!clientId) return
 
@@ -121,4 +139,5 @@ export async function resetDashboardLayout() {
     .delete()
     .eq('user_id', userId)
     .eq('client_id', clientId)
+    .eq('page', page)
 }

--- a/supabase/migrations/20260510000000_user_dashboard_preferences_page.sql
+++ b/supabase/migrations/20260510000000_user_dashboard_preferences_page.sql
@@ -1,0 +1,28 @@
+-- ============================================================================
+-- user_dashboard_preferences : ajout colonne `page` pour permettre à un même
+-- user / tenant de stocker plusieurs layouts (un par page à widgets).
+--
+-- Avant : (user_id, client_id) unique → un seul layout, celui du dashboard.
+-- Après : (user_id, client_id, page) unique. Backfill = 'dashboard' pour les
+--   rows existantes (le seul écran à widgets jusqu'à présent).
+--
+-- Permet la nouvelle page /controle-gestion/analyses (page='analyses') sans
+-- perturber le layout du dashboard.
+-- ============================================================================
+
+ALTER TABLE public.user_dashboard_preferences
+  ADD COLUMN IF NOT EXISTS page text NOT NULL DEFAULT 'dashboard';
+
+COMMENT ON COLUMN public.user_dashboard_preferences.page IS
+  'Identifiant logique de la page concernée (ex: ''dashboard'', ''analyses''). Permet de stocker des layouts distincts par page pour un même user/tenant.';
+
+-- Remplace l'unique (user_id, client_id) par (user_id, client_id, page)
+ALTER TABLE public.user_dashboard_preferences
+  DROP CONSTRAINT IF EXISTS user_dashboard_preferences_user_id_client_id_key;
+
+ALTER TABLE public.user_dashboard_preferences
+  ADD CONSTRAINT user_dashboard_preferences_user_client_page_key
+  UNIQUE (user_id, client_id, page);
+
+-- Index pour les lookups (user_id, client_id, page) — l'unique fournit déjà
+-- un index, on garde donc juste celui d'origine sur (user_id, client_id).


### PR DESCRIPTION
## Summary
PR 2/5 du chantier « Page Analyses ». Pose les fondations : nouvelle route, système widgets, filtres globaux, 5 KPIs CA et tableau jour/jour.

### Migration
- `supabase/migrations/20260510000000_user_dashboard_preferences_page.sql` (déjà appliquée en prod via MCP)
- Ajoute `page text NOT NULL DEFAULT 'dashboard'` à `user_dashboard_preferences`
- Remplace l'unique `(user_id, client_id)` par `(user_id, client_id, page)`
- Backfill = 'dashboard' (default value) → zéro casse pour le dashboard cuisine existant

### Code
- **Nouvelle route** : `/controle-gestion/analyses` (admin/directeur uniquement)
- **Filtres globaux** (`components/analyses/FilterBar.js`) : période 8 boutons (Aujourd'hui / 7j / 30j / Mois en cours [défaut] / Mois préc. / Trimestre / Année / Personnalisé), comparaison (Aucune / vs N-1 / vs Budget), filtre lieu, filtre service.
- **5 KPIs CA** : Couverts, CA TTC, CA HT, Ticket moyen, Écart vs Budget %.
- **Tableau jour-par-jour** : reprend le format de `/controle-gestion/ventes` avec la colonne Δ Budget colorée de PR 1, étendu à n'importe quelle plage de dates avec filtres.
- **Système widgets** : `lib/analysesPreferences.js` (catalogue + reconcile + save/load/reset sur la nouvelle colonne `page`), modal de personnalisation réutilisable.
- **Refacto** : extraction de `WidgetsCustomizeModal` (générique, prend catalog + save/reset en props). `DashboardCustomizeModal` devient un wrapper rétro-compatible — zéro changement côté `/dashboard`.
- **Helpers calculs** : `lib/caAnalyses.js` purs et testés (16 tests vitest sur bornes de période, agrégation totaux, conversion HT, budget agrégé avec fallback override).
- **Navbar** : entrée « Analyses » ajoutée juste avant « Marges » dans le menu Gestion.

### Conventions respectées
- Boutons accent : `color: c.texte` (pas `#fff`) ✅
- `useTheme()` destructuré ✅
- Migration commitée ET appliquée via MCP Supabase (`uvmslpdcywephdneciwd`) ✅
- Branche worktree `claude/page-analyses-squelette` ✅

## Test plan
- [ ] Naviguer vers `/controle-gestion/analyses` (rôle admin/directeur) → la page charge avec « Mois en cours » par défaut.
- [ ] Vérifier que les 5 KPIs s'affichent et que CA HT = sum(food/1.10 + alcool/1.20 + soft/1.10 + autre/1.10).
- [ ] Changer la période → les KPIs et le tableau se mettent à jour.
- [ ] Activer « Comparaison vs N-1 » → chaque KPI affiche un δ avec couleur (vert/rouge).
- [ ] Activer « Comparaison vs Budget » → seul KPI CA TTC + KPI Écart Budget affichent une comparaison utile.
- [ ] Filtrer par lieu / service → totaux et tableau recalculés.
- [ ] Cliquer ⚙ Personnaliser → masquer un KPI, sauvegarder, recharger la page → l'état persiste.
- [ ] Aller sur `/dashboard` → la personnalisation du dashboard cuisine est intacte (testée séparément du layout Analyses).
- [ ] Tester sur un client SANS budget : l'écart vs budget affiche « — » sans erreur.
- [ ] Tester en mobile : layout 2 colonnes pour les KPIs, tableau scroll horizontal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)