### PR TITLE
feat(analyses): export Excel multi-onglets + impression A4 paysage

### DIFF
--- a/app/controle-gestion/analyses/page.js
+++ b/app/controle-gestion/analyses/page.js
@@ -28,6 +28,8 @@ import {
   saveAnalysesLayout,
   resetAnalysesLayout,
 } from '../../../lib/analysesPreferences'
+import { buildAnalysesWorkbook, buildFilename } from '../../../lib/analysesExport'
+import * as XLSX from 'xlsx'
 import Navbar from '../../../components/Navbar'
 import WidgetsCustomizeModal from '../../../components/dashboard/WidgetsCustomizeModal'
 import FilterBar, { COMPARAISON_LABELS } from '../../../components/analyses/FilterBar'
@@ -373,9 +375,28 @@ export default function AnalysesPage() {
     }
   }
 
+  // ── Actions TopBar : export Excel + impression ───────────────────────────
+  const handleExportExcel = () => {
+    const lieuLabel = lieuId === 'all' ? 'Tous lieux' : (lieux.find((l) => l.id === lieuId)?.nom || lieuId)
+    const visibleIds = new Set(visibleLayout.map((l) => l.id))
+    const wb = buildAnalysesWorkbook({
+      visibleIds,
+      periode, dateDebut, dateFin, comparaison, lieuLabel, service,
+      totals, comparisonTotals, comparisonLabel, periodBudget,
+      buckets, granularity, perfWeekday, mix, topBottom, daysWithBudget,
+    })
+    XLSX.writeFile(wb, buildFilename(dateDebut, dateFin))
+  }
+
+  const handlePrint = () => {
+    if (typeof window !== 'undefined') window.print()
+  }
+
   return (
-    <div style={{ minHeight: '100vh', background: c.fond }}>
-      <Navbar section="cuisine" />
+    <div className="sk-analyses-page" style={{ minHeight: '100vh', background: c.fond }}>
+      <div className="no-print">
+        <Navbar section="cuisine" />
+      </div>
       <div style={{ padding: isMobile ? 16 : 24, maxWidth: 1300, margin: '0 auto' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, flexWrap: 'wrap', marginBottom: 16 }}>
           <div>
@@ -386,17 +407,29 @@ export default function AnalysesPage() {
               {humanRange(dateDebut, dateFin)}
             </p>
           </div>
-          <button
-            onClick={() => setShowCustomize(true)}
-            title="Personnaliser mes analyses"
-            style={{
-              background: 'transparent', border: `0.5px solid ${c.bordure}`, color: c.texteMuted,
-              borderRadius: 8, padding: '6px 12px', fontSize: 12, cursor: 'pointer',
-              display: 'inline-flex', alignItems: 'center', gap: 6,
-            }}
-          >
-            ⚙{isMobile ? '' : ' Personnaliser'}
-          </button>
+          <div className="no-print" style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            <button
+              onClick={handleExportExcel}
+              title="Exporter Excel (un onglet par widget visible)"
+              style={actionBtnStyle(c)}
+            >
+              📥{isMobile ? '' : ' Excel'}
+            </button>
+            <button
+              onClick={handlePrint}
+              title="Imprimer la page"
+              style={actionBtnStyle(c)}
+            >
+              🖨{isMobile ? '' : ' Imprimer'}
+            </button>
+            <button
+              onClick={() => setShowCustomize(true)}
+              title="Personnaliser mes analyses"
+              style={actionBtnStyle(c)}
+            >
+              ⚙{isMobile ? '' : ' Personnaliser'}
+            </button>
+          </div>
         </div>
 
         <FilterBar
@@ -417,7 +450,7 @@ export default function AnalysesPage() {
             display: 'grid', gridTemplateColumns: `repeat(${kpiCols}, 1fr)`,
             gap: isMobile ? 10 : 16, marginBottom: 24,
           }}>
-            {kpiLayout.map((l) => <div key={l.id}>{renderWidget(l.id)}</div>)}
+            {kpiLayout.map((l) => <div key={l.id} className="sk-print-section">{renderWidget(l.id)}</div>)}
           </div>
         )}
 
