### PR TITLE
feat(ventes): en-têtes de colonnes sticky sur CA mensuel

### DIFF
--- a/app/controle-gestion/ventes/page.js
+++ b/app/controle-gestion/ventes/page.js
@@ -419,6 +419,11 @@ function MonthTable({ days, totals, mois, isMobile, c }) {
     background: c.fond,
     borderBottom: `1px solid ${c.bordure}`,
     whiteSpace: 'nowrap',
+    // Sticky sous la Navbar (hauteur 56px) : on laisse les libellés visibles
+    // pendant qu'on scrolle dans le tableau du mois.
+    position: 'sticky',
+    top: 56,
+    zIndex: 1,
   }
   const cell = {
     padding: cellPad,
@@ -428,16 +433,19 @@ function MonthTable({ days, totals, mois, isMobile, c }) {
     borderBottom: `1px solid ${c.bordure}`,
     whiteSpace: 'nowrap',
   }
+  // Pas de wrapper overflow : la sticky du thead a besoin que son ancêtre
+  // direct ne soit pas un scroll-container (overflowX:auto force overflowY
+  // en auto par spec et casse la sticky verticale). Sur mobile, le scroll
+  // horizontal se fait au niveau du body si la largeur dépasse le viewport.
   return (
     <div
       style={{
         background: c.blanc,
         borderRadius: 12,
         border: `0.5px solid ${c.bordure}`,
-        overflow: 'hidden',
       }}
     >
-      <div style={{ overflowX: 'auto' }}>
+      <div>
         <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 720 }}>
           <thead>
             <tr>


### PR DESCRIPTION
## Summary
Quand on scrolle vers le bas dans le tableau du mois (page **/controle-gestion/ventes**), les libellés des colonnes (Date, Couv. midi, CA Food, Month to date, etc.) restent visibles en haut sous la Navbar — plus besoin de scroller vers le haut pour se rappeler à quoi correspond chaque chiffre.

## Implémentation
- `position: sticky` + `top: 56` (hauteur exacte de la Navbar) + `zIndex: 1` sur le style `head` des `<th>`.
- Suppression du wrapper `<div overflowX:auto>` + retrait de `overflow: hidden` sur le card parent : ces deux éléments créaient des « scrolling box » qui capturaient la sticky et l'empêchaient de coller à la viewport (spec CSS : toute valeur d'overflow ≠ visible crée un contexte de scroll).
- Conséquence : sur écran étroit (<720px), la table peut déborder du body — trade-off accepté, l'écran est principalement utilisé en desktop.

## Test plan
- [ ] Ouvrir `/controle-gestion/ventes` sur un mois avec ~30 jours de saisie → scroller vers le bas → les libellés de colonnes restent en haut sous la Navbar.
- [ ] Vérifier que le scroll horizontal sur mobile fonctionne correctement (au niveau du body si la table dépasse).
- [ ] Vérifier qu'il n'y a pas de superposition étrange entre la Navbar et le thead sticky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)