### PR TITLE
feat(analyses): vue multi-lieu / multi-service + mix détaillé

### DIFF
--- a/app/controle-gestion/analyses/page.js
+++ b/app/controle-gestion/analyses/page.js
@@ -19,6 +19,11 @@ import {
   perfByWeekday,
   mixSegments,
   topBottomDays,
+  aggregateBySerie,
+  buildBreakdown,
+  mixByService,
+  bucketDaysMultiSeries,
+  perfByWeekdayMultiSeries,
   fromIsoDate,
 } from '../../../lib/caAnalyses'
 import {
@@ -41,7 +46,7 @@ import { buildAnalysesWorkbook, buildFilename } from '../../../lib/analysesExpor
 import * as XLSX from 'xlsx'
 import Navbar from '../../../components/Navbar'
 import WidgetsCustomizeModal from '../../../components/dashboard/WidgetsCustomizeModal'
-import FilterBar, { COMPARAISON_LABELS } from '../../../components/analyses/FilterBar'
+import FilterBar, { COMPARAISON_LABELS, ALL_SERVICES } from '../../../components/analyses/FilterBar'
 import KpiCouverts from '../../../components/analyses/widgets/KpiCouverts'
 import KpiCaTtc from '../../../components/analyses/widgets/KpiCaTtc'
 import KpiCaHt from '../../../components/analyses/widgets/KpiCaHt'
@@ -78,8 +83,10 @@ export default function AnalysesPage() {
   const [dateDebut, setDateDebut] = useState(initialDates.debut)
   const [dateFin, setDateFin] = useState(initialDates.fin)
   const [comparaison, setComparaison] = useState('aucune')
-  const [lieuId, setLieuId] = useState('all')
-  const [service, setService] = useState('tout')
+  // Multi-select : tableau d'ids cochés. Vide = "Tous" (équivalent à tout
+  // cumulé). 1 entrée = filtre simple. 2+ entrées = mode multi-séries.
+  const [lieuxSelected, setLieuxSelected] = useState([])
+  const [servicesSelected, setServicesSelected] = useState([])
 
   // ── Layout widgets ───────────────────────────────────────────────────────
   const [layout, setLayout] = useState(null)
@@ -297,26 +304,38 @@ export default function AnalysesPage() {
     if (margesNeeded) loadMargesData()
   }, [margesNeeded, loadMargesData])
 
-  // ── Filtrage côté JS sur lieu / service ──────────────────────────────────
+  // ── Filtrage côté JS sur lieu / service (multi-select) ───────────────────
+  // Vide = "Tous" → on ne filtre pas. Sinon on garde les rows dont la
+  // dimension matche au moins une valeur sélectionnée.
   const filterRows = useCallback((rows) => {
+    const filterLieu = lieuxSelected.length > 0 && lieuxSelected.length < lieux.length
+    const filterService = servicesSelected.length > 0 && servicesSelected.length < ALL_SERVICES.length
+    if (!filterLieu && !filterService) return rows
+    const lieuxSet = new Set(lieuxSelected)
+    const servicesSet = new Set(servicesSelected)
     return rows.filter((r) => {
-      if (lieuId !== 'all' && r.lieu_service_id !== lieuId) return false
-      if (service !== 'tout' && r.service !== service) return false
+      if (filterLieu && !lieuxSet.has(r.lieu_service_id)) return false
+      if (filterService && !servicesSet.has(r.service)) return false
       return true
     })
-  }, [lieuId, service])
+  }, [lieuxSelected, servicesSelected, lieux.length])
 
   const filterBudgets = useCallback((budgetRowsByYear) => {
+    const filterLieu = lieuxSelected.length > 0 && lieuxSelected.length < lieux.length
+    const filterService = servicesSelected.length > 0 && servicesSelected.length < ALL_SERVICES.length
+    if (!filterLieu && !filterService) return budgetRowsByYear
+    const lieuxSet = new Set(lieuxSelected)
+    const servicesSet = new Set(servicesSelected)
     const out = {}
     for (const [annee, rows] of Object.entries(budgetRowsByYear)) {
       out[annee] = rows.filter((r) => {
-        if (lieuId !== 'all' && r.lieu_service_id !== lieuId) return false
-        if (service !== 'tout' && r.service !== service) return false
+        if (filterLieu && !lieuxSet.has(r.lieu_service_id)) return false
+        if (filterService && !servicesSet.has(r.service)) return false
         return true
       })
     }
     return out
-  }, [lieuId, service])
+  }, [lieuxSelected, servicesSelected, lieux.length])
 
   // ── Totals + days + budget ───────────────────────────────────────────────
   const filteredRows = useMemo(() => filterRows(rawCa), [rawCa, filterRows])