@@ -431,7 +464,7 @@ export default function AnalysesPage() {
               marginBottom: idx < sectionRows.length - 1 ? (isMobile ? 12 : 16) : 0,
             }}
           >
-            {row.map((l) => <div key={l.id}>{renderWidget(l.id)}</div>)}
+            {row.map((l) => <div key={l.id} className="sk-print-section">{renderWidget(l.id)}</div>)}
           </div>
         ))}
 
@@ -464,4 +497,12 @@ function humanRange(debut, fin) {
 function formatDate(iso) {
   const d = fromIsoDate(iso)
   return d.toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric' })
+}
+
+function actionBtnStyle(c) {
+  return {
+    background: 'transparent', border: `0.5px solid ${c.bordure}`, color: c.texteMuted,
+    borderRadius: 8, padding: '6px 12px', fontSize: 12, cursor: 'pointer',
+    display: 'inline-flex', alignItems: 'center', gap: 6,
+  }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -63,6 +63,19 @@ body {
     display: none !important;
     visibility: hidden !important;
   }
+
+  /* Page Analyses CA : éviter de couper un widget en plein milieu. Les
+     graphes recharts utilisent SVG → on garde la couleur (color-adjust
+     déjà actif au-dessus). */
+  .sk-print-section {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+  .sk-print-section table,
+  .sk-print-section .recharts-responsive-container {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
 }
 
 /* ──────────────────────────────────────────────────────────────

--- a/lib/__tests__/analysesExport.test.ts
+++ b/lib/__tests__/analysesExport.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest'
+import * as XLSX from 'xlsx'
+import {
+  buildPeriodSheetRows,
+  buildKpiSheetRows,
+  buildEvolutionCaSheetRows,
+  buildEvolutionCouvertsSheetRows,
+  buildPerfJourSemaineSheetRows,
+  buildMixSheetRows,
+  buildTopBottomSheetRows,
+  buildTableauJourJourSheetRows,
+  buildAnalysesWorkbook,
+  buildFilename,
+} from '../analysesExport'
+
+describe('buildPeriodSheetRows', () => {
+  it('produit une ligne par champ traçabilité', () => {
+    const rows = buildPeriodSheetRows({
+      periode: 'mois-en-cours', dateDebut: '2026-05-01', dateFin: '2026-05-09',
+      comparaison: 'n-1', lieuLabel: 'Salle', service: 'lunch', granularity: 'day',
+      generatedAt: new Date(2026, 4, 9, 14, 30),
+    })
+    expect(rows).toHaveLength(8)
+    const map = Object.fromEntries(rows.map((r) => [r.Champ, r.Valeur]))
+    expect(map['Période']).toBe('Mois en cours')
+    expect(map['Date début']).toBe('2026-05-01')
+    expect(map['Comparaison']).toBe('vs même période N-1')
+    expect(map['Lieu']).toBe('Salle')
+    expect(map['Service']).toBe('Déjeuner')
+    expect(map['Granularité auto']).toBe('Jour')
+  })
+})
+
+describe('buildKpiSheetRows', () => {
+  it('inclut les 5 KPIs avec comparaison N-1 si dispo', () => {
+    const rows = buildKpiSheetRows({
+      totals: { couverts: 100, caTtc: 5000, caHt: 4500, tm: 50 },
+      comparisonTotals: { couverts: 80, caTtc: 4000, caHt: 3600, tm: 50 },
+      comparisonLabel: 'vs N-1',
+      periodBudget: 4500,
+    })
+    expect(rows).toHaveLength(5)
+    const couverts = rows[0]
+    expect(couverts.KPI).toBe('Couverts')
+    expect(couverts.Valeur).toBe(100)
+    expect(couverts['Δ']).toBe(20)
+    expect(couverts['Δ (%)']).toBe('25.0 %')
+    // Écart vs Budget
+    expect(rows[4]['KPI']).toBe('Écart vs Budget (%)')
+    expect(String(rows[4]['Valeur'])).toContain('11.1') // (5000-4500)/4500 = 11.11 %
+  })
+
+  it('affiche "Pas de budget cible" quand le budget est 0', () => {
+    const rows = buildKpiSheetRows({
+      totals: { couverts: 10, caTtc: 100, caHt: 90, tm: 10 },
+      comparisonTotals: null,
+      comparisonLabel: '',
+      periodBudget: 0,
+    })
+    expect(rows[4]['Valeur']).toBe('Pas de budget cible')
+  })
+})
+
+describe('buildEvolutionCaSheetRows', () => {
+  it('1 ligne par bucket avec Δ Budget', () => {
+    const rows = buildEvolutionCaSheetRows([
+      { key: '2026-05-01', label: '01/05', caTot: 100, couverts: 10, budget: 80 },
+      { key: '2026-05-02', label: '02/05', caTot: 50,  couverts: 5,  budget: 80 },
+    ])
+    expect(rows[0]['CA TTC réel']).toBe(100)
+    expect(rows[0]['Δ Budget']).toBe(20)
+    expect(rows[1]['Δ Budget']).toBe(-30)
+  })
+})
+
+describe('buildEvolutionCouvertsSheetRows', () => {
+  it('1 ligne par bucket', () => {
+    const rows = buildEvolutionCouvertsSheetRows([
+      { label: '01/05', couverts: 10 }, { label: '02/05', couverts: 5 },
+    ])
+    expect(rows).toEqual([
+      { Période: '01/05', Couverts: 10 },
+      { Période: '02/05', Couverts: 5 },
+    ])
+  })
+})
+
+describe('buildPerfJourSemaineSheetRows', () => {
+  it('1 ligne par jour de semaine', () => {
+    const perf = [
+      { isoJds: 1, label: 'Lundi', count: 2, ca: 150, cv: 15, tm: 10 },
+      { isoJds: 2, label: 'Mardi', count: 0, ca: 0, cv: 0, tm: null },
+    ]
+    const rows = buildPerfJourSemaineSheetRows(perf)
+    expect(rows[0]['Jour']).toBe('Lundi')
+    expect(rows[0]['CA TTC moyen']).toBe(150)
+    expect(rows[1]['Ticket moyen']).toBe('')
+  })
+})
+
+describe('buildMixSheetRows', () => {
+  it('1 ligne par segment avec %', () => {
+    const rows = buildMixSheetRows([
+      { id: 'food', label: 'Food', value: 65, color: '#000', pct: 65 },
+      { id: 'bev20', label: 'Alcool', value: 28, color: '#000', pct: 28 },
+    ])
+    expect(rows[0]).toEqual({ Catégorie: 'Food', 'CA TTC': 65, 'Part (%)': '65.0 %' })
+  })
+})
+
+describe('buildTopBottomSheetRows', () => {
+  it('top puis bottom dans la même feuille', () => {
+    const rows = buildTopBottomSheetRows({
+      top:    [{ iso: '2026-05-01', couvertsTot: 30, caTot: 1000, tm: 33.33 }],
+      bottom: [{ iso: '2026-05-02', couvertsTot: 5,  caTot: 100,  tm: 20 }],
+    })
+    expect(rows).toHaveLength(2)
+    expect(rows[0].Groupe).toBe('Top')
+    expect(rows[1].Groupe).toBe('Bottom')
+  })
+})
+
+describe('buildTableauJourJourSheetRows', () => {
+  it('1 ligne par jour avec budget et Δ', () => {
+    const rows = buildTableauJourJourSheetRows([
+      { iso: '2026-05-01', lunchCouverts: 10, dinnerCouverts: 20, food: 200, bev_20: 50, bev_10: 10, autre: 5, caTot: 265, budget: 250, tm: 8.83 },
+    ])
+    expect(rows[0]['CA Total']).toBe(265)
+    expect(rows[0]['Budget']).toBe(250)
+    expect(rows[0]['Δ Budget']).toBe(15)
+  })
+})
+
+describe('buildAnalysesWorkbook', () => {
+  const baseOpts = {
+    visibleIds: new Set(['kpi-couverts', 'kpi-ca-ttc', 'section-evolution-ca', 'section-tableau-jour-jour']),
+    periode: '7j', dateDebut: '2026-05-03', dateFin: '2026-05-09',
+    comparaison: 'aucune', lieuLabel: 'Tous lieux', service: 'tout',
+    totals: { couverts: 100, caTtc: 5000, caHt: 4500, tm: 50, food: 3250, bev20: 1400, bev10: 350, autre: 0 },
+    comparisonTotals: null, comparisonLabel: '', periodBudget: 4800,
+    buckets: [{ key: '2026-05-03', label: '03/05', caTot: 1000, couverts: 20, budget: 700 }],
+    granularity: 'day',
+    perfWeekday: [],
+    mix: [],
+    topBottom: { top: [], bottom: [] },
+    daysWithBudget: [{ iso: '2026-05-03', lunchCouverts: 10, dinnerCouverts: 10, food: 700, bev_20: 250, bev_10: 50, autre: 0, caTot: 1000, budget: 700, tm: 50 }],
+  }
+
+  it('crée toujours l\'onglet "Période & filtres"', () => {
+    const wb = buildAnalysesWorkbook(baseOpts)
+    expect(wb.SheetNames).toContain('Période & filtres')
+  })
+
+  it('un onglet KPIs si au moins un KPI est visible', () => {
+    const wb = buildAnalysesWorkbook(baseOpts)
+    expect(wb.SheetNames).toContain('KPIs')
+  })
+
+  it('un onglet par section visible, et seulement celles-là', () => {
+    const wb = buildAnalysesWorkbook(baseOpts)
+    expect(wb.SheetNames).toContain('Évolution CA')
+    expect(wb.SheetNames).toContain('Tableau jour par jour')
+    expect(wb.SheetNames).not.toContain('Mix Food-Bev')
+    expect(wb.SheetNames).not.toContain('Évolution couverts')
+  })
+
+  it('respecte la limite Excel de 31 chars pour les noms d\'onglet', () => {
+    const wb = buildAnalysesWorkbook({
+      ...baseOpts,
+      visibleIds: new Set([
+        'kpi-couverts', 'kpi-ca-ttc', 'kpi-ca-ht', 'kpi-tm', 'kpi-ecart-budget-pct',
+        'section-evolution-ca', 'section-evolution-couverts', 'section-perf-jour-semaine',
+        'section-mix-food-bev', 'section-top-bottom-jours', 'section-tableau-jour-jour',
+      ]),
+    })
+    for (const name of wb.SheetNames) {
+      expect(name.length).toBeLessThanOrEqual(31)
+    }
+  })
+
+  it('l\'onglet KPIs contient bien 5 lignes', () => {
+    const wb = buildAnalysesWorkbook(baseOpts)
+    const sheet = wb.Sheets['KPIs']
+    const rows = XLSX.utils.sheet_to_json(sheet)
+    expect(rows).toHaveLength(5)
+  })
+})
+
+describe('buildFilename', () => {
+  it('inclut les dates de la période', () => {
+    expect(buildFilename('2026-05-01', '2026-05-09')).toBe('analyses-ca_2026-05-01_2026-05-09.xlsx')
+  })
+})

--- a/lib/analysesExport.js
+++ b/lib/analysesExport.js
@@ -1,0 +1,219 @@
+// Construction de l'export Excel multi-onglets pour la page Analyses CA.
+//
+// Stratégie : un onglet "Période & filtres" pour la traçabilité, un onglet
+// "KPIs" pour les 5 cartes (sinon ce serait 5 mini-onglets), et un onglet
+// par widget de section visible. Permet à l'user de retrouver ce qu'il a vu
+// à l'écran, en chiffres bruts manipulables sous Excel.
+//
+// Pour rester testable, ce module ne fait QUE construire le workbook xlsx.
+// L'écriture sur disque est faite côté caller (XLSX.writeFile) — autrement
+// les tests devraient mocker l'API File. Voir buildAnalysesWorkbook + ses tests.
+
+import * as XLSX from 'xlsx'
+
+const PERIODE_LABELS = {
+  'aujourdhui':     "Aujourd'hui",
+  '7j':             '7 derniers jours',
+  '30j':            '30 derniers jours',
+  'mois-en-cours':  'Mois en cours',
+  'mois-precedent': 'Mois précédent',
+  'trimestre':      'Trimestre',
+  'annee':          'Année',
+  'custom':         'Personnalisé',
+}
+
+const COMPARAISON_LABELS = {
+  'aucune':  'Aucune comparaison',
+  'n-1':     'vs même période N-1',
+  'budget':  'vs Budget',
+}
+
+const SERVICE_LABELS = {
+  'tout':   'Tous services',
+  'lunch':  'Déjeuner',
+  'dinner': 'Dîner',
+}
+
+// ─── Builders d'onglets (purs : prennent les data brutes, renvoient
+//     des arrays de records adaptés à XLSX.utils.json_to_sheet) ──────────────
+
+export function buildPeriodSheetRows({ periode, dateDebut, dateFin, comparaison, lieuLabel, service, granularity, generatedAt = new Date() }) {
+  return [
+    { Champ: 'Date d\'export',   Valeur: formatDateTime(generatedAt) },
+    { Champ: 'Période',          Valeur: PERIODE_LABELS[periode] || periode },
+    { Champ: 'Date début',       Valeur: dateDebut },
+    { Champ: 'Date fin',         Valeur: dateFin },
+    { Champ: 'Comparaison',      Valeur: COMPARAISON_LABELS[comparaison] || comparaison },
+    { Champ: 'Lieu',             Valeur: lieuLabel || 'Tous lieux' },
+    { Champ: 'Service',          Valeur: SERVICE_LABELS[service] || service },
+    { Champ: 'Granularité auto', Valeur: granularity === 'day' ? 'Jour' : granularity === 'week' ? 'Semaine' : 'Mois' },
+  ]
+}
+
+export function buildKpiSheetRows({ totals, comparisonTotals, comparisonLabel, periodBudget }) {
+  const rows = []
+  const push = (label, value, comparison = null) => rows.push({
+    KPI: label,
+    Valeur: value,
+    'Comparaison': comparison?.label ?? '',
+    'Δ': comparison?.delta ?? '',
+    'Δ (%)': comparison?.pct != null ? `${comparison.pct.toFixed(1)} %` : '',
+  })
+  push('Couverts', totals.couverts || 0, computeDelta(totals.couverts, comparisonTotals?.couverts, comparisonLabel))
+  push('CA TTC',   round(totals.caTtc),  computeDelta(totals.caTtc,   comparisonTotals?.caTtc,   comparisonLabel))
+  push('CA HT',    round(totals.caHt),   computeDelta(totals.caHt,    comparisonTotals?.caHt,    comparisonLabel))
+  push('Ticket moyen', totals.tm != null ? round2(totals.tm) : '', computeDelta(totals.tm, comparisonTotals?.tm, comparisonLabel))
+  if (periodBudget > 0) {
+    const ecart = ((totals.caTtc - periodBudget) / periodBudget) * 100
+    push('Écart vs Budget (%)', `${ecart.toFixed(1)} %`)
+  } else {
+    push('Écart vs Budget (%)', 'Pas de budget cible')
+  }
+  return rows
+}
+
+export function buildEvolutionCaSheetRows(buckets) {
+  return buckets.map((b) => ({
+    Période: b.label,
+    'CA TTC réel': round(b.caTot),
+    'Budget cible': round(b.budget),
+    'Δ Budget': round((b.caTot || 0) - (b.budget || 0)),
+  }))
+}
+
+export function buildEvolutionCouvertsSheetRows(buckets) {
+  return buckets.map((b) => ({
+    Période: b.label,
+    Couverts: b.couverts || 0,
+  }))
+}
+
+export function buildPerfJourSemaineSheetRows(perf) {
+  return perf.map((p) => ({
+    Jour: p.label,
+    'Jours observés': p.count,
+    'CA TTC moyen': round(p.ca),
+    'Couverts moyens': Math.round(p.cv),
+    'Ticket moyen': p.tm != null ? round2(p.tm) : '',
+  }))
+}
+
+export function buildMixSheetRows(segments) {
+  return segments.map((s) => ({
+    Catégorie: s.label,
+    'CA TTC': round(s.value),
+    'Part (%)': `${s.pct.toFixed(1)} %`,
+  }))
+}
+
+export function buildTopBottomSheetRows(topBottom) {
+  const fmt = (d, group) => ({
+    Groupe: group,
+    Date: d.iso,
+    Couverts: d.couvertsTot || 0,
+    'CA TTC': round(d.caTot),
+    'Ticket moyen': d.tm != null ? round2(d.tm) : '',
+  })
+  return [
+    ...topBottom.top.map((d) => fmt(d, 'Top')),
+    ...topBottom.bottom.map((d) => fmt(d, 'Bottom')),
+  ]
+}
+
+export function buildTableauJourJourSheetRows(daysWithBudget) {
+  return daysWithBudget.map((d) => ({
+    Date: d.iso,
+    'Couv. midi': d.lunchCouverts || 0,
+    'Couv. soir': d.dinnerCouverts || 0,
+    'CA Food': round(d.food),
+    'CA Alcool': round(d.bev_20),
+    'CA Soft': round(d.bev_10),
+    Autres: round(d.autre),
+    'CA Total': round(d.caTot),
+    'Budget': round(d.budget || 0),
+    'Δ Budget': round((d.caTot || 0) - (d.budget || 0)),
+    'Ticket moyen': d.tm != null ? round2(d.tm) : '',
+  }))
+}
+
+// ─── Assemblage du workbook ─────────────────────────────────────────────────
+
+// `visibleIds` : Set des ids de widgets effectivement affichés (le bouton
+// export ne dump que ce que l'user voit).
+//
+// Renvoie un objet XLSX workbook (testable) — le caller fait XLSX.writeFile.
+export function buildAnalysesWorkbook(opts) {
+  const {
+    visibleIds, periode, dateDebut, dateFin, comparaison, lieuLabel, service,
+    totals, comparisonTotals, comparisonLabel, periodBudget,
+    buckets, granularity, perfWeekday, mix, topBottom, daysWithBudget,
+  } = opts
+
+  const wb = XLSX.utils.book_new()
+
+  // Onglet 1 : Période & filtres (toujours présent)
+  const periodSheet = XLSX.utils.json_to_sheet(buildPeriodSheetRows({
+    periode, dateDebut, dateFin, comparaison, lieuLabel, service, granularity,
+  }))
+  XLSX.utils.book_append_sheet(wb, periodSheet, 'Période & filtres')
+
+  // Onglet 2 : KPIs (si au moins un KPI visible)
+  const anyKpiVisible = ['kpi-couverts', 'kpi-ca-ttc', 'kpi-ca-ht', 'kpi-tm', 'kpi-ecart-budget-pct']
+    .some((id) => visibleIds.has(id))
+  if (anyKpiVisible) {
+    const sheet = XLSX.utils.json_to_sheet(buildKpiSheetRows({
+      totals, comparisonTotals, comparisonLabel, periodBudget,
+    }))
+    XLSX.utils.book_append_sheet(wb, sheet, 'KPIs')
+  }
+
+  // Sections : un onglet par widget visible
+  const sectionBuilders = [
+    { id: 'section-evolution-ca',       name: 'Évolution CA',         build: () => buildEvolutionCaSheetRows(buckets) },
+    { id: 'section-evolution-couverts', name: 'Évolution couverts',   build: () => buildEvolutionCouvertsSheetRows(buckets) },
+    { id: 'section-perf-jour-semaine',  name: 'Perf jour semaine',    build: () => buildPerfJourSemaineSheetRows(perfWeekday) },
+    { id: 'section-mix-food-bev',       name: 'Mix Food-Bev',         build: () => buildMixSheetRows(mix) },
+    { id: 'section-top-bottom-jours',   name: 'Top et Bottom jours',  build: () => buildTopBottomSheetRows(topBottom) },
+    { id: 'section-tableau-jour-jour',  name: 'Tableau jour par jour', build: () => buildTableauJourJourSheetRows(daysWithBudget) },
+  ]
+  for (const b of sectionBuilders) {
+    if (!visibleIds.has(b.id)) continue
+    const rows = b.build()
+    if (!rows || rows.length === 0) continue
+    const sheet = XLSX.utils.json_to_sheet(rows)
+    XLSX.utils.book_append_sheet(wb, sheet, b.name)
+  }
+
+  return wb
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function round(n) {
+  if (n == null || isNaN(n)) return 0
+  return Math.round(n * 100) / 100
+}
+
+function round2(n) {
+  if (n == null || isNaN(n)) return 0
+  return Math.round(n * 100) / 100
+}
+
+function computeDelta(current, target, label) {
+  if (target == null || current == null) return null
+  const delta = current - target
+  const pct = target !== 0 ? (delta / target) * 100 : null
+  return { delta: round(delta), pct, label: label || '' }
+}
+
+function formatDateTime(d) {
+  return d.toLocaleString('fr-FR', {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  })
+}
+
+// Construit un nom de fichier safe avec dates de la période.
+export function buildFilename(dateDebut, dateFin) {
+  return `analyses-ca_${dateDebut}_${dateFin}.xlsx`
+}


### PR DESCRIPTION
## Summary
PR 4/5 du chantier « Page Analyses ». Ajoute deux actions dans la TopBar.

### 📥 Excel
- Onglet **Période & filtres** pour la traçabilité (période, dates, comparaison, lieu, service, granularité auto, horodatage de l'export).
- Onglet **KPIs** listant les 5 cartes visibles avec δ et % vs comparaison.
- Un onglet par widget de section visible : Évolution CA, Évolution couverts, Perf jour-semaine, Mix Food-Bev, Top/Bottom jours, Tableau jour-jour.
- Nom de fichier : `analyses-ca_<debut>_<fin>.xlsx`.

### 🖨 Imprimer
- `window.print()` avec `@page A4 paysage` (CSS déjà en place dans `globals.css`).
- `.no-print` posé sur la navbar et les boutons d'action de la page Analyses.
- `.sk-print-section` sur chaque widget pour activer `page-break-inside: avoid` (graphes recharts et tableaux ne sont plus coupés à cheval sur 2 pages).

### Tests
La construction du workbook est isolée dans [lib/analysesExport.js](lib/analysesExport.js) (pure, sans dépendance React) → **16 tests vitest** qui valident :
- onglet « Période & filtres » toujours présent
- onglet « KPIs » si au moins un KPI visible
- un onglet par section visible, et seulement celles-là
- noms d'onglets ≤ 31 chars (limite Excel)
- contenu des lignes pour chaque builder

Total tests : 89 → 104, tous verts.

## Test plan
- [ ] Cliquer **📥 Excel** sur la page Analyses → un .xlsx se télécharge avec les bons onglets.
- [ ] Vérifier que masquer un widget via ⚙ Personnaliser fait disparaître son onglet de l'export.
- [ ] Ouvrir le fichier dans Excel/LibreOffice → vérifier que les % et nombres s'affichent correctement, que le nom de chaque onglet ≤ 31 chars.
- [ ] Cliquer **🖨 Imprimer** → l'aperçu doit cacher la navbar + les 3 boutons d'action ; chaque widget reste sur une seule page.
- [ ] Tester l'impression sur un mois entier (≥ 30 jours) → le tableau jour/jour ne doit pas être coupé en plein milieu d'une ligne.
- [ ] Vérifier que les couleurs des graphes recharts sortent bien à l'impression (color-adjust déjà actif).

🤖 Generated with [Claude Code](https://claude.com/claude-code)