### PR TITLE
feat(analyses): charts évolution + perf jour-semaine + mix Food/Bev + top/bottom

### DIFF
--- a/app/controle-gestion/analyses/page.js
+++ b/app/controle-gestion/analyses/page.js
@@ -13,6 +13,11 @@ import {
   aggregateTotals,
   aggregateByDay,
   periodBudgetTotal,
+  pickGranularity,
+  bucketDays,
+  perfByWeekday,
+  mixSegments,
+  topBottomDays,
   fromIsoDate,
 } from '../../../lib/caAnalyses'
 import {
@@ -31,6 +36,11 @@ import KpiCaTtc from '../../../components/analyses/widgets/KpiCaTtc'
 import KpiCaHt from '../../../components/analyses/widgets/KpiCaHt'
 import KpiTm from '../../../components/analyses/widgets/KpiTm'
 import KpiEcartBudgetPct from '../../../components/analyses/widgets/KpiEcartBudgetPct'
+import SectionEvolutionCa from '../../../components/analyses/widgets/SectionEvolutionCa'
+import SectionEvolutionCouverts from '../../../components/analyses/widgets/SectionEvolutionCouverts'
+import SectionPerfJourSemaine from '../../../components/analyses/widgets/SectionPerfJourSemaine'
+import SectionMixFoodBev from '../../../components/analyses/widgets/SectionMixFoodBev'
+import SectionTopBottomJours from '../../../components/analyses/widgets/SectionTopBottomJours'
 import SectionTableauJourJour from '../../../components/analyses/widgets/SectionTableauJourJour'
 
 const DEFAULT_PERIODE = 'mois-en-cours'
@@ -289,6 +299,14 @@ export default function AnalysesPage() {
     }
   }, [daysWithBudget, totals])
 