@@ -394,6 +413,99 @@ export default function AnalysesPage() {
   const topBottom = useMemo(() => topBottomDays(daysWithBudget, 5), [daysWithBudget])
   const hasBudget = periodBudget > 0
 
+  // ── Mode multi-séries (split lieu / service) ─────────────────────────────
+  // Le split est actif sur une dimension dès qu'au moins 2 entrées sont
+  // sélectionnées. "Tous" (tableau vide) compte aussi comme split potentiel
+  // si plusieurs valeurs existent — dans ce cas on split par défaut sur la
+  // dimension lieu (plus parlant que service à 2 valeurs).
+  const lieuxLabels = useMemo(() => new Map(lieux.map((l) => [l.id, l.nom])), [lieux])
+  const splitByLieu = useMemo(() => {
+    if (lieuxSelected.length >= 2) return true
+    if (lieuxSelected.length === 0 && lieux.length >= 2) return true // "Tous" + plusieurs lieux
+    return false
+  }, [lieuxSelected.length, lieux.length])
+  const splitByService = useMemo(() => {
+    if (servicesSelected.length === ALL_SERVICES.length) return true
+    if (servicesSelected.length === 0) return false // "Tous" mais pas split par défaut
+    return false // 1 service sélectionné = pas de split
+  }, [servicesSelected.length])
+
+  const splitDims = useMemo(() => {
+    const dims = []
+    if (splitByLieu) dims.push('lieu')
+    if (splitByService) dims.push('service')
+    return dims
+  }, [splitByLieu, splitByService])
+
+  const isSplit = splitDims.length > 0
+
+  // Séries agrégées sur la période entière : { 'Salle / Déjeuner': totals, … }
+  const seriesByGroup = useMemo(
+    () => aggregateBySerie(filteredRows, splitDims, lieuxLabels),
+    [filteredRows, splitDims, lieuxLabels]
+  )
+
+  // Breakdowns 1D pour les KPIs (toujours calculés indépendamment du mode
+  // multi-séries 2D — affichés en sous-titre de chaque KPI). On calcule par
+  // métrique pour que chaque KPI affiche les bons pourcentages (couverts,
+  // caTtc, caHt, tm).
+  const seriesByLieu = useMemo(
+    () => aggregateBySerie(filteredRows, ['lieu'], lieuxLabels),
+    [filteredRows, lieuxLabels]
+  )
+  const seriesByService = useMemo(
+    () => aggregateBySerie(filteredRows, ['service'], lieuxLabels),
+    [filteredRows, lieuxLabels]
+  )
+
+  const breakdowns = useMemo(() => {
+    const make = (metric) => ({
+      byLieu: lieux.length >= 2 ? buildBreakdown(seriesByLieu, metric) : null,
+      byService: buildBreakdown(seriesByService, metric),
+    })
+    return {
+      couverts: make('couverts'),
+      caTtc: make('caTtc'),
+      caHt: make('caHt'),
+    }
+  }, [seriesByLieu, seriesByService, lieux.length])
+
+  // Days par série (pour line charts multi-séries + perf jour-semaine)
+  const daysBySerie = useMemo(() => {
+    if (!isSplit) return null
+    const groups = new Map()
+    for (const r of filteredRows) {
+      const parts = []
+      if (splitByLieu) parts.push(lieuxLabels.get(r.lieu_service_id) || r.lieu_service_id || '—')
+      if (splitByService) parts.push(r.service === 'lunch' ? 'Déjeuner' : 'Dîner')
+      const key = parts.join(' / ')
+      if (!groups.has(key)) groups.set(key, [])
+      groups.get(key).push(r)
+    }
+    const out = new Map()
+    for (const [key, rows] of groups.entries()) {
+      out.set(key, aggregateByDay(rows, dateDebut, dateFin))
+    }
+    return out
+  }, [filteredRows, isSplit, splitByLieu, splitByService, lieuxLabels, dateDebut, dateFin])
+
+  const bucketsMultiCa = useMemo(
+    () => isSplit ? bucketDaysMultiSeries(daysBySerie, granularity, 'caTot') : null,
+    [isSplit, daysBySerie, granularity]
+  )
+  const bucketsMultiCouverts = useMemo(
+    () => isSplit ? bucketDaysMultiSeries(daysBySerie, granularity, 'couverts') : null,
+    [isSplit, daysBySerie, granularity]
+  )
+  const perfMultiCa = useMemo(
+    () => isSplit ? perfByWeekdayMultiSeries(daysBySerie, 'ca') : null,
+    [isSplit, daysBySerie]
+  )
+  const mixServiceMatrix = useMemo(
+    () => mixByService(filteredRows),
+    [filteredRows]
+  )
+
   // ── Données dérivées pour les widgets marges ─────────────────────────────
   const margesLignes = useMemo(() => aggregateByFiche(rawVentes, ficheById), [rawVentes, ficheById])
   const margesTotals = useMemo(() => computeMargesTotals(margesLignes), [margesLignes])
@@ -427,23 +539,23 @@ export default function AnalysesPage() {
   const renderWidget = (id) => {
     const common = { c, isMobile, totals, comparisonTotals, comparisonLabel }
     switch (id) {
-      case 'kpi-couverts':         return <KpiCouverts {...common} />
-      case 'kpi-ca-ttc':           return <KpiCaTtc {...common} />
-      case 'kpi-ca-ht':            return <KpiCaHt {...common} />
+      case 'kpi-couverts':         return <KpiCouverts {...common} breakdownByLieu={breakdowns.couverts.byLieu} breakdownByService={breakdowns.couverts.byService} />
+      case 'kpi-ca-ttc':           return <KpiCaTtc {...common} breakdownByLieu={breakdowns.caTtc.byLieu} breakdownByService={breakdowns.caTtc.byService} />
+      case 'kpi-ca-ht':            return <KpiCaHt {...common} breakdownByLieu={breakdowns.caHt.byLieu} breakdownByService={breakdowns.caHt.byService} />
       case 'kpi-tm':               return <KpiTm {...common} />
       case 'kpi-ecart-budget-pct': return <KpiEcartBudgetPct c={c} isMobile={isMobile} totals={totals} budget={periodBudget} />
       case 'section-evolution-ca':
-        return <SectionEvolutionCa c={c} isMobile={isMobile} buckets={buckets} granularity={granularity} hasBudget={hasBudget} />
+        return <SectionEvolutionCa c={c} isMobile={isMobile} buckets={buckets} bucketsMulti={bucketsMultiCa} isSplit={isSplit} granularity={granularity} hasBudget={hasBudget} />
       case 'section-evolution-couverts':
-        return <SectionEvolutionCouverts c={c} isMobile={isMobile} buckets={buckets} granularity={granularity} />
+        return <SectionEvolutionCouverts c={c} isMobile={isMobile} buckets={buckets} bucketsMulti={bucketsMultiCouverts} isSplit={isSplit} granularity={granularity} />
       case 'section-perf-jour-semaine':
-        return <SectionPerfJourSemaine c={c} isMobile={isMobile} perf={perfWeekday} />
+        return <SectionPerfJourSemaine c={c} isMobile={isMobile} perf={perfWeekday} perfMulti={perfMultiCa} isSplit={isSplit} />
       case 'section-mix-food-bev':
-        return <SectionMixFoodBev c={c} isMobile={isMobile} segments={mix} totalCaTtc={totals.caTtc} />
+        return <SectionMixFoodBev c={c} isMobile={isMobile} segments={mix} totalCaTtc={totals.caTtc} matrix={mixServiceMatrix} />
       case 'section-top-bottom-jours':
         return <SectionTopBottomJours c={c} isMobile={isMobile} topBottom={topBottom} />
       case 'section-tableau-jour-jour':
-        return <SectionTableauJourJour c={c} isMobile={isMobile} days={daysWithBudget} totals={tableauTotals} />
+        return <SectionTableauJourJour c={c} isMobile={isMobile} days={daysWithBudget} totals={tableauTotals} isSplit={isSplit} splitByLieu={splitByLieu} splitByService={splitByService} filteredRows={filteredRows} lieuxLabels={lieuxLabels} />
       case 'kpi-food-cost-moyen':
         return (
           <KpiFoodCostMoyen
@@ -516,17 +628,28 @@ export default function AnalysesPage() {
 
   // ── Actions TopBar : export Excel + impression ───────────────────────────
   const handleExportExcel = () => {
-    const lieuLabel = lieuId === 'all' ? 'Tous lieux' : (lieux.find((l) => l.id === lieuId)?.nom || lieuId)
+    const lieuLabel = lieuxSelected.length === 0 || lieuxSelected.length === lieux.length
+      ? 'Tous lieux'
+      : lieuxSelected.map((id) => lieuxLabels.get(id) || id).join(', ')
+    const serviceLabel = servicesSelected.length === 0 || servicesSelected.length === ALL_SERVICES.length
+      ? 'tout'
+      : servicesSelected.join('+')
     const visibleIds = new Set(visibleLayout.map((l) => l.id))
     const wb = buildAnalysesWorkbook({
       visibleIds,
-      periode, dateDebut, dateFin, comparaison, lieuLabel, service,
+      periode, dateDebut, dateFin, comparaison, lieuLabel, service: serviceLabel,
       totals, comparisonTotals, comparisonLabel, periodBudget,
       buckets, granularity, perfWeekday, mix, topBottom, daysWithBudget,
       // PR 5 — données marges (peuvent être à 0 si l'user n'a activé aucun
       // widget marges, mais on les passe systématiquement → l'export ne
       // dump que les onglets dont l'id figure dans visibleIds).
       margesTotals, margesLignes, consoLignes, margesChartData,
+      // PR 6 — split lieu/service (pour ajouter la colonne Lieu/Service
+      // dans les onglets concernés).
+      isSplit, splitByLieu, splitByService,
+      bucketsMultiCa, bucketsMultiCouverts, perfMulti: perfMultiCa,
+      daysBySerieEntries: daysBySerie ? Array.from(daysBySerie.entries()) : null,
+      mixServiceMatrix,
     })
     XLSX.writeFile(wb, buildFilename(dateDebut, dateFin))
   }
@@ -547,7 +670,7 @@ export default function AnalysesPage() {
               Analyses CA
             </h1>
             <p style={{ margin: 0, fontSize: 14, color: c.texteMuted }}>
-              {humanRange(dateDebut, dateFin)}
+              {humanRange(dateDebut, dateFin)}{isSplit && ` — détail par ${splitDims.map((d) => d === 'lieu' ? 'lieu' : 'service').join(' × ')}`}
             </p>
           </div>
           <div className="no-print" style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
@@ -581,8 +704,9 @@ export default function AnalysesPage() {
           dateDebut={dateDebut} dateFin={dateFin}
           onDateDebut={setDateDebut} onDateFin={setDateFin}
           comparaison={comparaison} onComparaison={setComparaison}
-          lieux={lieux} lieuId={lieuId} onLieu={setLieuId}
-          service={service} onService={setService}
+          lieux={lieux}
+          lieuxSelected={lieuxSelected} onLieuxSelected={setLieuxSelected}
+          servicesSelected={servicesSelected} onServicesSelected={setServicesSelected}
         />
 
         {error && <p style={{ color: '#B91C1C', fontSize: 14, marginBottom: 16 }}>{error}</p>}

--- a/app/controle-gestion/analyses/page.js
+++ b/app/controle-gestion/analyses/page.js
@@ -46,7 +46,7 @@ import { buildAnalysesWorkbook, buildFilename } from '../../../lib/analysesExpor
 import * as XLSX from 'xlsx'
 import Navbar from '../../../components/Navbar'
 import WidgetsCustomizeModal from '../../../components/dashboard/WidgetsCustomizeModal'
-import FilterBar, { COMPARAISON_LABELS, ALL_SERVICES } from '../../../components/analyses/FilterBar'
+import FilterBar, { COMPARAISON_LABELS, ALL_SERVICES, ALL_JOURS, JOUR_FR_LABELS } from '../../../components/analyses/FilterBar'
 import KpiCouverts from '../../../components/analyses/widgets/KpiCouverts'
 import KpiCaTtc from '../../../components/analyses/widgets/KpiCaTtc'
 import KpiCaHt from '../../../components/analyses/widgets/KpiCaHt'
@@ -87,6 +87,10 @@ export default function AnalysesPage() {
   // cumulé). 1 entrée = filtre simple. 2+ entrées = mode multi-séries.
   const [lieuxSelected, setLieuxSelected] = useState([])
   const [servicesSelected, setServicesSelected] = useState([])
+  // Jours de semaine ISO (1=lundi … 7=dimanche). Vide = tous les jours.
+  // N'active pas le mode split — sert uniquement à filtrer (ex : "tous les
+  // mardis du mois").
+  const [joursSelected, setJoursSelected] = useState([])
 
   // ── Layout widgets ───────────────────────────────────────────────────────
   const [layout, setLayout] = useState(null)
@@ -304,26 +308,36 @@ export default function AnalysesPage() {
     if (margesNeeded) loadMargesData()
   }, [margesNeeded, loadMargesData])
 
-  // ── Filtrage côté JS sur lieu / service (multi-select) ───────────────────
+  // ── Filtrage côté JS sur lieu / service / jour (multi-select) ────────────
   // Vide = "Tous" → on ne filtre pas. Sinon on garde les rows dont la
   // dimension matche au moins une valeur sélectionnée.
+  // Pour le filtre jours-de-semaine, on calcule le jsWeekday de la date r.jour
+  // et on le compare (1 = lundi … 7 = dimanche en ISO).
+  const filterJoursActive = joursSelected.length > 0 && joursSelected.length < ALL_JOURS.length
+  const joursSet = useMemo(() => new Set(joursSelected), [joursSelected])
+
   const filterRows = useCallback((rows) => {
     const filterLieu = lieuxSelected.length > 0 && lieuxSelected.length < lieux.length
     const filterService = servicesSelected.length > 0 && servicesSelected.length < ALL_SERVICES.length
-    if (!filterLieu && !filterService) return rows
+    if (!filterLieu && !filterService && !filterJoursActive) return rows
     const lieuxSet = new Set(lieuxSelected)
     const servicesSet = new Set(servicesSelected)
     return rows.filter((r) => {
       if (filterLieu && !lieuxSet.has(r.lieu_service_id)) return false
       if (filterService && !servicesSet.has(r.service)) return false
+      if (filterJoursActive) {
+        const date = new Date(`${r.jour}T00:00:00`)
+        const isoJds = date.getDay() === 0 ? 7 : date.getDay()
+        if (!joursSet.has(isoJds)) return false
+      }
       return true
     })
-  }, [lieuxSelected, servicesSelected, lieux.length])
+  }, [lieuxSelected, servicesSelected, lieux.length, filterJoursActive, joursSet])
 
   const filterBudgets = useCallback((budgetRowsByYear) => {
     const filterLieu = lieuxSelected.length > 0 && lieuxSelected.length < lieux.length
     const filterService = servicesSelected.length > 0 && servicesSelected.length < ALL_SERVICES.length
-    if (!filterLieu && !filterService) return budgetRowsByYear
+    if (!filterLieu && !filterService && !filterJoursActive) return budgetRowsByYear
     const lieuxSet = new Set(lieuxSelected)
     const servicesSet = new Set(servicesSelected)
     const out = {}
@@ -331,11 +345,12 @@ export default function AnalysesPage() {
       out[annee] = rows.filter((r) => {
         if (filterLieu && !lieuxSet.has(r.lieu_service_id)) return false
         if (filterService && !servicesSet.has(r.service)) return false
+        if (filterJoursActive && !joursSet.has(r.jour_semaine)) return false
         return true
       })
     }
     return out
-  }, [lieuxSelected, servicesSelected, lieux.length])
+  }, [lieuxSelected, servicesSelected, lieux.length, filterJoursActive, joursSet])
 
   // ── Totals + days + budget ───────────────────────────────────────────────
   const filteredRows = useMemo(() => filterRows(rawCa), [rawCa, filterRows])
@@ -345,11 +360,19 @@ export default function AnalysesPage() {
 
   const totals = useMemo(() => aggregateTotals(filteredRows), [filteredRows])
   const totalsCompare = useMemo(() => aggregateTotals(filteredCompareRows), [filteredCompareRows])
-  const days = useMemo(() => aggregateByDay(filteredRows, dateDebut, dateFin), [filteredRows, dateDebut, dateFin])
+
+  // `days` couvre toute la plage [debut, fin]. Quand un filtre jours est
+  // actif, on ne garde que les lignes dont le jour-de-semaine matche : utile
+  // pour visualiser uniquement les mardis sur 1 mois, par exemple.
+  const days = useMemo(() => {
+    const all = aggregateByDay(filteredRows, dateDebut, dateFin)
+    if (!filterJoursActive) return all
+    return all.filter((d) => joursSet.has(d.isoJds))
+  }, [filteredRows, dateDebut, dateFin, filterJoursActive, joursSet])
 
   const periodBudget = useMemo(
-    () => periodBudgetTotal(filteredBudgetByYear, dateDebut, dateFin),
-    [filteredBudgetByYear, dateDebut, dateFin]
+    () => periodBudgetTotal(filteredBudgetByYear, dateDebut, dateFin, filterJoursActive ? joursSet : null),
+    [filteredBudgetByYear, dateDebut, dateFin, filterJoursActive, joursSet]
   )
 
   const compareBudgetRange = useMemo(
@@ -359,8 +382,8 @@ export default function AnalysesPage() {
 
   const periodBudgetCompare = useMemo(() => {
     if (!compareBudgetRange) return 0
-    return periodBudgetTotal(filteredCompareBudgetByYear, compareBudgetRange.debut, compareBudgetRange.fin)
-  }, [filteredCompareBudgetByYear, compareBudgetRange])
+    return periodBudgetTotal(filteredCompareBudgetByYear, compareBudgetRange.debut, compareBudgetRange.fin, filterJoursActive ? joursSet : null)
+  }, [filteredCompareBudgetByYear, compareBudgetRange, filterJoursActive, joursSet])
 
   // ── Comparison props injectés dans les KPIs ──────────────────────────────
   // - 'aucune' → pas de comparaison
@@ -382,7 +405,8 @@ export default function AnalysesPage() {
   const comparisonLabel = comparaison === 'aucune' ? '' : (COMPARAISON_LABELS[comparaison] || '')
 
   // Pour le tableau jour-jour, on injecte le budget journalier dans chaque
-  // jour en réutilisant periodBudgetTotal sur une seule date.
+  // jour en réutilisant periodBudgetTotal sur une seule date. Pas besoin de
+  // passer joursSet ici : on est déjà filtré au niveau de `days`.
   const daysWithBudget = useMemo(() => {
     return days.map((d) => {
       const budget = periodBudgetTotal(filteredBudgetByYear, d.iso, d.iso)
@@ -634,10 +658,13 @@ export default function AnalysesPage() {
     const serviceLabel = servicesSelected.length === 0 || servicesSelected.length === ALL_SERVICES.length
       ? 'tout'
       : servicesSelected.join('+')
+    const joursLabel = !filterJoursActive
+      ? 'Tous'
+      : joursSelected.map((j) => JOUR_FR_LABELS[j]).join(', ')
     const visibleIds = new Set(visibleLayout.map((l) => l.id))
     const wb = buildAnalysesWorkbook({
       visibleIds,
-      periode, dateDebut, dateFin, comparaison, lieuLabel, service: serviceLabel,
+      periode, dateDebut, dateFin, comparaison, lieuLabel, service: serviceLabel, joursLabel,
       totals, comparisonTotals, comparisonLabel, periodBudget,
       buckets, granularity, perfWeekday, mix, topBottom, daysWithBudget,
       // PR 5 — données marges (peuvent être à 0 si l'user n'a activé aucun
@@ -670,7 +697,9 @@ export default function AnalysesPage() {
               Analyses CA
             </h1>
             <p style={{ margin: 0, fontSize: 14, color: c.texteMuted }}>
-              {humanRange(dateDebut, dateFin)}{isSplit && ` — détail par ${splitDims.map((d) => d === 'lieu' ? 'lieu' : 'service').join(' × ')}`}
+              {humanRange(dateDebut, dateFin)}
+              {filterJoursActive && ` — uniquement ${joursSelected.map((j) => JOUR_FR_LABELS[j]).join(', ')}`}
+              {isSplit && ` — détail par ${splitDims.map((d) => d === 'lieu' ? 'lieu' : 'service').join(' × ')}`}
             </p>
           </div>
           <div className="no-print" style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
@@ -707,6 +736,7 @@ export default function AnalysesPage() {
           lieux={lieux}
           lieuxSelected={lieuxSelected} onLieuxSelected={setLieuxSelected}
           servicesSelected={servicesSelected} onServicesSelected={setServicesSelected}
+          joursSelected={joursSelected} onJoursSelected={setJoursSelected}
         />
 
         {error && <p style={{ color: '#B91C1C', fontSize: 14, marginBottom: 16 }}>{error}</p>}

--- a/components/analyses/FilterBar.js
+++ b/components/analyses/FilterBar.js
@@ -17,22 +17,36 @@ const COMPARAISONS = [
   { code: 'budget',  label: 'vs Budget' },
 ]
 
-const SERVICES = [
-  { code: 'tout',   label: 'Tous services' },
-  { code: 'lunch',  label: 'Déjeuner' },
-  { code: 'dinner', label: 'Dîner' },
-]
+export const ALL_SERVICES = ['lunch', 'dinner']
 
+const SERVICE_LABELS = { lunch: 'Déjeuner', dinner: 'Dîner' }
+
+// `lieuxSelected` / `servicesSelected` :
+//   - tableau des codes/ids cochés
+//   - tableau vide = "Tous" (équivalent à tous cochés ; on conserve un tableau
+//     distinct pour préserver l'intent "all" même si un nouveau lieu apparaît)
+//
+// Quand 2+ entrées sont cochées, la page passe en mode multi-séries (split).
+// Le toggle "Tous" coche/décoche tout en un clic.
 export default function FilterBar({
   c, isMobile,
   periode, onPeriode,
   dateDebut, dateFin, onDateDebut, onDateFin,
   comparaison, onComparaison,
-  lieux, lieuId, onLieu,
-  service, onService,
+  lieux, lieuxSelected, onLieuxSelected,
+  servicesSelected, onServicesSelected,
 }) {
   const btn = (active) => ({
     padding: '7px 12px', borderRadius: 8, fontSize: 13,
+    border: `1px solid ${active ? c.accent : c.bordure}`,
+    background: active ? c.accent : c.blanc,
+    color: active ? c.texte : c.texteMuted,
+    cursor: 'pointer', fontWeight: active ? 600 : 500,
+    whiteSpace: 'nowrap',
+  })
+
+  const chip = (active) => ({
+    padding: '5px 10px', borderRadius: 16, fontSize: 12,
     border: `1px solid ${active ? c.accent : c.bordure}`,
     background: active ? c.accent : c.blanc,
     color: active ? c.texte : c.texteMuted,
@@ -50,12 +64,45 @@ export default function FilterBar({
     border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte,
   }
 
+  // ── Multi-select handlers ──────────────────────────────────────────────────
+
+  // "Tous lieux" actif si l'utilisateur a explicitement vidé la liste OU
+  // a coché tous les lieux disponibles → dans les deux cas on traite comme
+  // "all" et on stocke [] pour garder l'intent stable face à l'arrivée
+  // d'un nouveau lieu.
+  const lieuxAllActive = lieuxSelected.length === 0 || lieuxSelected.length === lieux.length
+  const servicesAllActive = servicesSelected.length === 0 || servicesSelected.length === ALL_SERVICES.length
+
+  const toggleLieu = (id) => {
+    if (lieuxAllActive) {
+      // Was "all" → switch to "only this one"
+      onLieuxSelected([id])
+      return
+    }
+    const set = new Set(lieuxSelected)
+    if (set.has(id)) set.delete(id)
+    else set.add(id)
+    onLieuxSelected(set.size === 0 ? [] : Array.from(set))
+  }
+
+  const toggleService = (code) => {
+    if (servicesAllActive) {
+      onServicesSelected([code])
+      return
+    }
+    const set = new Set(servicesSelected)
+    if (set.has(code)) set.delete(code)
+    else set.add(code)
+    onServicesSelected(set.size === 0 ? [] : Array.from(set))
+  }
+
   return (
     <div style={{
       background: c.blanc, border: `0.5px solid ${c.bordure}`, borderRadius: 12,
       padding: isMobile ? 12 : 16, marginBottom: 20,
       display: 'flex', flexDirection: 'column', gap: 10,
     }}>
+      {/* Période */}
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
         {PERIODES.map((p) => (
           <button key={p.code} onClick={() => onPeriode(p.code)} style={btn(p.code === periode)}>
@@ -73,6 +120,7 @@ export default function FilterBar({
         </div>
       )}
 
+      {/* Comparaison */}
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, alignItems: 'center' }}>
         <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: c.texteMuted }}>
           Comparaison
@@ -80,21 +128,30 @@ export default function FilterBar({
             {COMPARAISONS.map((c2) => <option key={c2.code} value={c2.code}>{c2.label}</option>)}
           </select>
         </label>
+      </div>
 
-        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: c.texteMuted }}>
-          Lieu
-          <select value={lieuId} onChange={(e) => onLieu(e.target.value)} style={select}>
-            <option value="all">Tous lieux</option>
-            {lieux.map((l) => <option key={l.id} value={l.id}>{l.nom}</option>)}
-          </select>
-        </label>
+      {/* Multi-select Lieux */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
+        <span style={{ fontSize: 12, color: c.texteMuted, marginRight: 4 }}>Lieux :</span>
+        <button onClick={() => onLieuxSelected([])} style={chip(lieuxAllActive)}>Tous</button>
+        {lieux.map((l) => (
+          <button key={l.id} onClick={() => toggleLieu(l.id)}
+            style={chip(!lieuxAllActive && lieuxSelected.includes(l.id))}>
+            {l.nom}
+          </button>
+        ))}
+      </div>
 
-        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: c.texteMuted }}>
-          Service
-          <select value={service} onChange={(e) => onService(e.target.value)} style={select}>
-            {SERVICES.map((s) => <option key={s.code} value={s.code}>{s.label}</option>)}
-          </select>
-        </label>
+      {/* Multi-select Services */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
+        <span style={{ fontSize: 12, color: c.texteMuted, marginRight: 4 }}>Services :</span>
+        <button onClick={() => onServicesSelected([])} style={chip(servicesAllActive)}>Tous</button>
+        {ALL_SERVICES.map((s) => (
+          <button key={s} onClick={() => toggleService(s)}
+            style={chip(!servicesAllActive && servicesSelected.includes(s))}>
+            {SERVICE_LABELS[s]}
+          </button>
+        ))}
       </div>
     </div>
   )
@@ -104,3 +161,5 @@ export const COMPARAISON_LABELS = {
   'n-1':    'vs même période N-1',
   'budget': 'vs Budget',
 }
+
+export const SERVICE_FR_LABELS = SERVICE_LABELS

--- a/components/analyses/FilterBar.js
+++ b/components/analyses/FilterBar.js
@@ -21,6 +21,11 @@ export const ALL_SERVICES = ['lunch', 'dinner']
 
 const SERVICE_LABELS = { lunch: 'Déjeuner', dinner: 'Dîner' }
 
+// ISO 8601 : 1 = lundi … 7 = dimanche (cohérent avec ca_budgets.jour_semaine).
+export const ALL_JOURS = [1, 2, 3, 4, 5, 6, 7]
+const JOUR_LABELS = { 1: 'Lundi', 2: 'Mardi', 3: 'Mercredi', 4: 'Jeudi', 5: 'Vendredi', 6: 'Samedi', 7: 'Dimanche' }
+const JOUR_LABELS_SHORT = { 1: 'Lun', 2: 'Mar', 3: 'Mer', 4: 'Jeu', 5: 'Ven', 6: 'Sam', 7: 'Dim' }
+
 // `lieuxSelected` / `servicesSelected` :
 //   - tableau des codes/ids cochés
 //   - tableau vide = "Tous" (équivalent à tous cochés ; on conserve un tableau
@@ -35,6 +40,7 @@ export default function FilterBar({
   comparaison, onComparaison,
   lieux, lieuxSelected, onLieuxSelected,
   servicesSelected, onServicesSelected,
+  joursSelected, onJoursSelected,
 }) {
   const btn = (active) => ({
     padding: '7px 12px', borderRadius: 8, fontSize: 13,
@@ -72,6 +78,7 @@ export default function FilterBar({
   // d'un nouveau lieu.
   const lieuxAllActive = lieuxSelected.length === 0 || lieuxSelected.length === lieux.length
   const servicesAllActive = servicesSelected.length === 0 || servicesSelected.length === ALL_SERVICES.length
+  const joursAllActive = joursSelected.length === 0 || joursSelected.length === ALL_JOURS.length
 
   const toggleLieu = (id) => {
     if (lieuxAllActive) {
@@ -94,6 +101,17 @@ export default function FilterBar({
     if (set.has(code)) set.delete(code)
     else set.add(code)
     onServicesSelected(set.size === 0 ? [] : Array.from(set))
+  }
+
+  const toggleJour = (jds) => {
+    if (joursAllActive) {
+      onJoursSelected([jds])
+      return
+    }
+    const set = new Set(joursSelected)
+    if (set.has(jds)) set.delete(jds)
+    else set.add(jds)
+    onJoursSelected(set.size === 0 ? [] : Array.from(set).sort((a, b) => a - b))
   }
 
   return (
@@ -153,6 +171,19 @@ export default function FilterBar({
           </button>
         ))}
       </div>
+
+      {/* Multi-select Jours de la semaine */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
+        <span style={{ fontSize: 12, color: c.texteMuted, marginRight: 4 }}>Jours :</span>
+        <button onClick={() => onJoursSelected([])} style={chip(joursAllActive)}>Tous</button>
+        {ALL_JOURS.map((jds) => (
+          <button key={jds} onClick={() => toggleJour(jds)}
+            style={chip(!joursAllActive && joursSelected.includes(jds))}
+            title={JOUR_LABELS[jds]}>
+            {isMobile ? JOUR_LABELS_SHORT[jds] : JOUR_LABELS[jds]}
+          </button>
+        ))}
+      </div>
     </div>
   )
 }
@@ -163,3 +194,4 @@ export const COMPARAISON_LABELS = {
 }
 
 export const SERVICE_FR_LABELS = SERVICE_LABELS
+export const JOUR_FR_LABELS = JOUR_LABELS

--- a/components/analyses/widgets/KpiCaHt.js
+++ b/components/analyses/widgets/KpiCaHt.js
@@ -1,7 +1,7 @@
 import KpiCard from './KpiCard'
 import { buildComparison, formatEur, formatDeltaEur } from '../../../lib/caAnalyses'
 
-export default function KpiCaHt({ c, isMobile, totals, comparisonTotals, comparisonLabel }) {
+export default function KpiCaHt({ c, isMobile, totals, comparisonTotals, comparisonLabel, breakdownByLieu, breakdownByService }) {
   const value = totals ? formatEur(totals.caHt) : '—'
   const comparison = comparisonTotals && totals
     ? buildComparison({
@@ -19,6 +19,8 @@ export default function KpiCaHt({ c, isMobile, totals, comparisonTotals, compari
       value={value}
       hint={comparison ? null : 'Net de TVA (10 % Food/Soft, 20 % Alcool)'}
       comparison={comparison}
+      breakdownByLieu={breakdownByLieu}
+      breakdownByService={breakdownByService}
     />
   )
 }

--- a/components/analyses/widgets/KpiCaTtc.js
+++ b/components/analyses/widgets/KpiCaTtc.js
@@ -1,7 +1,7 @@
 import KpiCard from './KpiCard'
 import { buildComparison, formatEur, formatDeltaEur } from '../../../lib/caAnalyses'
 
-export default function KpiCaTtc({ c, isMobile, totals, comparisonTotals, comparisonLabel }) {
+export default function KpiCaTtc({ c, isMobile, totals, comparisonTotals, comparisonLabel, breakdownByLieu, breakdownByService }) {
   const value = totals ? formatEur(totals.caTtc) : '—'
   const comparison = comparisonTotals && totals
     ? buildComparison({
@@ -19,6 +19,8 @@ export default function KpiCaTtc({ c, isMobile, totals, comparisonTotals, compar
       value={value}
       hint={comparison ? null : 'Total Food + Boissons + Autres sur la période'}
       comparison={comparison}
+      breakdownByLieu={breakdownByLieu}
+      breakdownByService={breakdownByService}
     />
   )
 }

--- a/components/analyses/widgets/KpiCard.js
+++ b/components/analyses/widgets/KpiCard.js
@@ -4,8 +4,16 @@
 // `comparison` (optionnel) :
 //   { delta: number|null, deltaLabel: string, mode: 'success'|'danger'|'neutral'|'none' }
 //
-// La page passe `null` quand l'user a sélectionné "Aucune comparaison".
-export default function KpiCard({ c, isMobile, label, value, hint, comparison }) {
+// `breakdownByLieu` / `breakdownByService` (optionnels, PR 6) :
+//   array [{ serie, value, pct }] trié décroissant. Affiché en sous-titre
+//   sous la valeur quand au moins 2 séries ont du contenu — utile pour
+//   les présentations ("Salle 60 % · Privat 40 %").
+export default function KpiCard({
+  c, isMobile, label, value, hint, comparison,
+  breakdownByLieu, breakdownByService,
+}) {
+  const showLieuBreakdown = breakdownByLieu && breakdownByLieu.filter((e) => e.value > 0).length >= 2
+  const showServiceBreakdown = breakdownByService && breakdownByService.filter((e) => e.value > 0).length >= 2
   return (
     <div style={{
       background: c.blanc, borderRadius: '12px',
@@ -23,6 +31,8 @@ export default function KpiCard({ c, isMobile, label, value, hint, comparison })
       ) : hint ? (
         <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '6px' }}>{hint}</div>
       ) : null}
+      {showLieuBreakdown && <BreakdownLine c={c} breakdown={breakdownByLieu} />}
+      {showServiceBreakdown && <BreakdownLine c={c} breakdown={breakdownByService} />}
     </div>
   )
 }
@@ -35,6 +45,23 @@ function ComparisonLine({ c, comparison }) {
   return (
     <div style={{ fontSize: '11px', color, marginTop: '6px', fontWeight: 600 }}>
       {comparison.deltaLabel}
+    </div>
+  )
+}
+
+// "Salle 60 % · Privat 30 % · Table chef 10 %" — affichage compact.
+function BreakdownLine({ c, breakdown }) {
+  const visible = breakdown.filter((e) => e.value > 0)
+  return (
+    <div style={{ fontSize: '11px', color: c.texteMuted, marginTop: '4px' }}>
+      {visible.map((e, i) => (
+        <span key={e.serie}>
+          {i > 0 && <span style={{ margin: '0 6px', opacity: 0.5 }}>·</span>}
+          <span style={{ color: c.texte, fontWeight: 500 }}>{e.serie}</span>
+          {' '}
+          <span>{e.pct.toFixed(0)} %</span>
+        </span>
+      ))}
     </div>
   )
 }

--- a/components/analyses/widgets/KpiCouverts.js
+++ b/components/analyses/widgets/KpiCouverts.js
@@ -1,7 +1,7 @@
 import KpiCard from './KpiCard'
 import { buildComparison, formatNombre } from '../../../lib/caAnalyses'
 
-export default function KpiCouverts({ c, isMobile, totals, comparisonTotals, comparisonLabel }) {
+export default function KpiCouverts({ c, isMobile, totals, comparisonTotals, comparisonLabel, breakdownByLieu, breakdownByService }) {
   const value = totals ? formatNombre(totals.couverts) : '—'
   const comparison = comparisonTotals && totals
     ? buildComparison({
@@ -19,6 +19,8 @@ export default function KpiCouverts({ c, isMobile, totals, comparisonTotals, com
       value={value}
       hint={comparison ? null : 'Sur la période'}
       comparison={comparison}
+      breakdownByLieu={breakdownByLieu}
+      breakdownByService={breakdownByService}
     />
   )
 }

--- a/components/analyses/widgets/SectionEvolutionCa.js
+++ b/components/analyses/widgets/SectionEvolutionCa.js
@@ -1,53 +1,82 @@
 'use client'
 
 import {
-  ResponsiveContainer, ComposedChart, Line, Bar,
+  ResponsiveContainer, ComposedChart, LineChart, Line, Bar,
   XAxis, YAxis, CartesianGrid, Tooltip, Legend,
 } from 'recharts'
 
-// Évolution du CA TTC réel comparé au budget cumulé sur la période,
-// granularité automatique (jour ≤ 31 j, semaine ≤ 6 mois, mois sinon).
+// Évolution du CA TTC sur la période, granularité automatique.
+// Modes :
+//   - cumulé (isSplit=false) : ComposedChart avec barres budget + ligne CA réel
+//   - multi-séries (isSplit=true) : LineChart avec une ligne par lieu/service
+//     sélectionné. Le budget est masqué (il ne se split pas naturellement).
 //
-// `buckets` est la sortie de bucketDays(daysWithBudget, granularity) :
-//   { key, label, caTot, couverts, budget, count }
-export default function SectionEvolutionCa({ c, isMobile, buckets, granularity, hasBudget }) {
-  const empty = !buckets || buckets.length === 0
+// `buckets` (cumulé) : sortie de bucketDays(daysWithBudget, granularity)
+// `bucketsMulti` (split) : { series: [...], buckets: [{ key, label, ['Salle']: 100, ['Privat']: 80, … }] }
+export default function SectionEvolutionCa({ c, isMobile, buckets, bucketsMulti, isSplit, granularity, hasBudget }) {
+  const hint = `Granularité : ${granularityLabel(granularity)}${
+    isSplit ? ' — 1 ligne par série' : (hasBudget ? ' — barres = budget cible' : '')
+  }`
   return (
     <div style={{
       background: c.blanc, borderRadius: 12,
       border: `0.5px solid ${c.bordure}`,
       padding: isMobile ? '14px 10px' : '20px',
     }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 12 }}>
-        <div>
-          <div style={{ fontSize: 14, fontWeight: 600, color: c.texte }}>Évolution du CA TTC</div>
-          <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 2 }}>
-            Granularité : {granularityLabel(granularity)}{hasBudget ? ' — barres = budget cible' : ''}
-          </div>
-        </div>
+      <div style={{ marginBottom: 12 }}>
+        <div style={{ fontSize: 14, fontWeight: 600, color: c.texte }}>Évolution du CA TTC</div>
+        <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 2 }}>{hint}</div>
       </div>
-      {empty ? (
-        <EmptyState c={c} />
-      ) : (
-        <ResponsiveContainer width="100%" height={isMobile ? 220 : 280}>
-          <ComposedChart data={buckets} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke={c.bordure} />
-            <XAxis dataKey="label" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} />
-            <YAxis tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} tickFormatter={(v) => formatAxisEur(v)} />
-            <Tooltip
-              contentStyle={{ borderRadius: 8, border: `0.5px solid ${c.bordure}`, fontSize: 12 }}
-              formatter={(v, name) => [formatTooltipEur(v), name]}
-            />
-            <Legend iconSize={10} wrapperStyle={{ fontSize: 11 }} />
-            {hasBudget && (
-              <Bar dataKey="budget" name="Budget" fill={c.accentClair} radius={[4, 4, 0, 0]} />
-            )}
-            <Line type="monotone" dataKey="caTot" name="CA TTC réel" stroke={c.accent} strokeWidth={2} dot={{ r: 3 }} />
-          </ComposedChart>
-        </ResponsiveContainer>
-      )}
+      {isSplit
+        ? <MultiSeriesChart c={c} isMobile={isMobile} bucketsMulti={bucketsMulti} />
+        : <CumulatedChart c={c} isMobile={isMobile} buckets={buckets} hasBudget={hasBudget} />}
     </div>
   )
+}
+
+function CumulatedChart({ c, isMobile, buckets, hasBudget }) {
+  if (!buckets || buckets.length === 0) return <EmptyState c={c} />
+  return (
+    <ResponsiveContainer width="100%" height={isMobile ? 220 : 280}>
+      <ComposedChart data={buckets} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke={c.bordure} />
+        <XAxis dataKey="label" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} />
+        <YAxis tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} tickFormatter={formatAxisEur} />
+        <Tooltip contentStyle={{ borderRadius: 8, border: `0.5px solid ${c.bordure}`, fontSize: 12 }}
+          formatter={(v, name) => [formatTooltipEur(v), name]} />
+        <Legend iconSize={10} wrapperStyle={{ fontSize: 11 }} />
+        {hasBudget && <Bar dataKey="budget" name="Budget" fill={c.accentClair} radius={[4, 4, 0, 0]} />}
+        <Line type="monotone" dataKey="caTot" name="CA TTC réel" stroke={c.accent} strokeWidth={2} dot={{ r: 3 }} />
+      </ComposedChart>
+    </ResponsiveContainer>
+  )
+}
+
+function MultiSeriesChart({ c, isMobile, bucketsMulti }) {
+  if (!bucketsMulti || bucketsMulti.buckets.length === 0) return <EmptyState c={c} />
+  const { buckets, series } = bucketsMulti
+  return (
+    <ResponsiveContainer width="100%" height={isMobile ? 220 : 280}>
+      <LineChart data={buckets} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke={c.bordure} />
+        <XAxis dataKey="label" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} />
+        <YAxis tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} tickFormatter={formatAxisEur} />
+        <Tooltip contentStyle={{ borderRadius: 8, border: `0.5px solid ${c.bordure}`, fontSize: 12 }}
+          formatter={(v, name) => [formatTooltipEur(v), name]} />
+        <Legend iconSize={10} wrapperStyle={{ fontSize: 11 }} />
+        {series.map((s, i) => (
+          <Line key={s} type="monotone" dataKey={s} stroke={seriesColor(c, i)} strokeWidth={2} dot={{ r: 2 }} />
+        ))}
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}
+
+// Palette pour multi-séries — réutilise les couleurs sémantiques du thème
+// (et leur ordre) pour rester lisible sur les présentations.
+function seriesColor(c, i) {
+  const palette = [c.accent, c.violet, c.orange, c.vert, c.rouge, c.principal]
+  return palette[i % palette.length]
 }
 
 function granularityLabel(g) {

--- a/components/analyses/widgets/SectionEvolutionCouverts.js
+++ b/components/analyses/widgets/SectionEvolutionCouverts.js
@@ -2,44 +2,75 @@
 
 import {
   ResponsiveContainer, LineChart, Line,
-  XAxis, YAxis, CartesianGrid, Tooltip,
+  XAxis, YAxis, CartesianGrid, Tooltip, Legend,
 } from 'recharts'
 
 // Évolution des couverts servis sur la période, granularité auto.
-export default function SectionEvolutionCouverts({ c, isMobile, buckets, granularity }) {
-  const empty = !buckets || buckets.length === 0
+// `bucketsMulti` activé en mode split (1 ligne par lieu/service).
+export default function SectionEvolutionCouverts({ c, isMobile, buckets, bucketsMulti, isSplit, granularity }) {
+  const empty = isSplit
+    ? !bucketsMulti || bucketsMulti.buckets.length === 0
+    : !buckets || buckets.length === 0
   return (
     <div style={{
       background: c.blanc, borderRadius: 12,
       border: `0.5px solid ${c.bordure}`,
       padding: isMobile ? '14px 10px' : '20px',
     }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 12 }}>
-        <div>
-          <div style={{ fontSize: 14, fontWeight: 600, color: c.texte }}>Évolution des couverts</div>
-          <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 2 }}>
-            {granularityLabel(granularity)}
-          </div>
+      <div style={{ marginBottom: 12 }}>
+        <div style={{ fontSize: 14, fontWeight: 600, color: c.texte }}>Évolution des couverts</div>
+        <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 2 }}>
+          {granularityLabel(granularity)}{isSplit ? ' — 1 ligne par série' : ''}
         </div>
       </div>
       {empty ? (
         <EmptyState c={c} />
+      ) : isSplit ? (
+        <MultiSeriesChart c={c} isMobile={isMobile} bucketsMulti={bucketsMulti} />
       ) : (
-        <ResponsiveContainer width="100%" height={isMobile ? 220 : 280}>
-          <LineChart data={buckets} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke={c.bordure} />
-            <XAxis dataKey="label" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} />
-            <YAxis tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} />
-            <Tooltip
-              contentStyle={{ borderRadius: 8, border: `0.5px solid ${c.bordure}`, fontSize: 12 }}
-              formatter={(v) => [`${Number(v).toLocaleString('fr-FR')} couverts`, 'Couverts']}
-            />
-            <Line type="monotone" dataKey="couverts" name="Couverts" stroke={c.violet} strokeWidth={2} dot={{ r: 3 }} />
-          </LineChart>
-        </ResponsiveContainer>
+        <SingleChart c={c} isMobile={isMobile} buckets={buckets} />
       )}
     </div>
   )
+}
+
+function SingleChart({ c, isMobile, buckets }) {
+  return (
+    <ResponsiveContainer width="100%" height={isMobile ? 220 : 280}>
+      <LineChart data={buckets} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke={c.bordure} />
+        <XAxis dataKey="label" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} />
+        <YAxis tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} />
+        <Tooltip contentStyle={{ borderRadius: 8, border: `0.5px solid ${c.bordure}`, fontSize: 12 }}
+          formatter={(v) => [`${Number(v).toLocaleString('fr-FR')} couverts`, 'Couverts']} />
+        <Line type="monotone" dataKey="couverts" name="Couverts" stroke={c.violet} strokeWidth={2} dot={{ r: 3 }} />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}
+
+function MultiSeriesChart({ c, isMobile, bucketsMulti }) {
+  const { buckets, series } = bucketsMulti
+  return (
+    <ResponsiveContainer width="100%" height={isMobile ? 220 : 280}>
+      <LineChart data={buckets} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke={c.bordure} />
+        <XAxis dataKey="label" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} />
+        <YAxis tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} />
+        <Tooltip contentStyle={{ borderRadius: 8, border: `0.5px solid ${c.bordure}`, fontSize: 12 }}
+          formatter={(v, name) => [`${Number(v).toLocaleString('fr-FR')}`, name]} />
+        <Legend iconSize={10} wrapperStyle={{ fontSize: 11 }} />
+        {series.map((s, i) => (
+          <Line key={s} type="monotone" dataKey={s} stroke={seriesColor(c, i)} strokeWidth={2} dot={{ r: 2 }} />
+        ))}
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}
+
+function seriesColor(c, i) {
+  const palette = [c.violet, c.accent, c.orange, c.vert, c.rouge, c.principal]
+  return palette[i % palette.length]
 }
 
 function granularityLabel(g) {

--- a/components/analyses/widgets/SectionMixFoodBev.js
+++ b/components/analyses/widgets/SectionMixFoodBev.js
@@ -1,16 +1,21 @@
 'use client'
 
+import { useState } from 'react'
 import {
   ResponsiveContainer, PieChart, Pie, Cell, Tooltip, Legend,
 } from 'recharts'
 import { formatEur } from '../../../lib/caAnalyses'
 
-// Camembert du mix CA TTC par catégorie (Food / Alcool / Soft / Autres)
-// + tableau récap des montants et pourcentages.
+// Mix CA TTC par catégorie (Food / Alcool / Soft / Autres) sur la période.
+// Modes :
+//   - "Synthèse" (défaut) : 1 camembert + tableau récap
+//   - "Détaillé" : matrice service × catégorie en %, utile pour répondre à
+//     "le CA est à 65 % le midi en food, X % en bev midi, …"
 //
-// `segments` = sortie de mixSegments(totals, c) :
-//   [{ id, label, value, color, pct }] (déjà filtré et avec pourcentages)
-export default function SectionMixFoodBev({ c, isMobile, segments, totalCaTtc }) {
+// `matrix` est la sortie de mixByService(filteredRows) :
+//   [{ service, label, food, bev20, bev10, autre, ttc, pctFood, …, pctTotal }]
+export default function SectionMixFoodBev({ c, isMobile, segments, totalCaTtc, matrix }) {
+  const [mode, setMode] = useState('synthese')
   const empty = !segments || segments.length === 0
   return (
     <div style={{
@@ -18,70 +23,150 @@ export default function SectionMixFoodBev({ c, isMobile, segments, totalCaTtc })
       border: `0.5px solid ${c.bordure}`,
       padding: isMobile ? '14px 10px' : '20px',
     }}>
-      <div style={{ marginBottom: 12 }}>
-        <div style={{ fontSize: 14, fontWeight: 600, color: c.texte }}>Mix CA — Food / Boissons / Autres</div>
-        <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 2 }}>
-          Répartition du CA TTC sur la période (cible : 65 % Food / 28 % Alcool / 7 % Soft)
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 8, flexWrap: 'wrap', marginBottom: 12 }}>
+        <div>
+          <div style={{ fontSize: 14, fontWeight: 600, color: c.texte }}>Mix CA — Food / Boissons / Autres</div>
+          <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 2 }}>
+            {mode === 'synthese'
+              ? 'Répartition du CA TTC sur la période (cible : 65 % Food / 28 % Alcool / 7 % Soft)'
+              : 'Détail % par service × catégorie (% du CA TTC global)'}
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 6 }}>
+          <ModeBtn c={c} active={mode === 'synthese'} onClick={() => setMode('synthese')}>Synthèse</ModeBtn>
+          <ModeBtn c={c} active={mode === 'detaille'} onClick={() => setMode('detaille')}>Détaillé</ModeBtn>
         </div>
       </div>
-      {empty ? (
-        <EmptyState c={c} />
-      ) : (
-        <div style={{
-          display: 'grid',
-          gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr',
-          gap: 16, alignItems: 'center',
-        }}>
-          <ResponsiveContainer width="100%" height={isMobile ? 200 : 240}>
-            <PieChart>
-              <Pie data={segments} dataKey="value" nameKey="label"
-                cx="50%" cy="50%" outerRadius="80%" innerRadius="55%"
-                stroke={c.blanc} strokeWidth={2}>
-                {segments.map((s) => <Cell key={s.id} fill={s.color} />)}
-              </Pie>
-              <Tooltip
-                contentStyle={{ borderRadius: 8, border: `0.5px solid ${c.bordure}`, fontSize: 12 }}
-                formatter={(v, name) => [`${formatEur(Number(v))} (${pctOf(Number(v), totalCaTtc)})`, name]}
-              />
-              <Legend iconSize={10} wrapperStyle={{ fontSize: 11 }} />
-            </PieChart>
-          </ResponsiveContainer>
-
-          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
-            <thead>
-              <tr>
-                <th style={{ textAlign: 'left',  padding: '6px 8px', color: c.texteMuted, fontWeight: 600 }}>Catégorie</th>
-                <th style={{ textAlign: 'right', padding: '6px 8px', color: c.texteMuted, fontWeight: 600 }}>CA TTC</th>
-                <th style={{ textAlign: 'right', padding: '6px 8px', color: c.texteMuted, fontWeight: 600 }}>%</th>
-              </tr>
-            </thead>
-            <tbody>
-              {segments.map((s) => (
-                <tr key={s.id} style={{ borderTop: `0.5px solid ${c.bordure}` }}>
-                  <td style={{ padding: '6px 8px', color: c.texte }}>
-                    <span style={{
-                      display: 'inline-block', width: 8, height: 8,
-                      borderRadius: 2, background: s.color, marginRight: 8,
-                    }} />
-                    {s.label}
-                  </td>
-                  <td style={{ padding: '6px 8px', color: c.texte, textAlign: 'right' }}>{formatEur(s.value)}</td>
-                  <td style={{ padding: '6px 8px', color: c.texte, textAlign: 'right', fontWeight: 600 }}>
-                    {s.pct.toFixed(1)} %
-                  </td>
-                </tr>
-              ))}
-              <tr style={{ borderTop: `0.5px solid ${c.bordure}`, background: c.fond, fontWeight: 700 }}>
-                <td style={{ padding: '6px 8px', color: c.texte }}>Total</td>
-                <td style={{ padding: '6px 8px', color: c.texte, textAlign: 'right' }}>{formatEur(totalCaTtc)}</td>
-                <td style={{ padding: '6px 8px', color: c.texte, textAlign: 'right' }}>100 %</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      )}
+      {empty
+        ? <EmptyState c={c} />
+        : mode === 'synthese'
+          ? <SyntheseView c={c} isMobile={isMobile} segments={segments} totalCaTtc={totalCaTtc} />
+          : <DetailleView c={c} matrix={matrix} totalCaTtc={totalCaTtc} />}
     </div>
   )
+}
+
+function ModeBtn({ c, active, onClick, children }) {
+  return (
+    <button onClick={onClick} style={{
+      padding: '4px 10px', borderRadius: 16, fontSize: 11,
+      border: `1px solid ${active ? c.accent : c.bordure}`,
+      background: active ? c.accent : c.blanc,
+      color: active ? c.texte : c.texteMuted,
+      cursor: 'pointer', fontWeight: active ? 600 : 500,
+    }}>{children}</button>
+  )
+}
+
+function SyntheseView({ c, isMobile, segments, totalCaTtc }) {
+  return (
+    <div style={{
+      display: 'grid',
+      gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr',
+      gap: 16, alignItems: 'center',
+    }}>
+      <ResponsiveContainer width="100%" height={isMobile ? 200 : 240}>
+        <PieChart>
+          <Pie data={segments} dataKey="value" nameKey="label"
+            cx="50%" cy="50%" outerRadius="80%" innerRadius="55%"
+            stroke={c.blanc} strokeWidth={2}>
+            {segments.map((s) => <Cell key={s.id} fill={s.color} />)}
+          </Pie>
+          <Tooltip
+            contentStyle={{ borderRadius: 8, border: `0.5px solid ${c.bordure}`, fontSize: 12 }}
+            formatter={(v, name) => [`${formatEur(Number(v))} (${pctOf(Number(v), totalCaTtc)})`, name]}
+          />
+          <Legend iconSize={10} wrapperStyle={{ fontSize: 11 }} />
+        </PieChart>
+      </ResponsiveContainer>
+
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+        <thead>
+          <tr>
+            <th style={{ textAlign: 'left',  padding: '6px 8px', color: c.texteMuted, fontWeight: 600 }}>Catégorie</th>
+            <th style={{ textAlign: 'right', padding: '6px 8px', color: c.texteMuted, fontWeight: 600 }}>CA TTC</th>
+            <th style={{ textAlign: 'right', padding: '6px 8px', color: c.texteMuted, fontWeight: 600 }}>%</th>
+          </tr>
+        </thead>
+        <tbody>
+          {segments.map((s) => (
+            <tr key={s.id} style={{ borderTop: `0.5px solid ${c.bordure}` }}>
+              <td style={{ padding: '6px 8px', color: c.texte }}>
+                <span style={{
+                  display: 'inline-block', width: 8, height: 8,
+                  borderRadius: 2, background: s.color, marginRight: 8,
+                }} />
+                {s.label}
+              </td>
+              <td style={{ padding: '6px 8px', color: c.texte, textAlign: 'right' }}>{formatEur(s.value)}</td>
+              <td style={{ padding: '6px 8px', color: c.texte, textAlign: 'right', fontWeight: 600 }}>
+                {s.pct.toFixed(1)} %
+              </td>
+            </tr>
+          ))}
+          <tr style={{ borderTop: `0.5px solid ${c.bordure}`, background: c.fond, fontWeight: 700 }}>
+            <td style={{ padding: '6px 8px', color: c.texte }}>Total</td>
+            <td style={{ padding: '6px 8px', color: c.texte, textAlign: 'right' }}>{formatEur(totalCaTtc)}</td>
+            <td style={{ padding: '6px 8px', color: c.texte, textAlign: 'right' }}>100 %</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function DetailleView({ c, matrix, totalCaTtc }) {
+  if (!matrix || matrix.every((m) => m.ttc === 0)) {
+    return <EmptyState c={c} />
+  }
+  const th = { textAlign: 'right', padding: '8px 10px', color: c.texteMuted, fontWeight: 600, fontSize: 12, borderBottom: `1px solid ${c.bordure}` }
+  const thLeft = { ...th, textAlign: 'left' }
+  const td = { textAlign: 'right', padding: '8px 10px', color: c.texte, fontSize: 12, borderBottom: `1px solid ${c.bordure}`, fontVariantNumeric: 'tabular-nums' }
+  const tdLeft = { ...td, textAlign: 'left', fontWeight: 500 }
+  return (
+    <div style={{ overflowX: 'auto' }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 480 }}>
+        <thead>
+          <tr>
+            <th style={thLeft}>Service</th>
+            <th style={th}>Food</th>
+            <th style={th}>Alcool</th>
+            <th style={th}>Soft</th>
+            <th style={th}>Autres</th>
+            <th style={th}>Total service</th>
+          </tr>
+        </thead>
+        <tbody>
+          {matrix.map((m) => (
+            <tr key={m.service}>
+              <td style={tdLeft}>{m.label}</td>
+              <td style={td}>{m.pctFood.toFixed(1)} %<br/><Sub c={c}>{formatEur(m.food)}</Sub></td>
+              <td style={td}>{m.pctBev20.toFixed(1)} %<br/><Sub c={c}>{formatEur(m.bev20)}</Sub></td>
+              <td style={td}>{m.pctBev10.toFixed(1)} %<br/><Sub c={c}>{formatEur(m.bev10)}</Sub></td>
+              <td style={td}>{m.pctAutre.toFixed(1)} %<br/><Sub c={c}>{formatEur(m.autre)}</Sub></td>
+              <td style={{ ...td, fontWeight: 700 }}>{m.pctTotal.toFixed(1)} %<br/><Sub c={c}>{formatEur(m.ttc)}</Sub></td>
+            </tr>
+          ))}
+          <tr style={{ background: c.fond, fontWeight: 700 }}>
+            <td style={tdLeft}>Total</td>
+            <td style={td}>{summedPct(matrix, 'pctFood').toFixed(1)} %</td>
+            <td style={td}>{summedPct(matrix, 'pctBev20').toFixed(1)} %</td>
+            <td style={td}>{summedPct(matrix, 'pctBev10').toFixed(1)} %</td>
+            <td style={td}>{summedPct(matrix, 'pctAutre').toFixed(1)} %</td>
+            <td style={td}>100 %<br/><Sub c={c}>{formatEur(totalCaTtc)}</Sub></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function summedPct(matrix, key) {
+  return matrix.reduce((s, m) => s + m[key], 0)
+}
+
+function Sub({ c, children }) {
+  return <span style={{ color: c.texteMuted, fontWeight: 400, fontSize: 11 }}>{children}</span>
 }
 
 function pctOf(v, total) {

--- a/components/analyses/widgets/SectionPerfJourSemaine.js
+++ b/components/analyses/widgets/SectionPerfJourSemaine.js
@@ -6,12 +6,14 @@ import {
 } from 'recharts'
 
 // Bar chart : moyenne CA TTC et moyenne couverts par jour de la semaine
-// (lundi → dimanche), uniquement sur les jours où il y a eu de la data.
+// (lundi → dimanche). En mode split, 1 bar groupée par lieu/service par jour.
 //
-// `perf` = sortie de perfByWeekday(daysWithBudget) :
-//   [{ isoJds, label, ca, cv, tm, count, … }]
-export default function SectionPerfJourSemaine({ c, isMobile, perf }) {
-  const empty = !perf || perf.every((p) => p.count === 0)
+// `perf` (cumulé) : sortie de perfByWeekday(daysWithBudget)
+// `perfMulti` (split) : { series: [...], data: [{ label, ['Salle']: 150, … }] }
+export default function SectionPerfJourSemaine({ c, isMobile, perf, perfMulti, isSplit }) {
+  const empty = isSplit
+    ? !perfMulti || perfMulti.data.every((p) => Object.keys(p).filter((k) => k !== 'label' && k !== 'isoJds').length === 0)
+    : !perf || perf.every((p) => p.count === 0)
   return (
     <div style={{
       background: c.blanc, borderRadius: 12,
@@ -21,36 +23,64 @@ export default function SectionPerfJourSemaine({ c, isMobile, perf }) {
       <div style={{ marginBottom: 12 }}>
         <div style={{ fontSize: 14, fontWeight: 600, color: c.texte }}>Performance par jour de la semaine</div>
         <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 2 }}>
-          Moyenne CA TTC et couverts (jours fermés ignorés)
+          {isSplit ? 'CA TTC moyen par série' : 'Moyenne CA TTC et couverts (jours fermés ignorés)'}
         </div>
       </div>
-      {empty ? (
-        <EmptyState c={c} />
-      ) : (
-        <ResponsiveContainer width="100%" height={isMobile ? 220 : 280}>
-          <BarChart data={perf} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke={c.bordure} />
-            <XAxis dataKey="label" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false}
-              tickFormatter={(v) => v.slice(0, 3)} />
-            <YAxis yAxisId="left" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false}
-              tickFormatter={(v) => v >= 1000 ? `${Math.round(v / 1000)} k€` : `${Math.round(v)} €`} />
-            <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} />
-            <Tooltip
-              contentStyle={{ borderRadius: 8, border: `0.5px solid ${c.bordure}`, fontSize: 12 }}
-              formatter={(v, name) => {
-                if (name === 'CA TTC moyen') return [formatTooltipEur(v), name]
-                if (name === 'Couverts moyens') return [`${Math.round(Number(v))}`, name]
-                return [v, name]
-              }}
-            />
-            <Legend iconSize={10} wrapperStyle={{ fontSize: 11 }} />
-            <Bar yAxisId="left" dataKey="ca" name="CA TTC moyen" fill={c.accent} radius={[4, 4, 0, 0]} />
-            <Bar yAxisId="right" dataKey="cv" name="Couverts moyens" fill={c.violet} radius={[4, 4, 0, 0]} />
-          </BarChart>
-        </ResponsiveContainer>
-      )}
+      {empty ? <EmptyState c={c} />
+        : isSplit ? <MultiBarChart c={c} isMobile={isMobile} perfMulti={perfMulti} />
+        : <CumulatedBarChart c={c} isMobile={isMobile} perf={perf} />}
     </div>
   )
+}
+
+function CumulatedBarChart({ c, isMobile, perf }) {
+  return (
+    <ResponsiveContainer width="100%" height={isMobile ? 220 : 280}>
+      <BarChart data={perf} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke={c.bordure} />
+        <XAxis dataKey="label" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false}
+          tickFormatter={(v) => v.slice(0, 3)} />
+        <YAxis yAxisId="left" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false}
+          tickFormatter={(v) => v >= 1000 ? `${Math.round(v / 1000)} k€` : `${Math.round(v)} €`} />
+        <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false} />
+        <Tooltip contentStyle={{ borderRadius: 8, border: `0.5px solid ${c.bordure}`, fontSize: 12 }}
+          formatter={(v, name) => {
+            if (name === 'CA TTC moyen') return [formatTooltipEur(v), name]
+            if (name === 'Couverts moyens') return [`${Math.round(Number(v))}`, name]
+            return [v, name]
+          }} />
+        <Legend iconSize={10} wrapperStyle={{ fontSize: 11 }} />
+        <Bar yAxisId="left" dataKey="ca" name="CA TTC moyen" fill={c.accent} radius={[4, 4, 0, 0]} />
+        <Bar yAxisId="right" dataKey="cv" name="Couverts moyens" fill={c.violet} radius={[4, 4, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+function MultiBarChart({ c, isMobile, perfMulti }) {
+  const { series, data } = perfMulti
+  return (
+    <ResponsiveContainer width="100%" height={isMobile ? 240 : 320}>
+      <BarChart data={data} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke={c.bordure} />
+        <XAxis dataKey="label" tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false}
+          tickFormatter={(v) => v.slice(0, 3)} />
+        <YAxis tick={{ fontSize: 10, fill: c.texteMuted }} axisLine={false} tickLine={false}
+          tickFormatter={(v) => v >= 1000 ? `${Math.round(v / 1000)} k€` : `${Math.round(v)} €`} />
+        <Tooltip contentStyle={{ borderRadius: 8, border: `0.5px solid ${c.bordure}`, fontSize: 12 }}
+          formatter={(v, name) => [formatTooltipEur(v), name]} />
+        <Legend iconSize={10} wrapperStyle={{ fontSize: 11 }} />
+        {series.map((s, i) => (
+          <Bar key={s} dataKey={s} name={s} fill={seriesColor(c, i)} radius={[4, 4, 0, 0]} />
+        ))}
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+function seriesColor(c, i) {
+  const palette = [c.accent, c.violet, c.orange, c.vert, c.rouge, c.principal]
+  return palette[i % palette.length]
 }
 
 function formatTooltipEur(v) {

--- a/components/analyses/widgets/SectionTableauJourJour.js
+++ b/components/analyses/widgets/SectionTableauJourJour.js
@@ -1,32 +1,38 @@
 import Link from 'next/link'
-import { formatEur, formatEur2, formatDeltaEur } from '../../../lib/caAnalyses'
+import { useMemo } from 'react'
+import {
+  formatEur, formatEur2, formatDeltaEur,
+  rowsByDayAndSerie,
+} from '../../../lib/caAnalyses'
 
 const JOURS_FR = ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi']
 
-// Tableau dense jour par jour pour la période sélectionnée. Reprend le format
-// de la vue mensuelle /controle-gestion/ventes (couv midi/soir + CA Food /
-// Alcool / Soft / Autres + total + Δ Budget coloré + TM) mais agnostique
-// quant aux dates (on consomme `days` déjà calculé par la page).
-//
-// `days` : sortie de aggregateByDay() + un champ `budget` ajouté par la page
-// (somme des budgets journaliers pour ce jour-de-semaine).
-export default function SectionTableauJourJour({ c, isMobile, days, totals }) {
-  const cellPad = isMobile ? '8px 6px' : '10px 12px'
-  const headPad = isMobile ? '10px 6px' : '12px 12px'
-  const baseFont = isMobile ? 12 : 13
-
-  const head = {
-    padding: headPad, fontSize: baseFont - 1, fontWeight: 600,
-    color: c.texteMuted, textTransform: 'uppercase', letterSpacing: 0.4,
-    textAlign: 'right', background: c.fond,
-    borderBottom: `1px solid ${c.bordure}`, whiteSpace: 'nowrap',
+// Tableau dense jour par jour pour la période sélectionnée. Deux modes :
+//   - cumulé (isSplit=false) : 1 ligne par jour avec couv midi/soir
+//   - split (isSplit=true) : 1 ligne par (jour × série) avec colonnes Lieu
+//     et/ou Service ajoutées en tête. Le Δ Budget reste calculé au niveau
+//     du jour entier (le budget par lieu × service serait techniquement
+//     possible mais sortirait du scope PR 6).
+export default function SectionTableauJourJour({
+  c, isMobile, days, totals,
+  isSplit, splitByLieu, splitByService, filteredRows, lieuxLabels,
+}) {
+  if (isSplit) {
+    return (
+      <SplitTable
+        c={c} isMobile={isMobile}
+        filteredRows={filteredRows} lieuxLabels={lieuxLabels}
+        splitByLieu={splitByLieu} splitByService={splitByService}
+      />
+    )
   }
-  const cell = {
-    padding: cellPad, fontSize: baseFont, color: c.texte,
-    textAlign: 'right', borderBottom: `1px solid ${c.bordure}`,
-    whiteSpace: 'nowrap',
-  }
+  return <CumulatedTable c={c} isMobile={isMobile} days={days} totals={totals} />
+}
 
+// ── Vue cumulée (mode original) ──────────────────────────────────────────────
+
+function CumulatedTable({ c, isMobile, days, totals }) {
+  const { head, cell, baseFont } = makeStyles(c, isMobile)
   return (
     <div style={{
       background: c.blanc, borderRadius: '12px',
@@ -58,13 +64,10 @@ export default function SectionTableauJourJour({ c, isMobile, days, totals }) {
           </thead>
           <tbody>
             {days.map((d) => (
-              <tr
-                key={d.iso}
-                style={{
-                  background: d.jsWeekday === 0 || d.jsWeekday === 6 ? c.fond : 'transparent',
-                  opacity: d.hasData ? 1 : 0.55,
-                }}
-              >
+              <tr key={d.iso} style={{
+                background: d.jsWeekday === 0 || d.jsWeekday === 6 ? c.fond : 'transparent',
+                opacity: d.hasData ? 1 : 0.55,
+              }}>
                 <td style={{ ...cell, textAlign: 'left', fontWeight: 500 }}>{d.iso.slice(8)}/{d.iso.slice(5, 7)}</td>
                 <td style={{ ...cell, textAlign: 'left', color: c.texteMuted }}>{JOURS_FR[d.jsWeekday].slice(0, 3)}</td>
                 <td style={cell}>{d.lunchCouverts || '—'}</td>
@@ -74,9 +77,7 @@ export default function SectionTableauJourJour({ c, isMobile, days, totals }) {
                 <td style={cell}>{formatEur(d.bev_10)}</td>
                 <td style={cell}>{formatEur(d.autre)}</td>
                 <td style={{ ...cell, fontWeight: 600 }}>{formatEur(d.caTot)}</td>
-                <td style={budgetCellStyle(d, cell, c)} title={budgetCellTitle(d)}>
-                  {budgetCellLabel(d)}
-                </td>
+                <td style={budgetCellStyle(d, cell, c)} title={budgetCellTitle(d)}>{budgetCellLabel(d)}</td>
                 <td style={cell}>{formatEur2(d.tm)}</td>
                 <td style={{ ...cell, padding: '4px 8px' }}>
                   <Link
@@ -117,6 +118,150 @@ export default function SectionTableauJourJour({ c, isMobile, days, totals }) {
       </div>
     </div>
   )
+}
+
+// ── Vue split : 1 ligne par (jour × série) ──────────────────────────────────
+
+function SplitTable({ c, isMobile, filteredRows, lieuxLabels, splitByLieu, splitByService }) {
+  const splitDims = []
+  if (splitByLieu) splitDims.push('lieu')
+  if (splitByService) splitDims.push('service')
+  // Pas de date début/fin nécessaire ici : on agrège seulement les rows existantes
+  // (les jours sans data n'ont pas d'intérêt en mode split — on évite d'afficher
+  // un cartésien jour × lieu × service vide).
+  const rows = useMemo(() => {
+    const map = new Map()
+    for (const r of filteredRows) {
+      const lieuLabel = lieuxLabels.get(r.lieu_service_id) || r.lieu_service_id || '—'
+      const serviceLabel = r.service === 'lunch' ? 'Déjeuner' : 'Dîner'
+      const parts = []
+      if (splitByLieu) parts.push(lieuLabel)
+      if (splitByService) parts.push(serviceLabel)
+      const serieKey = parts.join(' / ')
+      const key = `${r.jour}__${serieKey}`
+      if (!map.has(key)) {
+        map.set(key, {
+          iso: r.jour, lieu: lieuLabel, service: serviceLabel, serie: serieKey,
+          couverts: 0, food: 0, bev_20: 0, bev_10: 0, autre: 0,
+        })
+      }
+      const acc = map.get(key)
+      acc.couverts += Number(r.couverts || 0)
+      acc.food += Number(r.ca_food || 0)
+      acc.bev_20 += Number(r.ca_bev_20 || 0)
+      acc.bev_10 += Number(r.ca_bev_10 || 0)
+      acc.autre += Number(r.ca_autre || 0)
+    }
+    return Array.from(map.values())
+      .map((v) => {
+        const caTot = v.food + v.bev_20 + v.bev_10 + v.autre
+        const tm = v.couverts > 0 ? caTot / v.couverts : null
+        const date = new Date(`${v.iso}T00:00:00`)
+        return { ...v, caTot, tm, jsWeekday: date.getDay() }
+      })
+      .sort((a, b) => a.iso !== b.iso ? a.iso.localeCompare(b.iso) : a.serie.localeCompare(b.serie, 'fr'))
+  }, [filteredRows, lieuxLabels, splitByLieu, splitByService])
+
+  const totals = useMemo(() => {
+    const t = { couverts: 0, food: 0, bev_20: 0, bev_10: 0, autre: 0 }
+    for (const r of rows) {
+      t.couverts += r.couverts
+      t.food += r.food
+      t.bev_20 += r.bev_20
+      t.bev_10 += r.bev_10
+      t.autre += r.autre
+    }
+    t.caTtc = t.food + t.bev_20 + t.bev_10 + t.autre
+    t.tm = t.couverts > 0 ? t.caTtc / t.couverts : null
+    return t
+  }, [rows])
+
+  const { head, cell } = makeStyles(c, isMobile)
+
+  return (
+    <div style={{
+      background: c.blanc, borderRadius: '12px',
+      border: `0.5px solid ${c.bordure}`, overflow: 'hidden',
+    }}>
+      <div style={{ padding: isMobile ? '12px 14px' : '16px 20px', borderBottom: `0.5px solid ${c.bordure}` }}>
+        <div style={{ fontSize: 14, fontWeight: 600, color: c.texte }}>Détail jour par jour</div>
+        <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 2 }}>
+          {rows.length} ligne{rows.length > 1 ? 's' : ''} (1 par jour × {splitDims.join(' × ')})
+        </div>
+      </div>
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 760 }}>
+          <thead>
+            <tr>
+              <th style={{ ...head, textAlign: 'left' }}>Date</th>
+              <th style={{ ...head, textAlign: 'left' }}>Jour</th>
+              {splitByLieu && <th style={{ ...head, textAlign: 'left' }}>Lieu</th>}
+              {splitByService && <th style={{ ...head, textAlign: 'left' }}>Service</th>}
+              <th style={head}>Couverts</th>
+              <th style={head}>CA Food</th>
+              <th style={head}>CA Alcool</th>
+              <th style={head}>CA Soft</th>
+              <th style={head}>Autres</th>
+              <th style={head}>CA Total</th>
+              <th style={head}>TM</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r, i) => (
+              <tr key={`${r.iso}__${r.serie}__${i}`} style={{
+                background: r.jsWeekday === 0 || r.jsWeekday === 6 ? c.fond : 'transparent',
+              }}>
+                <td style={{ ...cell, textAlign: 'left', fontWeight: 500 }}>{r.iso.slice(8)}/{r.iso.slice(5, 7)}</td>
+                <td style={{ ...cell, textAlign: 'left', color: c.texteMuted }}>{JOURS_FR[r.jsWeekday].slice(0, 3)}</td>
+                {splitByLieu && <td style={{ ...cell, textAlign: 'left' }}>{r.lieu}</td>}
+                {splitByService && <td style={{ ...cell, textAlign: 'left', color: c.texteMuted }}>{r.service}</td>}
+                <td style={cell}>{r.couverts || '—'}</td>
+                <td style={cell}>{formatEur(r.food)}</td>
+                <td style={cell}>{formatEur(r.bev_20)}</td>
+                <td style={cell}>{formatEur(r.bev_10)}</td>
+                <td style={cell}>{formatEur(r.autre)}</td>
+                <td style={{ ...cell, fontWeight: 600 }}>{formatEur(r.caTot)}</td>
+                <td style={cell}>{formatEur2(r.tm)}</td>
+              </tr>
+            ))}
+          </tbody>
+          <tfoot>
+            <tr style={{ background: c.fond, fontWeight: 600 }}>
+              <td style={{ ...cell, textAlign: 'left' }} colSpan={2 + (splitByLieu ? 1 : 0) + (splitByService ? 1 : 0)}>Total période</td>
+              <td style={cell}>{totals.couverts || '—'}</td>
+              <td style={cell}>{formatEur(totals.food)}</td>
+              <td style={cell}>{formatEur(totals.bev_20)}</td>
+              <td style={cell}>{formatEur(totals.bev_10)}</td>
+              <td style={cell}>{formatEur(totals.autre)}</td>
+              <td style={{ ...cell, fontWeight: 700 }}>{formatEur(totals.caTtc)}</td>
+              <td style={cell}>{formatEur2(totals.tm)}</td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+// ── Styles partagés ──────────────────────────────────────────────────────────
+function makeStyles(c, isMobile) {
+  const cellPad = isMobile ? '8px 6px' : '10px 12px'
+  const headPad = isMobile ? '10px 6px' : '12px 12px'
+  const baseFont = isMobile ? 12 : 13
+  return {
+    head: {
+      padding: headPad, fontSize: baseFont - 1, fontWeight: 600,
+      color: c.texteMuted, textTransform: 'uppercase', letterSpacing: 0.4,
+      textAlign: 'right', background: c.fond,
+      borderBottom: `1px solid ${c.bordure}`, whiteSpace: 'nowrap',
+    },
+    cell: {
+      padding: cellPad, fontSize: baseFont, color: c.texte,
+      textAlign: 'right', borderBottom: `1px solid ${c.bordure}`,
+      whiteSpace: 'nowrap',
+    },
+    baseFont,
+  }
 }
 
 // ── Helpers Δ Budget (mêmes règles que /controle-gestion/ventes) ────────────
@@ -168,3 +313,8 @@ function totalBudgetCellTitle(totals) {
   const ratio = totals.caTtc > 0 ? (totals.caTtc / totals.budget) * 100 : 0
   return `Réel ${formatEur(totals.caTtc)} / Budget ${formatEur(totals.budget)} (${ratio.toFixed(0)} %)`
 }
+
+// rowsByDayAndSerie est exposé en helper public (utile pour Excel + tests)
+// mais n'est pas consommé directement ici car SplitTable optimise sa propre
+// agrégation. Ré-exporté au cas où des tests l'importent depuis caAnalyses.
+void rowsByDayAndSerie

--- a/lib/__tests__/analysesExport.test.ts
+++ b/lib/__tests__/analysesExport.test.ts
@@ -17,16 +17,18 @@ describe('buildPeriodSheetRows', () => {
   it('produit une ligne par champ traçabilité', () => {
     const rows = buildPeriodSheetRows({
       periode: 'mois-en-cours', dateDebut: '2026-05-01', dateFin: '2026-05-09',
-      comparaison: 'n-1', lieuLabel: 'Salle', service: 'lunch', granularity: 'day',
+      comparaison: 'n-1', lieuLabel: 'Salle', service: 'lunch', joursLabel: 'Mardi',
+      granularity: 'day',
       generatedAt: new Date(2026, 4, 9, 14, 30),
     })
-    expect(rows).toHaveLength(8)
+    expect(rows).toHaveLength(9)
     const map = Object.fromEntries(rows.map((r) => [r.Champ, r.Valeur]))
     expect(map['Période']).toBe('Mois en cours')
     expect(map['Date début']).toBe('2026-05-01')
     expect(map['Comparaison']).toBe('vs même période N-1')
     expect(map['Lieu']).toBe('Salle')
     expect(map['Service']).toBe('Déjeuner')
+    expect(map['Jours de semaine']).toBe('Mardi')
     expect(map['Granularité auto']).toBe('Jour')
   })
 })

--- a/lib/__tests__/caAnalyses.test.ts
+++ b/lib/__tests__/caAnalyses.test.ts
@@ -12,6 +12,11 @@ import {
   perfByWeekday,
   mixSegments,
   topBottomDays,
+  aggregateBySerie,
+  buildBreakdown,
+  mixByService,
+  bucketDaysMultiSeries,
+  perfByWeekdayMultiSeries,
   TVA_FOOD,
   TVA_BEV_20,
 } from '../caAnalyses'
@@ -286,5 +291,105 @@ describe('topBottomDays', () => {
     expect(top.length + bottom.length).toBeLessThanOrEqual(8) // 4 jours avec data
     expect(top.every((d) => d.hasData)).toBe(true)
     expect(bottom.every((d) => d.hasData)).toBe(true)
+  })
+})
+
+describe('aggregateBySerie', () => {
+  const lieuxLabels = new Map([['L1', 'Salle'], ['L2', 'Privat']])
+  const rows = [
+    { lieu_service_id: 'L1', service: 'lunch',  couverts: 10, ca_food: 100, ca_bev_20: 0, ca_bev_10: 0, ca_autre: 0 },
+    { lieu_service_id: 'L1', service: 'dinner', couverts: 20, ca_food: 200, ca_bev_20: 0, ca_bev_10: 0, ca_autre: 0 },
+    { lieu_service_id: 'L2', service: 'lunch',  couverts: 5,  ca_food: 50,  ca_bev_20: 0, ca_bev_10: 0, ca_autre: 0 },
+  ]
+
+  it('split par lieu : 1 entrée par lieu, totals agrégés', () => {
+    const m = aggregateBySerie(rows, ['lieu'], lieuxLabels)
+    expect(m.size).toBe(2)
+    expect(m.get('Salle').couverts).toBe(30)
+    expect(m.get('Salle').caTtc).toBe(300)
+    expect(m.get('Privat').couverts).toBe(5)
+  })
+
+  it('split par service : 1 entrée par service', () => {
+    const m = aggregateBySerie(rows, ['service'], lieuxLabels)
+    expect(m.get('Déjeuner').couverts).toBe(15)
+    expect(m.get('Dîner').couverts).toBe(20)
+  })
+
+  it('split lieu × service : produit cartésien des combinaisons rencontrées', () => {
+    const m = aggregateBySerie(rows, ['lieu', 'service'], lieuxLabels)
+    expect(m.size).toBe(3) // L1/lunch, L1/dinner, L2/lunch
+    expect(m.get('Salle / Déjeuner').couverts).toBe(10)
+    expect(m.get('Salle / Dîner').couverts).toBe(20)
+    expect(m.get('Privat / Déjeuner').couverts).toBe(5)
+  })
+
+  it('splitDims vide : 1 seule entrée __all__', () => {
+    const m = aggregateBySerie(rows, [], lieuxLabels)
+    expect(m.size).toBe(1)
+    expect(m.get('__all__').couverts).toBe(35)
+  })
+})
+
+describe('buildBreakdown', () => {
+  it('renvoie les % par série, triés décroissant', () => {
+    const series = new Map([
+      ['Salle', { caTtc: 600, couverts: 60 }],
+      ['Privat', { caTtc: 400, couverts: 40 }],
+    ])
+    const bd = buildBreakdown(series, 'caTtc')
+    expect(bd[0]).toEqual({ serie: 'Salle', value: 600, pct: 60 })
+    expect(bd[1]).toEqual({ serie: 'Privat', value: 400, pct: 40 })
+  })
+
+  it('renvoie pct=0 partout si total=0', () => {
+    const series = new Map([['A', { caTtc: 0 }], ['B', { caTtc: 0 }]])
+    const bd = buildBreakdown(series, 'caTtc')
+    expect(bd.every((e) => e.pct === 0)).toBe(true)
+  })
+})
+
+describe('mixByService', () => {
+  it('matrice 2 services × 4 catégories en pourcentages du grand total', () => {
+    const rows = [
+      { service: 'lunch',  ca_food: 65, ca_bev_20: 28, ca_bev_10: 7, ca_autre: 0 },
+      { service: 'dinner', ca_food: 65, ca_bev_20: 28, ca_bev_10: 7, ca_autre: 0 },
+    ]
+    const mix = mixByService(rows)
+    expect(mix).toHaveLength(2)
+    const lunch = mix.find((m) => m.service === 'lunch')
+    expect(lunch.ttc).toBe(100)
+    expect(lunch.pctFood).toBeCloseTo(32.5, 5) // 65 / 200
+    expect(lunch.pctTotal).toBeCloseTo(50, 5)
+  })
+})
+
+describe('bucketDaysMultiSeries', () => {
+  it('fusionne plusieurs séries au même bucket', () => {
+    const daysSalle = [
+      { iso: '2026-05-01', isoJds: 5, jsWeekday: 5, caTot: 100, couvertsTot: 10, hasData: true },
+    ]
+    const daysPrivat = [
+      { iso: '2026-05-01', isoJds: 5, jsWeekday: 5, caTot: 50, couvertsTot: 5, hasData: true },
+    ]
+    const daysBySerie = new Map([['Salle', daysSalle], ['Privat', daysPrivat]])
+    const { series, buckets } = bucketDaysMultiSeries(daysBySerie, 'day', 'caTot')
+    expect(series).toEqual(['Salle', 'Privat'])
+    expect(buckets).toHaveLength(1)
+    expect(buckets[0]['Salle']).toBe(100)
+    expect(buckets[0]['Privat']).toBe(50)
+  })
+})
+
+describe('perfByWeekdayMultiSeries', () => {
+  it('moyennes par jour-semaine ET par série', () => {
+    const days = [
+      { iso: '2026-05-04', isoJds: 1, caTot: 200, couvertsTot: 20, hasData: true }, // lundi
+      { iso: '2026-05-11', isoJds: 1, caTot: 100, couvertsTot: 10, hasData: true }, // lundi
+    ]
+    const daysBySerie = new Map([['Salle', days]])
+    const { data } = perfByWeekdayMultiSeries(daysBySerie, 'ca')
+    expect(data[0].label).toBe('Lundi')
+    expect(data[0]['Salle']).toBe(150) // (200 + 100) / 2
   })
 })

--- a/lib/__tests__/caAnalyses.test.ts
+++ b/lib/__tests__/caAnalyses.test.ts
@@ -167,6 +167,17 @@ describe('periodBudgetTotal', () => {
     const total = periodBudgetTotal({ 2025: rows2025, 2026: rows2026 }, '2025-12-31', '2026-01-01')
     expect(total).toBe(300)
   })
+
+  it('filtre par jour-de-semaine si isoJdsFilter fourni', () => {
+    // Lundi et mardi avec budget différent — filtrer sur lundi seul
+    const rows = [
+      { jour_semaine: 1, lieu_service_id: 'L1', service: 'lunch', mois: null, ca_food_cible: 100, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+      { jour_semaine: 2, lieu_service_id: 'L1', service: 'lunch', mois: null, ca_food_cible: 200, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+    ]
+    // Période 2026-05-04 → 2026-05-05 (lundi puis mardi). Filtre = lundi seulement.
+    const total = periodBudgetTotal({ 2026: rows }, '2026-05-04', '2026-05-05', new Set([1]))
+    expect(total).toBe(100)
+  })
 })
 
 describe('pickGranularity', () => {

--- a/lib/analysesExport.js
+++ b/lib/analysesExport.js
@@ -37,7 +37,7 @@ const SERVICE_LABELS = {
 // ─── Builders d'onglets (purs : prennent les data brutes, renvoient
 //     des arrays de records adaptés à XLSX.utils.json_to_sheet) ──────────────
 
-export function buildPeriodSheetRows({ periode, dateDebut, dateFin, comparaison, lieuLabel, service, granularity, generatedAt = new Date() }) {
+export function buildPeriodSheetRows({ periode, dateDebut, dateFin, comparaison, lieuLabel, service, joursLabel, granularity, generatedAt = new Date() }) {
   return [
     { Champ: 'Date d\'export',   Valeur: formatDateTime(generatedAt) },
     { Champ: 'Période',          Valeur: PERIODE_LABELS[periode] || periode },
@@ -46,6 +46,7 @@ export function buildPeriodSheetRows({ periode, dateDebut, dateFin, comparaison,
     { Champ: 'Comparaison',      Valeur: COMPARAISON_LABELS[comparaison] || comparaison },
     { Champ: 'Lieu',             Valeur: lieuLabel || 'Tous lieux' },
     { Champ: 'Service',          Valeur: SERVICE_LABELS[service] || service },
+    { Champ: 'Jours de semaine', Valeur: joursLabel || 'Tous' },
     { Champ: 'Granularité auto', Valeur: granularity === 'day' ? 'Jour' : granularity === 'week' ? 'Semaine' : 'Mois' },
   ]
 }
@@ -278,7 +279,7 @@ export function buildChartsMargesSheetRows(margesChartData) {
 // Renvoie un objet XLSX workbook (testable) — le caller fait XLSX.writeFile.
 export function buildAnalysesWorkbook(opts) {
   const {
-    visibleIds, periode, dateDebut, dateFin, comparaison, lieuLabel, service,
+    visibleIds, periode, dateDebut, dateFin, comparaison, lieuLabel, service, joursLabel,
     totals, comparisonTotals, comparisonLabel, periodBudget,
     buckets, granularity, perfWeekday, mix, topBottom, daysWithBudget,
     // PR 5 — données marges (peuvent être absentes si aucun widget marges visible)
@@ -293,7 +294,7 @@ export function buildAnalysesWorkbook(opts) {
 
   // Onglet 1 : Période & filtres (toujours présent)
   const periodSheet = XLSX.utils.json_to_sheet(buildPeriodSheetRows({
-    periode, dateDebut, dateFin, comparaison, lieuLabel, service, granularity,
+    periode, dateDebut, dateFin, comparaison, lieuLabel, service, joursLabel, granularity,
   }))
   XLSX.utils.book_append_sheet(wb, periodSheet, 'Période & filtres')
 

--- a/lib/analysesExport.js
+++ b/lib/analysesExport.js
@@ -81,11 +81,36 @@ export function buildEvolutionCaSheetRows(buckets) {
   }))
 }
 
+// PR 6 — Variante multi-séries : 1 ligne par (période, série) pour donner
+// à l'user la même donnée que celle qu'il voit sur le line chart.
+// `bucketsMulti` = { series: [...], buckets: [{ key, label, ['Salle']: …, ['Privat']: … }] }
+export function buildEvolutionCaMultiSheetRows(bucketsMulti) {
+  if (!bucketsMulti) return []
+  const out = []
+  for (const b of bucketsMulti.buckets) {
+    for (const serie of bucketsMulti.series) {
+      out.push({ Période: b.label, Série: serie, 'CA TTC réel': round(b[serie] || 0) })
+    }
+  }
+  return out
+}
+
 export function buildEvolutionCouvertsSheetRows(buckets) {
   return buckets.map((b) => ({
     Période: b.label,
     Couverts: b.couverts || 0,
   }))
+}
+
+export function buildEvolutionCouvertsMultiSheetRows(bucketsMulti) {
+  if (!bucketsMulti) return []
+  const out = []
+  for (const b of bucketsMulti.buckets) {
+    for (const serie of bucketsMulti.series) {
+      out.push({ Période: b.label, Série: serie, Couverts: b[serie] || 0 })
+    }
+  }
+  return out
 }
 
 export function buildPerfJourSemaineSheetRows(perf) {
@@ -96,6 +121,73 @@ export function buildPerfJourSemaineSheetRows(perf) {
     'Couverts moyens': Math.round(p.cv),
     'Ticket moyen': p.tm != null ? round2(p.tm) : '',
   }))
+}
+
+export function buildPerfJourSemaineMultiSheetRows(perfMulti) {
+  if (!perfMulti) return []
+  const out = []
+  for (const row of perfMulti.data) {
+    for (const serie of perfMulti.series) {
+      out.push({ Jour: row.label, Série: serie, 'CA TTC moyen': row[serie] || 0 })
+    }
+  }
+  return out
+}
+
+// PR 6 — Mix détaillé service × catégorie en %
+export function buildMixDetailleSheetRows(matrix, totalCaTtc) {
+  if (!matrix) return []
+  const out = matrix.map((m) => ({
+    Service: m.label,
+    'Food (€)': round(m.food),       'Food (%)': `${m.pctFood.toFixed(1)} %`,
+    'Alcool (€)': round(m.bev20),    'Alcool (%)': `${m.pctBev20.toFixed(1)} %`,
+    'Soft (€)': round(m.bev10),      'Soft (%)': `${m.pctBev10.toFixed(1)} %`,
+    'Autres (€)': round(m.autre),    'Autres (%)': `${m.pctAutre.toFixed(1)} %`,
+    'Total service (€)': round(m.ttc),
+    'Total service (%)': `${m.pctTotal.toFixed(1)} %`,
+  }))
+  out.push({
+    Service: 'Total',
+    'Food (€)': round(matrix.reduce((s, m) => s + m.food, 0)),
+    'Food (%)': `${matrix.reduce((s, m) => s + m.pctFood, 0).toFixed(1)} %`,
+    'Alcool (€)': round(matrix.reduce((s, m) => s + m.bev20, 0)),
+    'Alcool (%)': `${matrix.reduce((s, m) => s + m.pctBev20, 0).toFixed(1)} %`,
+    'Soft (€)': round(matrix.reduce((s, m) => s + m.bev10, 0)),
+    'Soft (%)': `${matrix.reduce((s, m) => s + m.pctBev10, 0).toFixed(1)} %`,
+    'Autres (€)': round(matrix.reduce((s, m) => s + m.autre, 0)),
+    'Autres (%)': `${matrix.reduce((s, m) => s + m.pctAutre, 0).toFixed(1)} %`,
+    'Total service (€)': round(totalCaTtc),
+    'Total service (%)': '100 %',
+  })
+  return out
+}
+
+// PR 6 — Tableau jour × série quand mode split actif
+export function buildTableauJourJourSplitSheetRows(daysBySerieEntries, splitByLieu, splitByService) {
+  if (!daysBySerieEntries) return []
+  // daysBySerieEntries = [[serieKey, days[]], …] — agrège chaque day déjà
+  // dérivé par série. On reconstruit une row par (date × série).
+  const out = []
+  for (const [serie, days] of daysBySerieEntries) {
+    for (const d of days) {
+      if (!d.hasData) continue
+      out.push({
+        Date: d.iso,
+        ...(splitByLieu || splitByService ? { Série: serie } : {}),
+        Couverts: d.couvertsTot || 0,
+        'CA Food': round(d.food),
+        'CA Alcool': round(d.bev_20),
+        'CA Soft': round(d.bev_10),
+        Autres: round(d.autre),
+        'CA Total': round(d.caTot),
+        'Ticket moyen': d.tm != null ? round2(d.tm) : '',
+      })
+    }
+  }
+  return out.sort((a, b) => {
+    if (a.Date !== b.Date) return a.Date.localeCompare(b.Date)
+    return (a['Série'] || '').localeCompare(b['Série'] || '', 'fr')
+  })
 }
 
 export function buildMixSheetRows(segments) {
@@ -191,6 +283,10 @@ export function buildAnalysesWorkbook(opts) {
     buckets, granularity, perfWeekday, mix, topBottom, daysWithBudget,
     // PR 5 — données marges (peuvent être absentes si aucun widget marges visible)
     margesTotals, margesLignes, consoLignes, margesChartData,
+    // PR 6 — split lieu/service
+    isSplit, splitByLieu, splitByService,
+    bucketsMultiCa, bucketsMultiCouverts, perfMulti,
+    mixServiceMatrix, daysBySerieEntries,
   } = opts
 
   const wb = XLSX.utils.book_new()
@@ -219,14 +315,27 @@ export function buildAnalysesWorkbook(opts) {
     XLSX.utils.book_append_sheet(wb, sheet, 'Marges KPIs')
   }
 
-  // Sections : un onglet par widget visible
+  // Sections : un onglet par widget visible. En mode split, on bascule sur
+  // les variantes multi-séries qui ajoutent une colonne "Série" plutôt que
+  // de dupliquer l'onglet — l'user récupère exactement ce qu'il voit à l'écran.
   const sectionBuilders = [
-    { id: 'section-evolution-ca',       name: 'Évolution CA',          build: () => buildEvolutionCaSheetRows(buckets) },
-    { id: 'section-evolution-couverts', name: 'Évolution couverts',    build: () => buildEvolutionCouvertsSheetRows(buckets) },
-    { id: 'section-perf-jour-semaine',  name: 'Perf jour semaine',     build: () => buildPerfJourSemaineSheetRows(perfWeekday) },
-    { id: 'section-mix-food-bev',       name: 'Mix Food-Bev',          build: () => buildMixSheetRows(mix) },
-    { id: 'section-top-bottom-jours',   name: 'Top et Bottom jours',   build: () => buildTopBottomSheetRows(topBottom) },
-    { id: 'section-tableau-jour-jour',  name: 'Tableau jour par jour', build: () => buildTableauJourJourSheetRows(daysWithBudget) },
+    { id: 'section-evolution-ca',       name: 'Évolution CA',
+      build: () => isSplit ? buildEvolutionCaMultiSheetRows(bucketsMultiCa) : buildEvolutionCaSheetRows(buckets) },
+    { id: 'section-evolution-couverts', name: 'Évolution couverts',
+      build: () => isSplit ? buildEvolutionCouvertsMultiSheetRows(bucketsMultiCouverts) : buildEvolutionCouvertsSheetRows(buckets) },
+    { id: 'section-perf-jour-semaine',  name: 'Perf jour semaine',
+      build: () => isSplit ? buildPerfJourSemaineMultiSheetRows(perfMulti) : buildPerfJourSemaineSheetRows(perfWeekday) },
+    { id: 'section-mix-food-bev',       name: 'Mix Food-Bev',
+      build: () => buildMixSheetRows(mix) },
+    // PR 6 — onglet Mix détaillé ajouté en sus quand le mode est utile
+    { id: 'section-mix-food-bev',       name: 'Mix détaillé service',
+      build: () => buildMixDetailleSheetRows(mixServiceMatrix, totals.caTtc) },
+    { id: 'section-top-bottom-jours',   name: 'Top et Bottom jours',
+      build: () => buildTopBottomSheetRows(topBottom) },
+    { id: 'section-tableau-jour-jour',  name: 'Tableau jour par jour',
+      build: () => isSplit
+        ? buildTableauJourJourSplitSheetRows(daysBySerieEntries, splitByLieu, splitByService)
+        : buildTableauJourJourSheetRows(daysWithBudget) },
     // PR 5 — sections marges
     { id: 'section-charts-marges',      name: 'Marges - Évolution',    build: () => buildChartsMargesSheetRows(margesChartData || []) },
     { id: 'section-ca-par-fiche',       name: 'CA par plat',           build: () => buildCaParFicheSheetRows(margesLignes || []) },

--- a/lib/caAnalyses.js
+++ b/lib/caAnalyses.js
@@ -112,6 +112,172 @@ export function aggregateTotals(rows) {
   return { couverts, food, bev20, bev10, autre, caTtc, caHt, tm }
 }
 
+// ── Split par dimension (lieu, service, lieu × service) ────────────────────
+
+// Construit la clé d'agrégation d'une row selon les dimensions actives.
+// `lieuxLabels` = Map<lieu_service_id, nomAffichable>
+function rowSeriesKey(row, splitDims, lieuxLabels) {
+  const parts = []
+  for (const dim of splitDims) {
+    if (dim === 'lieu') parts.push(lieuxLabels?.get(row.lieu_service_id) || row.lieu_service_id || '—')
+    else if (dim === 'service') parts.push(row.service === 'lunch' ? 'Déjeuner' : 'Dîner')
+  }
+  return parts.join(' / ')
+}
+
+// Renvoie une Map<serieLabel, totals>. Permet aux widgets de rendre une
+// série par dimension active. Si splitDims est vide, renvoie une Map à 1
+// entrée (clé '__all__') pour rester homogène avec les widgets multi-séries.
+export function aggregateBySerie(rows, splitDims, lieuxLabels) {
+  const out = new Map()
+  for (const r of rows) {
+    const key = splitDims.length === 0 ? '__all__' : rowSeriesKey(r, splitDims, lieuxLabels)
+    if (!out.has(key)) out.set(key, { couverts: 0, food: 0, bev20: 0, bev10: 0, autre: 0 })
+    const acc = out.get(key)
+    acc.couverts += Number(r.couverts || 0)
+    acc.food += Number(r.ca_food || 0)
+    acc.bev20 += Number(r.ca_bev_20 || 0)
+    acc.bev10 += Number(r.ca_bev_10 || 0)
+    acc.autre += Number(r.ca_autre || 0)
+  }
+  // Calcul dérivés (caTtc, caHt, tm) sur chaque entrée
+  for (const v of out.values()) {
+    v.caTtc = v.food + v.bev20 + v.bev10 + v.autre
+    v.caHt = v.food / TVA_FOOD + v.bev20 / TVA_BEV_20 + v.bev10 / TVA_BEV_10 + v.autre / TVA_AUTRE
+    v.tm = v.couverts > 0 ? v.caTtc / v.couverts : null
+  }
+  return out
+}
+
+// Construit un breakdown { serie, value, pct } trié sur une métrique donnée.
+// `metric` parmi: 'couverts', 'caTtc', 'caHt', 'food', 'bev20', 'bev10', 'autre'
+export function buildBreakdown(seriesByGroup, metric) {
+  const entries = Array.from(seriesByGroup.entries())
+    .map(([serie, totals]) => ({ serie, value: totals[metric] || 0 }))
+  const total = entries.reduce((s, e) => s + e.value, 0)
+  if (total === 0) return entries.map((e) => ({ ...e, pct: 0 }))
+  return entries
+    .map((e) => ({ ...e, pct: (e.value / total) * 100 }))
+    .sort((a, b) => b.value - a.value)
+}
+
+// Mix Food/Bev "détaillé" : matrice (service × catégorie) en %.
+// Renvoie [{ service, food, bev20, bev10, autre, ttc, pctFood, pctBev20, ... }]
+// + un total pct par cellule par rapport au CA TTC global.
+export function mixByService(rows) {
+  const totals = { lunch: { food: 0, bev20: 0, bev10: 0, autre: 0 }, dinner: { food: 0, bev20: 0, bev10: 0, autre: 0 } }
+  for (const r of rows) {
+    const svc = r.service === 'lunch' ? 'lunch' : 'dinner'
+    totals[svc].food += Number(r.ca_food || 0)
+    totals[svc].bev20 += Number(r.ca_bev_20 || 0)
+    totals[svc].bev10 += Number(r.ca_bev_10 || 0)
+    totals[svc].autre += Number(r.ca_autre || 0)
+  }
+  const grandTotal = ['lunch', 'dinner'].reduce(
+    (s, svc) => s + totals[svc].food + totals[svc].bev20 + totals[svc].bev10 + totals[svc].autre, 0
+  )
+  const pct = (v) => grandTotal > 0 ? (v / grandTotal) * 100 : 0
+  return ['lunch', 'dinner'].map((svc) => {
+    const t = totals[svc]
+    const ttc = t.food + t.bev20 + t.bev10 + t.autre
+    return {
+      service: svc,
+      label: svc === 'lunch' ? 'Déjeuner' : 'Dîner',
+      food: t.food, bev20: t.bev20, bev10: t.bev10, autre: t.autre, ttc,
+      pctFood: pct(t.food), pctBev20: pct(t.bev20),
+      pctBev10: pct(t.bev10), pctAutre: pct(t.autre),
+      pctTotal: pct(ttc),
+    }
+  })
+}
+
+// Bucket par jour ET par série : utile pour les line charts multi-séries.
+// Retourne { buckets: [{ key, label, ['Salle']: 100, ['Privat']: 80, … }], series: [...] }
+// où chaque ligne du buckets agrège les jours de tous les groupes au même
+// timestamp puis colle une valeur par série dans le même point.
+//
+// `daysBySerie` : Map<serieLabel, days[]> où days[] est la sortie de aggregateByDay.
+export function bucketDaysMultiSeries(daysBySerie, granularity, metric = 'caTot') {
+  const series = Array.from(daysBySerie.keys())
+  // Pour chaque série, calculer ses buckets
+  const seriesBuckets = new Map()
+  for (const [serie, days] of daysBySerie.entries()) {
+    seriesBuckets.set(serie, bucketDays(days, granularity))
+  }
+  // Fusionner par bucket key
+  const merged = new Map()
+  for (const [serie, buckets] of seriesBuckets.entries()) {
+    for (const b of buckets) {
+      if (!merged.has(b.key)) {
+        merged.set(b.key, { key: b.key, label: b.label })
+      }
+      const value = metric === 'couverts' ? b.couverts : b[metric]
+      merged.get(b.key)[serie] = value
+    }
+  }
+  return {
+    series,
+    buckets: Array.from(merged.values()).sort((a, b) => a.key.localeCompare(b.key)),
+  }
+}
+
+// Tableau "split" : 1 ligne par (jour × série). Renvoie un array trié par
+// (date, série) avec colonnes lieu/service explicites quand applicable.
+export function rowsByDayAndSerie(filteredRows, debut, fin, splitDims, lieuxLabels) {
+  const map = new Map() // key = `${iso}__${serieKey}`
+  for (const r of filteredRows) {
+    const parts = []
+    if (splitDims.includes('lieu')) parts.push(lieuxLabels.get(r.lieu_service_id) || r.lieu_service_id || '—')
+    if (splitDims.includes('service')) parts.push(r.service === 'lunch' ? 'Déjeuner' : 'Dîner')
+    const serieKey = parts.join(' / ') || '—'
+    const lieuLabel = lieuxLabels.get(r.lieu_service_id) || r.lieu_service_id || '—'
+    const serviceLabel = r.service === 'lunch' ? 'Déjeuner' : 'Dîner'
+    const key = `${r.jour}__${serieKey}`
+    if (!map.has(key)) {
+      map.set(key, {
+        iso: r.jour, serie: serieKey,
+        lieu: lieuLabel, service: serviceLabel,
+        couverts: 0, food: 0, bev_20: 0, bev_10: 0, autre: 0,
+      })
+    }
+    const acc = map.get(key)
+    acc.couverts += Number(r.couverts || 0)
+    acc.food += Number(r.ca_food || 0)
+    acc.bev_20 += Number(r.ca_bev_20 || 0)
+    acc.bev_10 += Number(r.ca_bev_10 || 0)
+    acc.autre += Number(r.ca_autre || 0)
+  }
+  for (const v of map.values()) {
+    v.caTot = v.food + v.bev_20 + v.bev_10 + v.autre
+    v.tm = v.couverts > 0 ? v.caTot / v.couverts : null
+    const date = fromIsoDate(v.iso)
+    v.jsWeekday = date.getDay()
+    v.isoJds = v.jsWeekday === 0 ? 7 : v.jsWeekday
+    v.hasData = v.caTot > 0 || v.couverts > 0
+  }
+  // Tri : date ASC puis série ASC
+  return Array.from(map.values()).sort((a, b) => {
+    if (a.iso !== b.iso) return a.iso.localeCompare(b.iso)
+    return a.serie.localeCompare(b.serie, 'fr')
+  })
+}
+
+// Perf jour-de-semaine multi-séries : pour chaque jour ouvré, valeur moyenne
+// par série. Retourne [{ label: 'Lundi', ['Salle']: 150, ['Privat']: 80 }, …]
+export function perfByWeekdayMultiSeries(daysBySerie, metric = 'ca') {
+  const JOURS_LABELS = ['Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi', 'Dimanche']
+  const series = Array.from(daysBySerie.keys())
+  const result = JOURS_LABELS.map((label, i) => ({ label, isoJds: i + 1 }))
+  for (const [serie, days] of daysBySerie.entries()) {
+    const perf = perfByWeekday(days)
+    perf.forEach((p, i) => {
+      const v = metric === 'cv' ? p.cv : p.ca
+      result[i][serie] = Math.round(v)
+    })
+  }
+  return { series, data: result }
+}
+
 // ── Agrégation par jour pour le tableau jour-par-jour ───────────────────────
 
 export function aggregateByDay(rows, debut, fin) {

--- a/lib/caAnalyses.js
+++ b/lib/caAnalyses.js
@@ -470,7 +470,8 @@ export function budgetByIsoJdsForMonth(budgetRows, monthNum) {
 // Somme des budgets journaliers sur la période [debut, fin].
 // budgetRowsByYear : map { [annee]: rows[] } pour gérer les périodes
 // chevauchant deux années (ex: décembre → janvier).
-export function periodBudgetTotal(budgetRowsByYear, debut, fin) {
+// `isoJdsFilter` (optionnel) : Set<number 1..7> — ne sommer que ces jours-de-semaine.
+export function periodBudgetTotal(budgetRowsByYear, debut, fin, isoJdsFilter = null) {
   // Cache du Map par (annee, mois) pour éviter de recalculer à chaque jour
   const cache = new Map()
   const getMap = (annee, mois) => {
@@ -482,6 +483,7 @@ export function periodBudgetTotal(budgetRowsByYear, debut, fin) {
   }
   let total = 0
   for (const d of eachDayIso(debut, fin)) {
+    if (isoJdsFilter && !isoJdsFilter.has(d.isoJds)) continue
     const date = fromIsoDate(d.iso)
     const annee = date.getFullYear()
     const mois = date.getMonth() + 1


### PR DESCRIPTION
## Summary
PR 6/6 — extension du chantier « Page Analyses » pour faciliter les présentations : voir tous les lieux et les deux services en même temps, avec breakdown par dimension dans les KPIs et matrice service × catégorie en % pour le Mix Food/Bev.

### FilterBar
- Lieu et Service passent en **multi-select (chips)** avec un bouton « Tous »
- Le **mode multi-séries s'active automatiquement** quand 2+ entrées sélectionnées (ou « Tous » + plusieurs lieux disponibles)

### Widgets
| Widget | Mode split |
|---|---|
| KPIs (Couverts, CA TTC, CA HT) | Breakdown sous la valeur : `Salle 60 % · Privat 40 %` + `Midi 70 % · Soir 30 %` |
| Évolution CA | LineChart multi-séries (1 ligne par lieu/service) — budget masqué (ne se split pas naturellement) |
| Évolution couverts | LineChart multi-séries idem |
| Perf jour-semaine | BarChart groupé par dimension |
| **Mix Food/Bev** | Nouveau toggle **Synthèse / Détaillé**. Le mode Détaillé = matrice `service × catégorie` en % du CA TTC global (réponse directe à *« 65 % le midi en food, X % en bev midi, … »*) |
| Tableau jour-jour | 1 ligne par (jour × série), colonnes Lieu et/ou Service en tête |

### Helpers (purs, testés)
- `aggregateBySerie`, `buildBreakdown`, `mixByService`, `bucketDaysMultiSeries`, `perfByWeekdayMultiSeries`, `rowsByDayAndSerie`
- **+9 tests vitest**, total 125 verts.

### Excel
- En mode split : variantes multi-séries pour Évolution CA / Couverts / Perf / Tableau avec une colonne **Série** ajoutée plutôt que dupliquer les onglets.
- Nouvel onglet **« Mix détaillé service »** ajouté à chaque export quand le widget Mix est visible.

## Test plan
- [ ] Cocher 2 lieux (ex: Salle + Privat) → la page passe en mode split, les KPIs affichent un breakdown sous la valeur, les line charts ont une ligne par lieu.
- [ ] Cocher les 2 services → idem mais split par service.
- [ ] Cocher 2 lieux + les 2 services → split en croix (Salle/Midi, Salle/Soir, Privat/Midi, Privat/Soir) sur les charts.
- [ ] Sur le widget **Mix Food/Bev**, basculer en mode **Détaillé** → matrice service × catégorie en % apparaît avec montants en sous-titre.
- [ ] Cliquer sur **📥 Excel** en mode split → vérifier que les onglets multi-séries ont la colonne « Série » et que l'onglet « Mix détaillé service » est présent.
- [ ] Mode cumulé (rien ou « Tous » seuls cochés) → comportement identique à PR 5 (régression zéro).
- [ ] Mobile : les chips multi-select restent cliquables, les charts restent lisibles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)