+  // ── Données dérivées pour les charts ─────────────────────────────────────
+  const granularity = useMemo(() => pickGranularity(dateDebut, dateFin), [dateDebut, dateFin])
+  const buckets = useMemo(() => bucketDays(daysWithBudget, granularity), [daysWithBudget, granularity])
+  const perfWeekday = useMemo(() => perfByWeekday(daysWithBudget), [daysWithBudget])
+  const mix = useMemo(() => mixSegments(totals, c), [totals, c])
+  const topBottom = useMemo(() => topBottomDays(daysWithBudget, 5), [daysWithBudget])
+  const hasBudget = periodBudget > 0
+
   // ── Rendu d'un widget par id ─────────────────────────────────────────────
   const renderWidget = (id) => {
     const common = { c, isMobile, totals, comparisonTotals, comparisonLabel }
@@ -298,6 +316,16 @@ export default function AnalysesPage() {
       case 'kpi-ca-ht':            return <KpiCaHt {...common} />
       case 'kpi-tm':               return <KpiTm {...common} />
       case 'kpi-ecart-budget-pct': return <KpiEcartBudgetPct c={c} isMobile={isMobile} totals={totals} budget={periodBudget} />
+      case 'section-evolution-ca':
+        return <SectionEvolutionCa c={c} isMobile={isMobile} buckets={buckets} granularity={granularity} hasBudget={hasBudget} />
+      case 'section-evolution-couverts':
+        return <SectionEvolutionCouverts c={c} isMobile={isMobile} buckets={buckets} granularity={granularity} />
+      case 'section-perf-jour-semaine':
+        return <SectionPerfJourSemaine c={c} isMobile={isMobile} perf={perfWeekday} />
+      case 'section-mix-food-bev':
+        return <SectionMixFoodBev c={c} isMobile={isMobile} segments={mix} totalCaTtc={totals.caTtc} />
+      case 'section-top-bottom-jours':
+        return <SectionTopBottomJours c={c} isMobile={isMobile} topBottom={topBottom} />
       case 'section-tableau-jour-jour':
         return <SectionTableauJourJour c={c} isMobile={isMobile} days={daysWithBudget} totals={tableauTotals} />
       default: return null
@@ -324,6 +352,26 @@ export default function AnalysesPage() {
   const kpiCols = isMobile
     ? Math.min(Math.max(kpiLayout.length, 1), 2)
     : Math.min(Math.max(kpiLayout.length, 1), 5)
+
+  // Groupement des sections en lignes : deux 'half' consécutives s'associent,
+  // sinon chaque widget prend la pleine largeur. Même logique que /dashboard.
+  const sectionRows = []
+  {
+    let i = 0
+    while (i < sectionLayout.length) {
+      const current = sectionLayout[i]
+      const next = sectionLayout[i + 1]
+      const currentSize = WIDGET_BY_ID[current.id].size
+      const nextSize = next ? WIDGET_BY_ID[next.id].size : null
+      if (currentSize === 'half' && nextSize === 'half') {
+        sectionRows.push([current, next])
+        i += 2
+      } else {
+        sectionRows.push([current])
+        i += 1
+      }
+    }
+  }
 
   return (
     <div style={{ minHeight: '100vh', background: c.fond }}>
@@ -373,9 +421,17 @@ export default function AnalysesPage() {
           </div>
         )}
 
-        {!loading && !error && sectionLayout.map((l) => (
-          <div key={l.id} style={{ marginBottom: isMobile ? 12 : 16 }}>
-            {renderWidget(l.id)}
+        {!loading && !error && sectionRows.map((row, idx) => (
+          <div
+            key={row.map((r) => r.id).join('|')}
+            style={{
+              display: 'grid',
+              gridTemplateColumns: isMobile || row.length === 1 ? '1fr' : '1fr 1fr',
+              gap: isMobile ? 12 : 16,
+              marginBottom: idx < sectionRows.length - 1 ? (isMobile ? 12 : 16) : 0,
+            }}
+          >
+            {row.map((l) => <div key={l.id}>{renderWidget(l.id)}</div>)}
           </div>
         ))}
 

--- a/components/analyses/widgets/SectionEvolutionCa.js
+++ b/components/analyses/widgets/SectionEvolutionCa.js
@@ -1,0 +1,81 @@
+'use client'
+
+import {
+  ResponsiveContainer, ComposedChart, Line, Bar,
+  XAxis, YAxis, CartesianGrid, Tooltip, Legend,
+} from 'recharts'
+
+// Évolution du CA TTC réel comparé au budget cumulé sur la période,
+// granularité automatique (jour ≤ 31 j, semaine ≤ 6 mois, mois sinon).
+//
+// `buckets` est la sortie de bucketDays(daysWithBudget, granularity) :
+//   { key, label, caTot, couverts, budget, count }
+export default function SectionEvolutionCa({ c, isMobile, buckets, granularity, hasBudget }) {
+  const empty = !buckets || buckets.length === 0
+  return (
+    <div style={{
+      background: c.blanc, borderRadius: 12,
+      border: `0.5px solid ${c.bordure}`,
+      padding: isMobile ? '14px 10px' : '20px',
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 12 }}>
+        <div>
+          <div style={{ fontSize: 14, fontWeight: 600, color: c.texte }}>Évolution du CA TTC</div>
+          <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 2 }}>
+            Granularité : {granularityLabel(granularity)}{hasBudget ? ' — barres = budget cible' : ''}
+          </div>
+        </div>
+      </div>
+      {empty ? (
+        <EmptyState c={c} />
+      ) : (
+        <ResponsiveContainer width="100%" height={isMobile ? 220 : 280}>
+          <ComposedChart data={buckets} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke={c.bordure} />
+            <XAxis dataKey="label" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} />
+            <YAxis tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} tickFormatter={(v) => formatAxisEur(v)} />
+            <Tooltip
+              contentStyle={{ borderRadius: 8, border: `0.5px solid ${c.bordure}`, fontSize: 12 }}
+              formatter={(v, name) => [formatTooltipEur(v), name]}
+            />
+            <Legend iconSize={10} wrapperStyle={{ fontSize: 11 }} />
+            {hasBudget && (
+              <Bar dataKey="budget" name="Budget" fill={c.accentClair} radius={[4, 4, 0, 0]} />
+            )}
+            <Line type="monotone" dataKey="caTot" name="CA TTC réel" stroke={c.accent} strokeWidth={2} dot={{ r: 3 }} />
+          </ComposedChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  )
+}
+
+function granularityLabel(g) {
+  if (g === 'day') return 'jour par jour'
+  if (g === 'week') return 'semaine par semaine'
+  if (g === 'month') return 'mois par mois'
+  return ''
+}
+
+function formatAxisEur(v) {
+  if (v == null) return ''
+  if (Math.abs(v) >= 1000) return `${Math.round(v / 1000)} k€`
+  return `${Math.round(v)} €`
+}
+
+function formatTooltipEur(v) {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'currency', currency: 'EUR', maximumFractionDigits: 0,
+  }).format(Number(v) || 0)
+}
+
+function EmptyState({ c }) {
+  return (
+    <div style={{
+      padding: '32px 16px', textAlign: 'center',
+      color: c.texteMuted, fontSize: 13,
+    }}>
+      Aucune donnée sur la période sélectionnée.
+    </div>
+  )
+}

--- a/components/analyses/widgets/SectionEvolutionCouverts.js
+++ b/components/analyses/widgets/SectionEvolutionCouverts.js
@@ -1,0 +1,61 @@
+'use client'
+
+import {
+  ResponsiveContainer, LineChart, Line,
+  XAxis, YAxis, CartesianGrid, Tooltip,
+} from 'recharts'
+
+// Évolution des couverts servis sur la période, granularité auto.
+export default function SectionEvolutionCouverts({ c, isMobile, buckets, granularity }) {
+  const empty = !buckets || buckets.length === 0
+  return (
+    <div style={{
+      background: c.blanc, borderRadius: 12,
+      border: `0.5px solid ${c.bordure}`,
+      padding: isMobile ? '14px 10px' : '20px',
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 12 }}>
+        <div>
+          <div style={{ fontSize: 14, fontWeight: 600, color: c.texte }}>Évolution des couverts</div>
+          <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 2 }}>
+            {granularityLabel(granularity)}
+          </div>
+        </div>
+      </div>
+      {empty ? (
+        <EmptyState c={c} />
+      ) : (
+        <ResponsiveContainer width="100%" height={isMobile ? 220 : 280}>
+          <LineChart data={buckets} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke={c.bordure} />
+            <XAxis dataKey="label" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} />
+            <YAxis tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} />
+            <Tooltip
+              contentStyle={{ borderRadius: 8, border: `0.5px solid ${c.bordure}`, fontSize: 12 }}
+              formatter={(v) => [`${Number(v).toLocaleString('fr-FR')} couverts`, 'Couverts']}
+            />
+            <Line type="monotone" dataKey="couverts" name="Couverts" stroke={c.violet} strokeWidth={2} dot={{ r: 3 }} />
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  )
+}
+
+function granularityLabel(g) {
+  if (g === 'day') return 'jour par jour'
+  if (g === 'week') return 'semaine par semaine'
+  if (g === 'month') return 'mois par mois'
+  return ''
+}
+
+function EmptyState({ c }) {
+  return (
+    <div style={{
+      padding: '32px 16px', textAlign: 'center',
+      color: c.texteMuted, fontSize: 13,
+    }}>
+      Aucune donnée sur la période sélectionnée.
+    </div>
+  )
+}

--- a/components/analyses/widgets/SectionMixFoodBev.js
+++ b/components/analyses/widgets/SectionMixFoodBev.js
@@ -1,0 +1,101 @@
+'use client'
+
+import {
+  ResponsiveContainer, PieChart, Pie, Cell, Tooltip, Legend,
+} from 'recharts'
+import { formatEur } from '../../../lib/caAnalyses'
+
+// Camembert du mix CA TTC par catégorie (Food / Alcool / Soft / Autres)
+// + tableau récap des montants et pourcentages.
+//
+// `segments` = sortie de mixSegments(totals, c) :
+//   [{ id, label, value, color, pct }] (déjà filtré et avec pourcentages)
+export default function SectionMixFoodBev({ c, isMobile, segments, totalCaTtc }) {
+  const empty = !segments || segments.length === 0
+  return (
+    <div style={{
+      background: c.blanc, borderRadius: 12,
+      border: `0.5px solid ${c.bordure}`,
+      padding: isMobile ? '14px 10px' : '20px',
+    }}>
+      <div style={{ marginBottom: 12 }}>
+        <div style={{ fontSize: 14, fontWeight: 600, color: c.texte }}>Mix CA — Food / Boissons / Autres</div>
+        <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 2 }}>
+          Répartition du CA TTC sur la période (cible : 65 % Food / 28 % Alcool / 7 % Soft)
+        </div>
+      </div>
+      {empty ? (
+        <EmptyState c={c} />
+      ) : (
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr',
+          gap: 16, alignItems: 'center',
+        }}>
+          <ResponsiveContainer width="100%" height={isMobile ? 200 : 240}>
+            <PieChart>
+              <Pie data={segments} dataKey="value" nameKey="label"
+                cx="50%" cy="50%" outerRadius="80%" innerRadius="55%"
+                stroke={c.blanc} strokeWidth={2}>
+                {segments.map((s) => <Cell key={s.id} fill={s.color} />)}
+              </Pie>
+              <Tooltip
+                contentStyle={{ borderRadius: 8, border: `0.5px solid ${c.bordure}`, fontSize: 12 }}
+                formatter={(v, name) => [`${formatEur(Number(v))} (${pctOf(Number(v), totalCaTtc)})`, name]}
+              />
+              <Legend iconSize={10} wrapperStyle={{ fontSize: 11 }} />
+            </PieChart>
+          </ResponsiveContainer>
+
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+            <thead>
+              <tr>
+                <th style={{ textAlign: 'left',  padding: '6px 8px', color: c.texteMuted, fontWeight: 600 }}>Catégorie</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', color: c.texteMuted, fontWeight: 600 }}>CA TTC</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', color: c.texteMuted, fontWeight: 600 }}>%</th>
+              </tr>
+            </thead>
+            <tbody>
+              {segments.map((s) => (
+                <tr key={s.id} style={{ borderTop: `0.5px solid ${c.bordure}` }}>
+                  <td style={{ padding: '6px 8px', color: c.texte }}>
+                    <span style={{
+                      display: 'inline-block', width: 8, height: 8,
+                      borderRadius: 2, background: s.color, marginRight: 8,
+                    }} />
+                    {s.label}
+                  </td>
+                  <td style={{ padding: '6px 8px', color: c.texte, textAlign: 'right' }}>{formatEur(s.value)}</td>
+                  <td style={{ padding: '6px 8px', color: c.texte, textAlign: 'right', fontWeight: 600 }}>
+                    {s.pct.toFixed(1)} %
+                  </td>
+                </tr>
+              ))}
+              <tr style={{ borderTop: `0.5px solid ${c.bordure}`, background: c.fond, fontWeight: 700 }}>
+                <td style={{ padding: '6px 8px', color: c.texte }}>Total</td>
+                <td style={{ padding: '6px 8px', color: c.texte, textAlign: 'right' }}>{formatEur(totalCaTtc)}</td>
+                <td style={{ padding: '6px 8px', color: c.texte, textAlign: 'right' }}>100 %</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function pctOf(v, total) {
+  if (!total) return '—'
+  return `${((v / total) * 100).toFixed(1)} %`
+}
+
+function EmptyState({ c }) {
+  return (
+    <div style={{
+      padding: '32px 16px', textAlign: 'center',
+      color: c.texteMuted, fontSize: 13,
+    }}>
+      Aucune donnée sur la période sélectionnée.
+    </div>
+  )
+}

--- a/components/analyses/widgets/SectionPerfJourSemaine.js
+++ b/components/analyses/widgets/SectionPerfJourSemaine.js
@@ -1,0 +1,71 @@
+'use client'
+
+import {
+  ResponsiveContainer, BarChart, Bar,
+  XAxis, YAxis, CartesianGrid, Tooltip, Legend,
+} from 'recharts'
+
+// Bar chart : moyenne CA TTC et moyenne couverts par jour de la semaine
+// (lundi → dimanche), uniquement sur les jours où il y a eu de la data.
+//
+// `perf` = sortie de perfByWeekday(daysWithBudget) :
+//   [{ isoJds, label, ca, cv, tm, count, … }]
+export default function SectionPerfJourSemaine({ c, isMobile, perf }) {
+  const empty = !perf || perf.every((p) => p.count === 0)
+  return (
+    <div style={{
+      background: c.blanc, borderRadius: 12,
+      border: `0.5px solid ${c.bordure}`,
+      padding: isMobile ? '14px 10px' : '20px',
+    }}>
+      <div style={{ marginBottom: 12 }}>
+        <div style={{ fontSize: 14, fontWeight: 600, color: c.texte }}>Performance par jour de la semaine</div>
+        <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 2 }}>
+          Moyenne CA TTC et couverts (jours fermés ignorés)
+        </div>
+      </div>
+      {empty ? (
+        <EmptyState c={c} />
+      ) : (
+        <ResponsiveContainer width="100%" height={isMobile ? 220 : 280}>
+          <BarChart data={perf} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke={c.bordure} />
+            <XAxis dataKey="label" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false}
+              tickFormatter={(v) => v.slice(0, 3)} />
+            <YAxis yAxisId="left" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false}
+              tickFormatter={(v) => v >= 1000 ? `${Math.round(v / 1000)} k€` : `${Math.round(v)} €`} />
+            <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} />
+            <Tooltip
+              contentStyle={{ borderRadius: 8, border: `0.5px solid ${c.bordure}`, fontSize: 12 }}
+              formatter={(v, name) => {
+                if (name === 'CA TTC moyen') return [formatTooltipEur(v), name]
+                if (name === 'Couverts moyens') return [`${Math.round(Number(v))}`, name]
+                return [v, name]
+              }}
+            />
+            <Legend iconSize={10} wrapperStyle={{ fontSize: 11 }} />
+            <Bar yAxisId="left" dataKey="ca" name="CA TTC moyen" fill={c.accent} radius={[4, 4, 0, 0]} />
+            <Bar yAxisId="right" dataKey="cv" name="Couverts moyens" fill={c.violet} radius={[4, 4, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  )
+}
+
+function formatTooltipEur(v) {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'currency', currency: 'EUR', maximumFractionDigits: 0,
+  }).format(Number(v) || 0)
+}
+
+function EmptyState({ c }) {
+  return (
+    <div style={{
+      padding: '32px 16px', textAlign: 'center',
+      color: c.texteMuted, fontSize: 13,
+    }}>
+      Aucune donnée sur la période sélectionnée.
+    </div>
+  )
+}

--- a/components/analyses/widgets/SectionTopBottomJours.js
+++ b/components/analyses/widgets/SectionTopBottomJours.js
@@ -1,0 +1,88 @@
+'use client'
+
+import { formatEur, formatEur2, fromIsoDate } from '../../../lib/caAnalyses'
+
+const JOURS_FR = ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi']
+
+// Top 5 et Bottom 5 jours par CA TTC sur la période. Ignore les jours fermés.
+//
+// `topBottom` = sortie de topBottomDays(daysWithBudget) :
+//   { top: [...days], bottom: [...days] }
+export default function SectionTopBottomJours({ c, isMobile, topBottom }) {
+  const empty = !topBottom || (topBottom.top.length === 0 && topBottom.bottom.length === 0)
+  return (
+    <div style={{
+      background: c.blanc, borderRadius: 12,
+      border: `0.5px solid ${c.bordure}`,
+      padding: isMobile ? '14px 10px' : '20px',
+    }}>
+      <div style={{ marginBottom: 12 }}>
+        <div style={{ fontSize: 14, fontWeight: 600, color: c.texte }}>Top &amp; bottom jours</div>
+        <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 2 }}>
+          Les 5 meilleurs et les 5 moins bons jours par CA TTC
+        </div>
+      </div>
+      {empty ? (
+        <EmptyState c={c} />
+      ) : (
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr',
+          gap: 16,
+        }}>
+          <DaysList c={c} title="Top 5" days={topBottom.top} accent={c.vert} />
+          <DaysList c={c} title="Bottom 5" days={topBottom.bottom} accent={c.rouge} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function DaysList({ c, title, days, accent }) {
+  return (
+    <div>
+      <div style={{ fontSize: 12, fontWeight: 600, color: accent, marginBottom: 6 }}>{title}</div>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+        <thead>
+          <tr>
+            <th style={{ textAlign: 'left',  padding: '6px 8px', color: c.texteMuted, fontWeight: 600 }}>Date</th>
+            <th style={{ textAlign: 'right', padding: '6px 8px', color: c.texteMuted, fontWeight: 600 }}>Couverts</th>
+            <th style={{ textAlign: 'right', padding: '6px 8px', color: c.texteMuted, fontWeight: 600 }}>CA TTC</th>
+            <th style={{ textAlign: 'right', padding: '6px 8px', color: c.texteMuted, fontWeight: 600 }}>TM</th>
+          </tr>
+        </thead>
+        <tbody>
+          {days.length === 0 ? (
+            <tr><td colSpan={4} style={{ padding: '8px', color: c.texteMuted, fontSize: 12 }}>—</td></tr>
+          ) : days.map((d) => (
+            <tr key={d.iso} style={{ borderTop: `0.5px solid ${c.bordure}` }}>
+              <td style={{ padding: '6px 8px', color: c.texte }}>
+                {humanDate(d.iso)}
+              </td>
+              <td style={{ padding: '6px 8px', color: c.texte, textAlign: 'right' }}>{d.couvertsTot || '—'}</td>
+              <td style={{ padding: '6px 8px', color: c.texte, textAlign: 'right', fontWeight: 600 }}>{formatEur(d.caTot)}</td>
+              <td style={{ padding: '6px 8px', color: c.texte, textAlign: 'right' }}>{formatEur2(d.tm)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function humanDate(iso) {
+  const d = fromIsoDate(iso)
+  const wd = JOURS_FR[d.getDay()].slice(0, 3).toLowerCase()
+  return `${wd}. ${iso.slice(8)}/${iso.slice(5, 7)}`
+}
+
+function EmptyState({ c }) {
+  return (
+    <div style={{
+      padding: '32px 16px', textAlign: 'center',
+      color: c.texteMuted, fontSize: 13,
+    }}>
+      Aucune donnée sur la période sélectionnée.
+    </div>
+  )
+}

--- a/lib/__tests__/caAnalyses.test.ts
+++ b/lib/__tests__/caAnalyses.test.ts
@@ -6,6 +6,12 @@ import {
   aggregateByDay,
   budgetByIsoJdsForMonth,
   periodBudgetTotal,
+  pickGranularity,
+  isoWeekStart,
+  bucketDays,
+  perfByWeekday,
+  mixSegments,
+  topBottomDays,
   TVA_FOOD,
   TVA_BEV_20,
 } from '../caAnalyses'
@@ -155,5 +161,130 @@ describe('periodBudgetTotal', () => {
     ]
     const total = periodBudgetTotal({ 2025: rows2025, 2026: rows2026 }, '2025-12-31', '2026-01-01')
     expect(total).toBe(300)
+  })
+})
+
+describe('pickGranularity', () => {
+  it('≤ 31 jours → day', () => {
+    expect(pickGranularity('2026-05-01', '2026-05-31')).toBe('day')
+  })
+  it('> 31 et ≤ 183 jours → week', () => {
+    expect(pickGranularity('2026-01-01', '2026-04-30')).toBe('week')
+  })
+  it('> 183 jours → month', () => {
+    expect(pickGranularity('2026-01-01', '2026-12-31')).toBe('month')
+  })
+})
+
+describe('isoWeekStart', () => {
+  it('renvoie le lundi de la semaine ISO', () => {
+    // 2026-05-09 = samedi → lundi de la semaine = 2026-05-04
+    expect(isoWeekStart('2026-05-09')).toBe('2026-05-04')
+    // 2026-05-04 = lundi → reste 2026-05-04
+    expect(isoWeekStart('2026-05-04')).toBe('2026-05-04')
+    // 2026-05-10 = dimanche → lundi de la semaine = 2026-05-04
+    expect(isoWeekStart('2026-05-10')).toBe('2026-05-04')
+  })
+})
+
+describe('bucketDays', () => {
+  const sampleDays = [
+    { iso: '2026-05-04', isoJds: 1, jsWeekday: 1, caTot: 100, couvertsTot: 10, budget: 80, hasData: true },
+    { iso: '2026-05-05', isoJds: 2, jsWeekday: 2, caTot: 200, couvertsTot: 20, budget: 80, hasData: true },
+    { iso: '2026-05-11', isoJds: 1, jsWeekday: 1, caTot: 150, couvertsTot: 15, budget: 80, hasData: true },
+  ]
+
+  it('day : 1 bucket par jour', () => {
+    const buckets = bucketDays(sampleDays, 'day')
+    expect(buckets).toHaveLength(3)
+    expect(buckets[0].caTot).toBe(100)
+    expect(buckets[0].label).toBe('04/05')
+  })
+
+  it('week : agrège lundi → dimanche, lundi suivant nouveau bucket', () => {
+    const buckets = bucketDays(sampleDays, 'week')
+    expect(buckets).toHaveLength(2)
+    expect(buckets[0].key).toBe('2026-05-04')
+    expect(buckets[0].caTot).toBe(300) // 04 + 05 mai
+    expect(buckets[0].budget).toBe(160)
+    expect(buckets[1].caTot).toBe(150) // 11 mai
+  })
+
+  it('month : agrège par YYYY-MM', () => {
+    const days = [
+      { iso: '2026-04-30', isoJds: 4, jsWeekday: 4, caTot: 50, couvertsTot: 5, budget: 40, hasData: true },
+      { iso: '2026-05-01', isoJds: 5, jsWeekday: 5, caTot: 100, couvertsTot: 10, budget: 80, hasData: true },
+      { iso: '2026-05-15', isoJds: 5, jsWeekday: 5, caTot: 200, couvertsTot: 20, budget: 80, hasData: true },
+    ]
+    const buckets = bucketDays(days, 'month')
+    expect(buckets).toHaveLength(2)
+    expect(buckets[0].label).toBe('Avr.')
+    expect(buckets[0].caTot).toBe(50)
+    expect(buckets[1].label).toBe('Mai')
+    expect(buckets[1].caTot).toBe(300)
+  })
+})
+
+describe('perfByWeekday', () => {
+  it('moyennes par jour ouvré, ignore les jours sans data', () => {
+    const days = [
+      { iso: '2026-05-04', isoJds: 1, caTot: 100, couvertsTot: 10, hasData: true },
+      { iso: '2026-05-11', isoJds: 1, caTot: 200, couvertsTot: 20, hasData: true },
+      { iso: '2026-05-05', isoJds: 2, caTot: 0,   couvertsTot: 0,  hasData: false },
+    ]
+    const perf = perfByWeekday(days)
+    expect(perf).toHaveLength(7)
+    // Lundi : moyenne = (100+200)/2 = 150 ; couverts = 30/2 = 15
+    expect(perf[0].label).toBe('Lundi')
+    expect(perf[0].ca).toBe(150)
+    expect(perf[0].cv).toBe(15)
+    // Mardi : pas de data → 0
+    expect(perf[1].count).toBe(0)
+    expect(perf[1].ca).toBe(0)
+  })
+})
+
+describe('mixSegments', () => {
+  const c = { principal: '#000', violet: '#7C3AED', accent: '#6366F1', orange: '#D97706' }
+
+  it('renvoie les pourcentages par catégorie', () => {
+    const segs = mixSegments({ food: 60, bev20: 28, bev10: 7, autre: 5 }, c)
+    expect(segs).toHaveLength(4)
+    expect(segs.find((s) => s.id === 'food').pct).toBeCloseTo(60, 5)
+    expect(segs.find((s) => s.id === 'bev20').pct).toBeCloseTo(28, 5)
+  })
+
+  it('exclut les catégories à 0', () => {
+    const segs = mixSegments({ food: 100, bev20: 0, bev10: 0, autre: 0 }, c)
+    expect(segs).toHaveLength(1)
+    expect(segs[0].id).toBe('food')
+    expect(segs[0].pct).toBe(100)
+  })
+
+  it('renvoie [] si total = 0', () => {
+    expect(mixSegments({ food: 0, bev20: 0, bev10: 0, autre: 0 }, c)).toEqual([])
+  })
+})
+
+describe('topBottomDays', () => {
+  const days = [
+    { iso: '2026-05-01', caTot: 100, hasData: true },
+    { iso: '2026-05-02', caTot: 500, hasData: true },
+    { iso: '2026-05-03', caTot: 0,   hasData: false },
+    { iso: '2026-05-04', caTot: 300, hasData: true },
+    { iso: '2026-05-05', caTot: 200, hasData: true },
+  ]
+
+  it('top 2 / bottom 2 par CA TTC', () => {
+    const { top, bottom } = topBottomDays(days, 2)
+    expect(top.map((d) => d.iso)).toEqual(['2026-05-02', '2026-05-04'])
+    expect(bottom.map((d) => d.iso)).toEqual(['2026-05-01', '2026-05-05'])
+  })
+
+  it('ignore les jours sans data', () => {
+    const { top, bottom } = topBottomDays(days, 5)
+    expect(top.length + bottom.length).toBeLessThanOrEqual(8) // 4 jours avec data
+    expect(top.every((d) => d.hasData)).toBe(true)
+    expect(bottom.every((d) => d.hasData)).toBe(true)
   })
 })

--- a/lib/analysesPreferences.js
+++ b/lib/analysesPreferences.js
@@ -27,8 +27,15 @@ export const WIDGET_CATALOG = [
   { id: 'kpi-tm',              label: 'KPI — Ticket moyen',       size: 'kpi',  defaultVisible: true },
   { id: 'kpi-ecart-budget-pct',label: 'KPI — Écart budget (%)',   size: 'kpi',  defaultVisible: true },
 
-  // ── Sections ──────────────────────────────────────────────────────────────
-  { id: 'section-tableau-jour-jour', label: 'Tableau jour par jour', size: 'full', defaultVisible: true },
+  // ── Sections — Charts (PR 3) ──────────────────────────────────────────────
+  { id: 'section-evolution-ca',       label: 'Évolution du CA TTC (réel vs budget)', size: 'half', defaultVisible: true },
+  { id: 'section-evolution-couverts', label: 'Évolution des couverts',               size: 'half', defaultVisible: true },
+  { id: 'section-perf-jour-semaine',  label: 'Performance par jour de la semaine',   size: 'half', defaultVisible: true },
+  { id: 'section-mix-food-bev',       label: 'Mix CA Food / Boissons / Autres',      size: 'half', defaultVisible: true },
+  { id: 'section-top-bottom-jours',   label: 'Top et bottom jours',                  size: 'full', defaultVisible: true },
+
+  // ── Sections — Détail tabulaire (PR 2) ────────────────────────────────────
+  { id: 'section-tableau-jour-jour', label: 'Tableau jour par jour',                 size: 'full', defaultVisible: true },
 ]
 
 export const WIDGET_BY_ID = Object.fromEntries(WIDGET_CATALOG.map((w) => [w.id, w]))

--- a/lib/caAnalyses.js
+++ b/lib/caAnalyses.js
@@ -155,6 +155,123 @@ export function aggregateByDay(rows, debut, fin) {
   return result
 }
 
+// ── Granularité auto + bucketisation pour les charts d'évolution ───────────
+
+// Choix de granularité automatique selon la longueur de la période :
+//   ≤ 31 j  → 'day'    (1 point par jour)
+//   ≤ 183 j → 'week'   (1 point par semaine ISO, lundi → dimanche)
+//   sinon   → 'month'  (1 point par mois calendaire)
+export function pickGranularity(debut, fin) {
+  const start = fromIsoDate(debut)
+  const end = fromIsoDate(fin)
+  const days = Math.floor((end - start) / (24 * 60 * 60 * 1000)) + 1
+  if (days <= 31) return 'day'
+  if (days <= 183) return 'week'
+  return 'month'
+}
+
+const MOIS_FR_SHORT = ['Janv.', 'Févr.', 'Mars', 'Avr.', 'Mai', 'Juin', 'Juil.', 'Août', 'Sept.', 'Oct.', 'Nov.', 'Déc.']
+
+// Renvoie la clé ISO du lundi (semaine ISO) du jour donné.
+export function isoWeekStart(iso) {
+  const d = fromIsoDate(iso)
+  const jsWeekday = d.getDay()
+  // ISO week starts Monday : reculer (jsWeekday - 1), traiter dimanche=0 comme jour 7
+  const offset = jsWeekday === 0 ? 6 : jsWeekday - 1
+  d.setDate(d.getDate() - offset)
+  return toIsoDate(d)
+}
+
+// Agrège la sortie de aggregateByDay() (+ optionnellement un budget journalier
+// déjà calculé sur chaque jour via day.budget) en buckets selon la granularité.
+//
+// Renvoie [{ key, label, caTot, couverts, budget, count }] ordonnés par date.
+export function bucketDays(days, granularity) {
+  const map = new Map()
+  for (const d of days) {
+    let key, label
+    if (granularity === 'day') {
+      key = d.iso
+      label = `${d.iso.slice(8)}/${d.iso.slice(5, 7)}`
+    } else if (granularity === 'week') {
+      key = isoWeekStart(d.iso)
+      label = `Sem. ${key.slice(8)}/${key.slice(5, 7)}`
+    } else {
+      key = d.iso.slice(0, 7) // YYYY-MM
+      const monthIdx = Number(key.slice(5, 7)) - 1
+      label = MOIS_FR_SHORT[monthIdx] || key
+    }
+    if (!map.has(key)) {
+      map.set(key, { key, label, caTot: 0, couverts: 0, budget: 0, count: 0 })
+    }
+    const acc = map.get(key)
+    acc.caTot += d.caTot || 0
+    acc.couverts += d.couvertsTot || 0
+    acc.budget += d.budget || 0
+    acc.count += 1
+  }
+  return Array.from(map.values()).sort((a, b) => a.key.localeCompare(b.key))
+}
+
+// ── Performance par jour de la semaine ──────────────────────────────────────
+
+const JOURS_LABELS = ['Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi', 'Dimanche']
+
+// Moyennes CA / couverts / TM par jour-de-semaine sur la période.
+// Ne compte que les jours avec data (hasData) pour éviter de tirer la moyenne
+// vers 0 sur les jours fermés.
+export function perfByWeekday(days) {
+  const buckets = Array.from({ length: 7 }, (_, i) => ({
+    isoJds: i + 1,                 // 1 = lundi
+    label: JOURS_LABELS[i],
+    caTot: 0, couverts: 0, count: 0, ca: 0, cv: 0, tm: null,
+  }))
+  for (const d of days) {
+    if (!d.hasData) continue
+    const b = buckets[d.isoJds - 1]
+    b.caTot += d.caTot
+    b.couverts += d.couvertsTot
+    b.count += 1
+  }
+  for (const b of buckets) {
+    b.ca = b.count > 0 ? b.caTot / b.count : 0
+    b.cv = b.count > 0 ? b.couverts / b.count : 0
+    b.tm = b.couverts > 0 ? b.caTot / b.couverts : null
+  }
+  return buckets
+}
+
+// ── Mix Food / Boissons / Autres ────────────────────────────────────────────
+
+// Renvoie les segments du camembert avec couleurs fixes (palette skalcook
+// alignée sur la sémantique du module : Food = principal, Alcool = violet,
+// Soft = accent, Autre = orange).
+export function mixSegments(totals, c) {
+  const total = (totals.food || 0) + (totals.bev20 || 0) + (totals.bev10 || 0) + (totals.autre || 0)
+  if (total === 0) return []
+  const segments = [
+    { id: 'food',  label: 'Food',   value: totals.food  || 0, color: c.principal },
+    { id: 'bev20', label: 'Alcool', value: totals.bev20 || 0, color: c.violet },
+    { id: 'bev10', label: 'Soft',   value: totals.bev10 || 0, color: c.accent },
+    { id: 'autre', label: 'Autres', value: totals.autre || 0, color: c.orange },
+  ]
+  return segments
+    .filter((s) => s.value > 0)
+    .map((s) => ({ ...s, pct: (s.value / total) * 100 }))
+}
+
+// ── Top / Bottom jours ──────────────────────────────────────────────────────
+
+// Retourne les n meilleurs et n pires jours par CA TTC (ignore les jours
+// sans data). `n` peut être surchargé.
+export function topBottomDays(days, n = 5) {
+  const withData = days.filter((d) => d.hasData)
+  const sorted = [...withData].sort((a, b) => b.caTot - a.caTot)
+  const top = sorted.slice(0, n)
+  const bottom = sorted.slice(-n).reverse() // n derniers, du moins bon vers le moins bon
+  return { top, bottom }
+}
+
 // ── Budget ──────────────────────────────────────────────────────────────────
 
 // budgetRows : ca_budgets sur l'année concernée, filtrés (par lieu/service


### PR DESCRIPTION
## Summary
PR 3/5 du chantier « Page Analyses ». Ajoute 5 widgets graphiques au catalogue Analyses.

### Nouveaux widgets
- **section-evolution-ca** : composed chart (line CA réel + barres Budget), granularité auto (jour ≤ 31 j, semaine ≤ 6 mois, mois sinon).
- **section-evolution-couverts** : line chart couverts, granularité auto identique.
- **section-perf-jour-semaine** : bar chart moyennes CA et couverts par jour-de-semaine (lun → dim), ignore les jours fermés.
- **section-mix-food-bev** : camembert + tableau récap (cible 65/28/7 rappelée en sous-titre).
- **section-top-bottom-jours** : top 5 / bottom 5 jours par CA TTC.

### Helpers (purs, testés vitest)
Ajoutés à [lib/caAnalyses.js](lib/caAnalyses.js) : `pickGranularity`, `isoWeekStart`, `bucketDays`, `perfByWeekday`, `mixSegments`, `topBottomDays`. **+13 tests** (76 → 89, tous verts).

### Layout
Row-pairing `'half'+'half'` ajouté à la page Analyses (deux graphes par ligne en desktop, 1 par ligne mobile) — même logique que `/dashboard`.

### Couleurs camembert
Calées sur la palette skalcook via `useTheme()` : Food = `principal`, Alcool = `violet`, Soft = `accent`, Autres = `orange`. Reste cohérent en branding personnalisé.

## Test plan
- [ ] Aller sur `/controle-gestion/analyses` → les 5 nouveaux graphes apparaissent par défaut.
- [ ] Mois en cours (≤ 31 j) → granularité « jour par jour » ; passer en « Année » → « mois par mois ».
- [ ] Sur Évolution CA : vérifier que les barres budget sont visibles uniquement si un budget est défini.
- [ ] Filtrer par lieu / service → tous les graphes recalculent.
- [ ] Activer « Personnaliser » → masquer un graphe → recharger → l'état persiste.
- [ ] Tester en mobile : 1 graphe par ligne, scroll vertical fluide.
- [ ] Tester sur un client SANS data sur la période → chaque widget affiche son empty state propre, sans erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)