### PR TITLE
feat(budgets): export Excel équipes (1 onglet par jour pré-rempli)

### DIFF
--- a/app/controle-gestion/ventes/budgets/page.js
+++ b/app/controle-gestion/ventes/budgets/page.js
@@ -8,6 +8,7 @@ import { supabase, getClientId } from '../../../../lib/supabase'
 import { useIsMobile } from '../../../../lib/useIsMobile'
 import { useTheme } from '../../../../lib/useTheme'
 import Navbar from '../../../../components/Navbar'
+import { buildBudgetsEquipesWorkbook, buildEquipesFilename } from '../../../../lib/budgetsExcelTemplate'
 
 const DEBUG_FALLBACK_CLIENT_ID = 'fa725e66-2cad-4ea4-892a-7eb3e90496a7'
 
@@ -544,6 +545,38 @@ export default function BudgetsPage() {
 
   // Vide tous les budgets du lieu sélectionné (12 mois × 7 jours × 2 svcs).
   // Le trigger d'audit log les DELETE.
+  // Génère le template Excel "équipes" pour un mois donné : un onglet par
+  // jour avec budgets pré-remplis et formules pour le cumulé, plus un onglet
+  // Synthèse mensuelle. Téléchargement direct via Blob.
+  const handleExportEquipes = useCallback(async (moisCible) => {
+    if (!clientId) return
+    setError('')
+    setOkMsg('')
+    try {
+      const moisBudgets = budgets[moisCible] || {}
+      const wb = await buildBudgetsEquipesWorkbook({
+        annee,
+        mois: moisCible,
+        lieux,
+        moisBudgets,
+        joursOverride,
+        clientNom: 'Skalcook',
+      })
+      const buf = await wb.xlsx.writeBuffer()
+      const blob = new Blob([buf], {
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = buildEquipesFilename(annee, moisCible)
+      a.click()
+      setTimeout(() => URL.revokeObjectURL(url), 1000)
+    } catch (e) {
+      setError(e.message || "Erreur lors de la génération du fichier Excel")
+    }
+  }, [clientId, annee, lieux, budgets, joursOverride])
+
   const handleResetLieu = useCallback(async () => {
     if (!clientId || !lieuFilter) return
     setSaving(true)
@@ -709,6 +742,7 @@ export default function BudgetsPage() {
             onOpenHistory={() => setHistoryOpen(true)}
             onReset={() => setResetConfirm('lieu')}
             onSave={handleSave}
+            onExportEquipes={handleExportEquipes}
             saving={saving}
             c={c}
             isMobile={isMobile}
@@ -928,10 +962,19 @@ function TopBar({
   onOpenHistory,
   onReset,
   onSave,
+  onExportEquipes,
   saving,
   c,
   isMobile,
 }) {
+  // Sélecteur mois pour l'export équipes (par défaut = mois courant)
+  const [exportMois, setExportMois] = useState(() => new Date().getMonth() + 1)
+  const [exporting, setExporting] = useState(false)
+  const handleExport = async () => {
+    if (!onExportEquipes || exporting) return
+    setExporting(true)
+    try { await onExportEquipes(exportMois) } finally { setExporting(false) }
+  }
   return (
     <div
       style={{
@@ -1021,6 +1064,47 @@ function TopBar({
         >
           Importer Excel
         </button>
+        {/* Excel équipes : template pré-rempli envoyé aux équipes en début de mois */}
+        <div style={{ display: 'inline-flex', alignItems: 'stretch', gap: 0 }}>
+          <select
+            value={exportMois}
+            onChange={(e) => setExportMois(Number(e.target.value))}
+            disabled={exporting}
+            style={{
+              padding: '8px 8px',
+              borderRadius: '8px 0 0 8px',
+              fontSize: 13,
+              border: `1px solid ${c.bordure}`,
+              borderRight: 'none',
+              background: c.blanc,
+              color: c.texte,
+              cursor: exporting ? 'not-allowed' : 'pointer',
+            }}
+            title="Mois à exporter"
+          >
+            {MOIS.map((m) => (
+              <option key={m} value={m}>{MOIS_LABEL[m]}</option>
+            ))}
+          </select>
+          <button
+            onClick={handleExport}
+            disabled={exporting}
+            title="Génère un Excel avec 1 onglet par jour, budgets pré-remplis et formules de cumul"
+            style={{
+              padding: '8px 14px',
+              borderRadius: '0 8px 8px 0',
+              fontSize: 13,
+              border: `1px solid ${c.bordure}`,
+              background: c.accent,
+              color: c.texte,
+              cursor: exporting ? 'not-allowed' : 'pointer',
+              fontWeight: 500,
+              opacity: exporting ? 0.6 : 1,
+            }}
+          >
+            {exporting ? 'Génération…' : '📤 Excel équipes'}
+          </button>
+        </div>
         <button
           onClick={onOpenHistory}
           style={{

--- a/app/controle-gestion/ventes/budgets/page.js
+++ b/app/controle-gestion/ventes/budgets/page.js
@@ -290,20 +290,32 @@ export default function BudgetsPage() {
   useEffect(() => {
     let cancel = false
     ;(async () => {
-      const { data: sessionData } = await supabase.auth.getSession()
-      if (cancel) return
-      if (!sessionData?.session) {
-        router.replace('/')
-        return
+      try {
+        const { data: sessionData } = await supabase.auth.getSession()
+        if (cancel) return
+        if (!sessionData?.session) {
+          router.replace('/')
+          return
+        }
+        let cid = await getClientId()
+        if (!cid) {
+          console.warn('getClientId vide — fallback debug:', DEBUG_FALLBACK_CLIENT_ID)
+          cid = DEBUG_FALLBACK_CLIENT_ID
+        }
+        if (cancel) return
+        setClientId(cid)
+        setAuthChecked(true)
+      } catch (e) {
+        // Si supabase.auth.getSession() ou getClientId() rejette (lock
+        // contesté en strict mode, réseau lent, etc.) on tente quand même
+        // de rendre la page avec un fallback : authChecked passe à true et
+        // un message d'erreur s'affiche au lieu d'une page blanche.
+        if (cancel) return
+        console.warn('Erreur auth budgets, fallback :', e?.message || e)
+        setClientId(DEBUG_FALLBACK_CLIENT_ID)
+        setAuthChecked(true)
+        setError("Connexion lente — la page peut prendre quelques secondes à charger. Rechargez si nécessaire.")
       }
-      let cid = await getClientId()
-      if (!cid) {
-        console.warn('getClientId vide — fallback debug:', DEBUG_FALLBACK_CLIENT_ID)
-        cid = DEBUG_FALLBACK_CLIENT_ID
-      }
-      if (cancel) return
-      setClientId(cid)
-      setAuthChecked(true)
     })()
     return () => {
       cancel = true

--- a/app/controle-gestion/ventes/budgets/page.js
+++ b/app/controle-gestion/ventes/budgets/page.js
@@ -9,6 +9,7 @@ import { useIsMobile } from '../../../../lib/useIsMobile'
 import { useTheme } from '../../../../lib/useTheme'
 import Navbar from '../../../../components/Navbar'
 import { buildBudgetsEquipesWorkbook, buildEquipesFilename } from '../../../../lib/budgetsExcelTemplate'
+import JoursFermesModal from '../../../../components/budgets/JoursFermesModal'
 
 const DEBUG_FALLBACK_CLIENT_ID = 'fa725e66-2cad-4ea4-892a-7eb3e90496a7'
 
@@ -269,6 +270,7 @@ export default function BudgetsPage() {
   const [saving, setSaving] = useState(false)
   const [historyOpen, setHistoryOpen] = useState(false)
   const [wizardOpen, setWizardOpen] = useState(false)
+  const [joursFermesOpen, setJoursFermesOpen] = useState(false)
   const [resetConfirm, setResetConfirm] = useState(null) // 'lieu' | null
   const [importPreview, setImportPreview] = useState(null)
   const [expandedMois, setExpandedMois] = useState(() => new Set(MOIS))
@@ -547,19 +549,35 @@ export default function BudgetsPage() {
   // Le trigger d'audit log les DELETE.
   // Génère le template Excel "équipes" pour un mois donné : un onglet par
   // jour avec budgets pré-remplis et formules pour le cumulé, plus un onglet
-  // Synthèse mensuelle. Téléchargement direct via Blob.
+  // Synthèse mensuelle. Les dates listées dans ca_jours_fermes sont
+  // pré-remplies dans la colonne Exception. Téléchargement direct via Blob.
   const handleExportEquipes = useCallback(async (moisCible) => {
     if (!clientId) return
     setError('')
     setOkMsg('')
     try {
       const moisBudgets = budgets[moisCible] || {}
+      // Charge les jours fermés du mois cible (en BDD)
+      const debut = `${annee}-${String(moisCible).padStart(2, '0')}-01`
+      const finDate = new Date(annee, moisCible, 0)
+      const fin = `${annee}-${String(moisCible).padStart(2, '0')}-${String(finDate.getDate()).padStart(2, '0')}`
+      const { data: joursFermesData, error: jfErr } = await supabase
+        .from('ca_jours_fermes')
+        .select('date, motif')
+        .eq('client_id', clientId)
+        .gte('date', debut)
+        .lte('date', fin)
+      if (jfErr) throw jfErr
+      const joursFermesMap = {}
+      for (const r of (joursFermesData || [])) joursFermesMap[r.date] = r.motif
+
       const wb = await buildBudgetsEquipesWorkbook({
         annee,
         mois: moisCible,
         lieux,
         moisBudgets,
         joursOverride,
+        joursFermes: joursFermesMap,
         clientNom: 'Skalcook',
       })
       const buf = await wb.xlsx.writeBuffer()
@@ -743,6 +761,7 @@ export default function BudgetsPage() {
             onReset={() => setResetConfirm('lieu')}
             onSave={handleSave}
             onExportEquipes={handleExportEquipes}
+            onOpenJoursFermes={() => setJoursFermesOpen(true)}
             saving={saving}
             c={c}
             isMobile={isMobile}
@@ -905,6 +924,15 @@ export default function BudgetsPage() {
         <HistoryModal clientId={clientId} onClose={() => setHistoryOpen(false)} c={c} isMobile={isMobile} />
       )}
 
+      {joursFermesOpen && (
+        <JoursFermesModal
+          c={c}
+          clientId={clientId}
+          annee={annee}
+          onClose={() => setJoursFermesOpen(false)}
+        />
+      )}
+
       {importPreview && (
         <ImportPreviewModal
           preview={importPreview}
@@ -963,6 +991,7 @@ function TopBar({
   onReset,
   onSave,
   onExportEquipes,
+  onOpenJoursFermes,
   saving,
   c,
   isMobile,
@@ -1063,6 +1092,21 @@ function TopBar({
           }}
         >
           Importer Excel
+        </button>
+        <button
+          onClick={onOpenJoursFermes}
+          title="Jours fermés / fériés — pré-remplit la colonne Exception du fichier Excel équipes"
+          style={{
+            padding: '8px 14px',
+            borderRadius: 8,
+            fontSize: 13,
+            border: `1px solid ${c.bordure}`,
+            background: c.blanc,
+            color: c.texte,
+            cursor: 'pointer',
+          }}
+        >
+          🗓 Jours fermés
         </button>
         {/* Excel équipes : template pré-rempli envoyé aux équipes en début de mois */}
         <div style={{ display: 'inline-flex', alignItems: 'stretch', gap: 0 }}>

--- a/app/controle-gestion/ventes/budgets/page.js
+++ b/app/controle-gestion/ventes/budgets/page.js
@@ -569,19 +569,45 @@ export default function BudgetsPage() {
     setOkMsg('')
     try {
       const moisBudgets = budgets[moisCible] || {}
-      // Charge les jours fermés du mois cible (en BDD)
+      // Charge les jours fermés du mois cible : dates spécifiques (ferié,
+      // privatisation, vacances...) ET fermetures hebdomadaires récurrentes
+      // (ex : tous les lundis). Les deux sont fusionnés dans un seul map
+      // { 'YYYY-MM-DD': motif } passé au builder Excel.
       const debut = `${annee}-${String(moisCible).padStart(2, '0')}-01`
       const finDate = new Date(annee, moisCible, 0)
       const fin = `${annee}-${String(moisCible).padStart(2, '0')}-${String(finDate.getDate()).padStart(2, '0')}`
-      const { data: joursFermesData, error: jfErr } = await supabase
-        .from('ca_jours_fermes')
-        .select('date, motif')
-        .eq('client_id', clientId)
-        .gte('date', debut)
-        .lte('date', fin)
-      if (jfErr) throw jfErr
+      const [jfRes, jfhRes] = await Promise.all([
+        supabase
+          .from('ca_jours_fermes')
+          .select('date, motif')
+          .eq('client_id', clientId)
+          .gte('date', debut)
+          .lte('date', fin),
+        supabase
+          .from('ca_jours_fermes_hebdo')
+          .select('jour_semaine, motif')
+          .eq('client_id', clientId),
+      ])
+      if (jfRes.error) throw jfRes.error
+      if (jfhRes.error) throw jfhRes.error
+
       const joursFermesMap = {}
-      for (const r of (joursFermesData || [])) joursFermesMap[r.date] = r.motif
+      // 1. Hebdo d'abord : étend chaque jour-de-semaine à toutes les dates
+      //    du mois cible qui matchent.
+      const hebdoMap = {}
+      for (const r of (jfhRes.data || [])) hebdoMap[r.jour_semaine] = r.motif
+      const lastDay = finDate.getDate()
+      for (let d = 1; d <= lastDay; d++) {
+        const date = new Date(annee, moisCible - 1, d)
+        const jds = date.getDay() === 0 ? 7 : date.getDay()
+        if (hebdoMap[jds]) {
+          const iso = `${annee}-${String(moisCible).padStart(2, '0')}-${String(d).padStart(2, '0')}`
+          joursFermesMap[iso] = hebdoMap[jds]
+        }
+      }
+      // 2. Dates spécifiques ensuite : écrasent l'hebdo si même date
+      //    (ex : 1er mai un lundi → "1er mai" plutôt que "Fermé hebdo")
+      for (const r of (jfRes.data || [])) joursFermesMap[r.date] = r.motif
 
       const wb = await buildBudgetsEquipesWorkbook({
         annee,

--- a/components/budgets/JoursFermesModal.js
+++ b/components/budgets/JoursFermesModal.js
@@ -10,6 +10,17 @@ const MOIS_LABEL = [
 
 const JOURS_FR_LONG = ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi']
 
+// ISO 1=lundi … 7=dimanche (utilisé en BDD pour ca_jours_fermes_hebdo).
+const JOURS_HEBDO = [
+  { code: 1, label: 'Lun' },
+  { code: 2, label: 'Mar' },
+  { code: 3, label: 'Mer' },
+  { code: 4, label: 'Jeu' },
+  { code: 5, label: 'Ven' },
+  { code: 6, label: 'Sam' },
+  { code: 7, label: 'Dim' },
+]
+
 // Fériés FR fixes + flottants pour pré-remplissage. Pré-rempli SEULEMENT
 // quand l'utilisateur clique sur le bouton dédié, jamais automatiquement.
 // (L'utilisateur a explicitement demandé de garder la main.)
@@ -62,32 +73,84 @@ function humanDate(iso) {
 // d'une année donnée.
 export default function JoursFermesModal({ c, clientId, annee, onClose }) {
   const [rows, setRows] = useState([])
+  // Fermetures hebdomadaires récurrentes : { [jds]: motif } pour ce client
+  const [hebdo, setHebdo] = useState({})
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [newDate, setNewDate] = useState('')
   const [newMotif, setNewMotif] = useState('Férié')
   const [adding, setAdding] = useState(false)
   const [filtreAnnee, setFiltreAnnee] = useState(annee)
+  const [hebdoMotif, setHebdoMotif] = useState('Fermé')
 
   const load = useCallback(async () => {
     if (!clientId) return
     setLoading(true)
     try {
-      const { data, error: e } = await supabase
-        .from('ca_jours_fermes')
-        .select('id, date, motif')
-        .eq('client_id', clientId)
-        .gte('date', `${filtreAnnee}-01-01`)
-        .lte('date', `${filtreAnnee}-12-31`)
-        .order('date')
-      if (e) throw e
-      setRows(data || [])
+      const [resDates, resHebdo] = await Promise.all([
+        supabase
+          .from('ca_jours_fermes')
+          .select('id, date, motif')
+          .eq('client_id', clientId)
+          .gte('date', `${filtreAnnee}-01-01`)
+          .lte('date', `${filtreAnnee}-12-31`)
+          .order('date'),
+        supabase
+          .from('ca_jours_fermes_hebdo')
+          .select('jour_semaine, motif')
+          .eq('client_id', clientId),
+      ])
+      if (resDates.error) throw resDates.error
+      if (resHebdo.error) throw resHebdo.error
+      setRows(resDates.data || [])
+      const hebdoMap = {}
+      for (const r of (resHebdo.data || [])) hebdoMap[r.jour_semaine] = r.motif
+      setHebdo(hebdoMap)
+      // Initialise le motif du formulaire hebdo avec le premier motif trouvé
+      const firstMotif = Object.values(hebdoMap)[0]
+      if (firstMotif) setHebdoMotif(firstMotif)
     } catch (e) {
       setError(e.message || 'Erreur de chargement')
     } finally {
       setLoading(false)
     }
   }, [clientId, filtreAnnee])
+
+  // Toggle d'un jour-de-semaine en fermeture hebdo
+  const toggleHebdo = useCallback(async (jds) => {
+    if (!clientId) return
+    setError('')
+    const wasActive = !!hebdo[jds]
+    // Optimistic UI
+    setHebdo((prev) => {
+      const next = { ...prev }
+      if (wasActive) delete next[jds]
+      else next[jds] = hebdoMotif || 'Fermé'
+      return next
+    })
+    try {
+      if (wasActive) {
+        const { error: e } = await supabase
+          .from('ca_jours_fermes_hebdo')
+          .delete()
+          .eq('client_id', clientId)
+          .eq('jour_semaine', jds)
+        if (e) throw e
+      } else {
+        const { error: e } = await supabase
+          .from('ca_jours_fermes_hebdo')
+          .upsert(
+            { client_id: clientId, jour_semaine: jds, motif: hebdoMotif || 'Fermé' },
+            { onConflict: 'client_id,jour_semaine' }
+          )
+        if (e) throw e
+      }
+    } catch (e) {
+      setError(e.message || 'Erreur lors de la mise à jour de la fermeture hebdo')
+      // Rollback optimistic
+      load()
+    }
+  }, [clientId, hebdo, hebdoMotif, load])
 
   useEffect(() => { load() }, [load])
 
@@ -207,6 +270,49 @@ export default function JoursFermesModal({ c, clientId, annee, onClose }) {
             style={{ background: 'transparent', border: 'none', fontSize: 20, color: c.texteMuted, cursor: 'pointer', lineHeight: 1 }}>
             ×
           </button>
+        </div>
+
+        {/* Section Fermeture hebdomadaire */}
+        <div style={{
+          padding: 12, marginBottom: 16, borderRadius: 10,
+          border: `0.5px solid ${c.bordure}`, background: c.fond,
+        }}>
+          <div style={{ fontSize: 12, color: c.texteMuted, marginBottom: 8, fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.4 }}>
+            Fermeture hebdomadaire
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center', marginBottom: 8 }}>
+            {JOURS_HEBDO.map((j) => {
+              const active = !!hebdo[j.code]
+              return (
+                <button
+                  key={j.code}
+                  onClick={() => toggleHebdo(j.code)}
+                  title={active ? `${j.label} — fermé hebdo (cliquer pour retirer)` : `${j.label} — ouvert (cliquer pour marquer fermé hebdo)`}
+                  style={{
+                    padding: '6px 12px', borderRadius: 16, fontSize: 12,
+                    border: `1px solid ${active ? c.accent : c.bordure}`,
+                    background: active ? c.accent : c.blanc,
+                    color: active ? c.texte : c.texteMuted,
+                    cursor: 'pointer', fontWeight: active ? 600 : 500,
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {j.label}
+                </button>
+              )
+            })}
+          </div>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: c.texteMuted }}>
+            Motif appliqué aux jours sélectionnés :
+            <input
+              type="text" value={hebdoMotif} onChange={(e) => setHebdoMotif(e.target.value)}
+              placeholder="Fermé"
+              style={{
+                flex: 1, padding: '4px 8px', borderRadius: 6, fontSize: 12,
+                border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte,
+              }}
+            />
+          </label>
         </div>
 
         {/* Sélecteur année + Pré-remplir FR */}

--- a/components/budgets/JoursFermesModal.js
+++ b/components/budgets/JoursFermesModal.js
@@ -1,0 +1,334 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { supabase } from '../../lib/supabase'
+
+const MOIS_LABEL = [
+  '', 'Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin',
+  'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre',
+]
+
+const JOURS_FR_LONG = ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi']
+
+// Fériés FR fixes + flottants pour pré-remplissage. Pré-rempli SEULEMENT
+// quand l'utilisateur clique sur le bouton dédié, jamais automatiquement.
+// (L'utilisateur a explicitement demandé de garder la main.)
+function feriesFR(annee) {
+  // Calcul Pâques (algorithme de Meeus/Jones/Butcher)
+  const a = annee % 19
+  const b = Math.floor(annee / 100)
+  const c = annee % 100
+  const d = Math.floor(b / 4)
+  const e = b % 4
+  const f = Math.floor((b + 8) / 25)
+  const g = Math.floor((b - f + 1) / 3)
+  const h = (19 * a + b - d - g + 15) % 30
+  const i = Math.floor(c / 4)
+  const k = c % 4
+  const l = (32 + 2 * e + 2 * i - h - k) % 7
+  const m = Math.floor((a + 11 * h + 22 * l) / 451)
+  const moisPaques = Math.floor((h + l - 7 * m + 114) / 31)
+  const jourPaques = ((h + l - 7 * m + 114) % 31) + 1
+  const paques = new Date(annee, moisPaques - 1, jourPaques)
+  const lundiPaques = new Date(paques); lundiPaques.setDate(paques.getDate() + 1)
+  const ascension = new Date(paques); ascension.setDate(paques.getDate() + 39)
+  const pentecote = new Date(paques); pentecote.setDate(paques.getDate() + 49)
+  const lundiPentecote = new Date(paques); lundiPentecote.setDate(paques.getDate() + 50)
+  const fmt = (d) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  return [
+    { date: `${annee}-01-01`, motif: 'Jour de l\'an' },
+    { date: fmt(lundiPaques), motif: 'Lundi de Pâques' },
+    { date: `${annee}-05-01`, motif: '1er mai' },
+    { date: `${annee}-05-08`, motif: 'Victoire 1945' },
+    { date: fmt(ascension), motif: 'Ascension' },
+    { date: fmt(lundiPentecote), motif: 'Lundi de Pentecôte' },
+    { date: `${annee}-07-14`, motif: 'Fête nationale' },
+    { date: `${annee}-08-15`, motif: 'Assomption' },
+    { date: `${annee}-11-01`, motif: 'Toussaint' },
+    { date: `${annee}-11-11`, motif: 'Armistice 1918' },
+    { date: `${annee}-12-25`, motif: 'Noël' },
+  ]
+}
+
+function humanDate(iso) {
+  const [y, m, d] = iso.split('-').map(Number)
+  const date = new Date(y, m - 1, d)
+  const jourLabel = JOURS_FR_LONG[date.getDay()].slice(0, 3).toLowerCase()
+  return `${jourLabel}. ${String(d).padStart(2, '0')}/${String(m).padStart(2, '0')}/${y}`
+}
+
+// Modal de gestion des jours fermés / fériés. Liste éditable, dates uniques.
+// Persiste dans ca_jours_fermes. Pré-remplissage optionnel des fériés FR
+// d'une année donnée.
+export default function JoursFermesModal({ c, clientId, annee, onClose }) {
+  const [rows, setRows] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [newDate, setNewDate] = useState('')
+  const [newMotif, setNewMotif] = useState('Férié')
+  const [adding, setAdding] = useState(false)
+  const [filtreAnnee, setFiltreAnnee] = useState(annee)
+
+  const load = useCallback(async () => {
+    if (!clientId) return
+    setLoading(true)
+    try {
+      const { data, error: e } = await supabase
+        .from('ca_jours_fermes')
+        .select('id, date, motif')
+        .eq('client_id', clientId)
+        .gte('date', `${filtreAnnee}-01-01`)
+        .lte('date', `${filtreAnnee}-12-31`)
+        .order('date')
+      if (e) throw e
+      setRows(data || [])
+    } catch (e) {
+      setError(e.message || 'Erreur de chargement')
+    } finally {
+      setLoading(false)
+    }
+  }, [clientId, filtreAnnee])
+
+  useEffect(() => { load() }, [load])
+
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const handleAdd = async () => {
+    if (!clientId || !newDate || !newMotif.trim()) return
+    setAdding(true)
+    setError('')
+    try {
+      const { error: e } = await supabase
+        .from('ca_jours_fermes')
+        .upsert(
+          { client_id: clientId, date: newDate, motif: newMotif.trim() },
+          { onConflict: 'client_id,date' }
+        )
+      if (e) throw e
+      setNewDate('')
+      setNewMotif('Férié')
+      await load()
+    } catch (e) {
+      setError(e.message || "Erreur lors de l'ajout")
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  const handleDelete = async (id) => {
+    setError('')
+    try {
+      const { error: e } = await supabase
+        .from('ca_jours_fermes')
+        .delete()
+        .eq('id', id)
+      if (e) throw e
+      setRows((prev) => prev.filter((r) => r.id !== id))
+    } catch (e) {
+      setError(e.message || 'Erreur de suppression')
+    }
+  }
+
+  const handlePreFillFR = async () => {
+    if (!clientId) return
+    setAdding(true)
+    setError('')
+    try {
+      const existing = new Set(rows.map((r) => r.date))
+      const toAdd = feriesFR(filtreAnnee).filter((f) => !existing.has(f.date))
+      if (toAdd.length === 0) {
+        setError('Tous les fériés FR de l\'année sont déjà ajoutés.')
+        return
+      }
+      const { error: e } = await supabase
+        .from('ca_jours_fermes')
+        .upsert(
+          toAdd.map((f) => ({ client_id: clientId, date: f.date, motif: f.motif })),
+          { onConflict: 'client_id,date' }
+        )
+      if (e) throw e
+      await load()
+    } catch (e) {
+      setError(e.message || 'Erreur lors du pré-remplissage')
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  const groupedByMois = useMemo(() => {
+    const groups = new Map()
+    for (const r of rows) {
+      const mois = Number(r.date.slice(5, 7))
+      if (!groups.has(mois)) groups.set(mois, [])
+      groups.get(mois).push(r)
+    }
+    return Array.from(groups.entries()).sort(([a], [b]) => a - b)
+  }, [rows])
+
+  const annees = useMemo(() => {
+    const now = new Date().getFullYear()
+    const years = new Set([annee])
+    for (let y = now - 1; y <= now + 2; y++) years.add(y)
+    return Array.from(years).sort((a, b) => a - b)
+  }, [annee])
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0, zIndex: 200,
+        background: 'rgba(9,9,11,0.45)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        padding: 16,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: '100%', maxWidth: 640, maxHeight: '90vh', overflowY: 'auto',
+          background: c.blanc, borderRadius: 14,
+          border: `0.5px solid ${c.bordure}`, boxShadow: '0 20px 40px rgba(0,0,0,0.2)',
+          padding: 20,
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 12 }}>
+          <div>
+            <div style={{ fontSize: 17, fontWeight: 600, color: c.texte }}>Jours fermés / fériés</div>
+            <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 4 }}>
+              Ces dates seront pré-remplies dans la colonne « Exception » du fichier Excel
+              équipes (cumuls Budget et Réel les excluent automatiquement).
+            </div>
+          </div>
+          <button onClick={onClose} aria-label="Fermer"
+            style={{ background: 'transparent', border: 'none', fontSize: 20, color: c.texteMuted, cursor: 'pointer', lineHeight: 1 }}>
+            ×
+          </button>
+        </div>
+
+        {/* Sélecteur année + Pré-remplir FR */}
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 16, flexWrap: 'wrap' }}>
+          <label style={{ fontSize: 12, color: c.texteMuted }}>Année :</label>
+          <select value={filtreAnnee} onChange={(e) => setFiltreAnnee(Number(e.target.value))}
+            style={{
+              padding: '6px 10px', borderRadius: 8, fontSize: 13,
+              border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte,
+            }}>
+            {annees.map((y) => <option key={y} value={y}>{y}</option>)}
+          </select>
+          <div style={{ flex: 1 }} />
+          <button
+            onClick={handlePreFillFR}
+            disabled={adding}
+            title="Ajoute les 11 fériés FR standards pour l'année sélectionnée (sans toucher aux dates déjà présentes)"
+            style={{
+              padding: '6px 12px', borderRadius: 8, fontSize: 12,
+              border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte,
+              cursor: adding ? 'not-allowed' : 'pointer', opacity: adding ? 0.6 : 1,
+            }}
+          >
+            + Pré-remplir fériés FR
+          </button>
+        </div>
+
+        {/* Ajout d'une date */}
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 16, flexWrap: 'wrap' }}>
+          <input
+            type="date" value={newDate} onChange={(e) => setNewDate(e.target.value)}
+            min={`${filtreAnnee}-01-01`} max={`${filtreAnnee}-12-31`}
+            style={{
+              padding: '7px 10px', borderRadius: 8, fontSize: 13,
+              border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte,
+            }}
+          />
+          <input
+            type="text" placeholder="Motif (ex: Férié, Privatisation…)"
+            value={newMotif} onChange={(e) => setNewMotif(e.target.value)}
+            style={{
+              flex: 1, minWidth: 180,
+              padding: '7px 10px', borderRadius: 8, fontSize: 13,
+              border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte,
+            }}
+          />
+          <button
+            onClick={handleAdd}
+            disabled={adding || !newDate || !newMotif.trim()}
+            style={{
+              padding: '7px 14px', borderRadius: 8, fontSize: 13,
+              border: 'none', background: c.accent, color: c.texte,
+              cursor: (adding || !newDate) ? 'not-allowed' : 'pointer',
+              fontWeight: 600, opacity: (adding || !newDate) ? 0.6 : 1,
+            }}
+          >
+            Ajouter
+          </button>
+        </div>
+
+        {error && (
+          <div style={{ marginBottom: 12, padding: '8px 12px', background: '#FCEBEB', color: '#A32D2D', borderRadius: 8, fontSize: 12 }}>
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div style={{ padding: 32, textAlign: 'center', color: c.texteMuted, fontSize: 13 }}>Chargement…</div>
+        ) : rows.length === 0 ? (
+          <div style={{ padding: 32, textAlign: 'center', color: c.texteMuted, fontSize: 13 }}>
+            Aucune date ajoutée pour {filtreAnnee}.
+          </div>
+        ) : (
+          <div style={{ border: `0.5px solid ${c.bordure}`, borderRadius: 10, overflow: 'hidden' }}>
+            {groupedByMois.map(([mois, items], idx) => (
+              <div key={mois}>
+                <div style={{
+                  padding: '6px 12px', background: c.fond,
+                  fontSize: 11, fontWeight: 600, color: c.texteMuted,
+                  textTransform: 'uppercase', letterSpacing: 0.4,
+                  borderTop: idx > 0 ? `0.5px solid ${c.bordure}` : 'none',
+                }}>
+                  {MOIS_LABEL[mois]} {filtreAnnee}
+                </div>
+                {items.map((r) => (
+                  <div key={r.id} style={{
+                    display: 'flex', alignItems: 'center', gap: 10, padding: '8px 12px',
+                    borderTop: `0.5px solid ${c.bordure}`,
+                  }}>
+                    <div style={{ fontSize: 13, color: c.texte, minWidth: 140 }}>
+                      {humanDate(r.date)}
+                    </div>
+                    <div style={{ flex: 1, fontSize: 13, color: c.texte }}>{r.motif}</div>
+                    <button
+                      onClick={() => handleDelete(r.id)}
+                      style={{
+                        background: 'transparent', border: `0.5px solid ${c.bordure}`,
+                        borderRadius: 6, padding: '3px 8px', fontSize: 11,
+                        color: c.texteMuted, cursor: 'pointer',
+                      }}
+                      title="Supprimer"
+                    >
+                      Supprimer
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 16 }}>
+          <button onClick={onClose}
+            style={{
+              padding: '8px 14px', borderRadius: 8, fontSize: 13,
+              border: `0.5px solid ${c.bordure}`, background: c.blanc, color: c.texteMuted,
+              cursor: 'pointer',
+            }}>
+            Fermer
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/__tests__/budgetsExcelTemplate.test.ts
+++ b/lib/__tests__/budgetsExcelTemplate.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildBudgetsEquipesWorkbook,
+  buildEquipesFilename,
+  isDayOpen,
+  cellBudgetTotal,
+  joursDansMois,
+  jsWeekdayToIso,
+  MOIS_LABEL,
+} from '../budgetsExcelTemplate'
+
+describe('jsWeekdayToIso', () => {
+  it('convertit dimanche=0 en ISO 7', () => {
+    expect(jsWeekdayToIso(0)).toBe(7)
+    expect(jsWeekdayToIso(1)).toBe(1)
+    expect(jsWeekdayToIso(6)).toBe(6)
+  })
+})
+
+describe('joursDansMois', () => {
+  it('compte les jeudis de Mai 2026', () => {
+    // Jeudis de mai 2026 : 7, 14, 21, 28 → 4 jeudis
+    expect(joursDansMois(2026, 5, 4)).toBe(4)
+  })
+  it('compte les vendredis de Mai 2026', () => {
+    // Vendredis de mai 2026 : 1, 8, 15, 22, 29 → 5 vendredis
+    expect(joursDansMois(2026, 5, 5)).toBe(5)
+  })
+})
+
+describe('cellBudgetTotal', () => {
+  it('somme les 4 ca_*_cible', () => {
+    expect(cellBudgetTotal({
+      ca_food_cible: 100, ca_bev_20_cible: 50, ca_bev_10_cible: 25, ca_autre_cible: 5,
+    })).toBe(180)
+  })
+  it('retourne 0 pour une cellule absente', () => {
+    expect(cellBudgetTotal(null)).toBe(0)
+    expect(cellBudgetTotal(undefined)).toBe(0)
+  })
+})
+
+describe('isDayOpen', () => {
+  const lieux = [{ id: 'L1', nom: 'Salle', label: 'SALLE' }]
+  const services = [{ code: 'lunch' }, { code: 'dinner' }]
+
+  it('renvoie true si au moins une cellule a un budget ou des couverts', () => {
+    const moisBudgets = {
+      '1_L1_lunch': { couverts_cible: 20, ca_food_cible: 0, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+    }
+    expect(isDayOpen(1, lieux, services, moisBudgets)).toBe(true)
+  })
+
+  it('renvoie false si toutes les cellules sont à 0', () => {
+    const moisBudgets = {
+      '1_L1_lunch':  { couverts_cible: 0, ca_food_cible: 0, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+      '1_L1_dinner': { couverts_cible: 0, ca_food_cible: 0, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+    }
+    expect(isDayOpen(1, lieux, services, moisBudgets)).toBe(false)
+  })
+
+  it('renvoie false si aucune cellule pour ce jour-de-semaine', () => {
+    expect(isDayOpen(1, lieux, services, {})).toBe(false)
+  })
+})
+
+describe('buildEquipesFilename', () => {
+  it('format ISO : suivi-ca_YYYY-MM.xlsx', () => {
+    expect(buildEquipesFilename(2026, 5)).toBe('suivi-ca_2026-05.xlsx')
+    expect(buildEquipesFilename(2026, 12)).toBe('suivi-ca_2026-12.xlsx')
+  })
+})
+
+describe('MOIS_LABEL', () => {
+  it('labels FR commencent à index 1', () => {
+    expect(MOIS_LABEL[1]).toBe('Janvier')
+    expect(MOIS_LABEL[12]).toBe('Décembre')
+  })
+})
+
+describe('buildBudgetsEquipesWorkbook', () => {
+  const lieux = [
+    { id: 'L1', nom: 'Salle à manger', actif: true, ordre: 1 },
+  ]
+  // Budgets : ouvert le mardi (jds=2) et vendredi (jds=5)
+  const moisBudgets = {
+    '2_L1_lunch':  { couverts_cible: 25, ca_food_cible: 4000, ca_bev_20_cible: 1500, ca_bev_10_cible: 500, ca_autre_cible: 0 },
+    '2_L1_dinner': { couverts_cible: 40, ca_food_cible: 8000, ca_bev_20_cible: 3500, ca_bev_10_cible: 500, ca_autre_cible: 0 },
+    '5_L1_lunch':  { couverts_cible: 30, ca_food_cible: 5000, ca_bev_20_cible: 2000, ca_bev_10_cible: 500, ca_autre_cible: 0 },
+    '5_L1_dinner': { couverts_cible: 45, ca_food_cible: 9000, ca_bev_20_cible: 3500, ca_bev_10_cible: 500, ca_autre_cible: 0 },
+  }
+
+  it('crée un onglet par jour du mois + un onglet Synthèse', async () => {
+    const wb = await buildBudgetsEquipesWorkbook({
+      annee: 2026, mois: 5, lieux, moisBudgets,
+    })
+    // Mai 2026 = 31 jours + 1 onglet Synthèse
+    expect(wb.worksheets).toHaveLength(32)
+    expect(wb.worksheets[0].name).toBe('Synthèse')
+    expect(wb.worksheets[1].name).toBe('01-05')
+    expect(wb.worksheets[31].name).toBe('31-05')
+  })
+
+  it('marque correctement les jours fermés (lundi, mercredi, jeudi en mai)', async () => {
+    const wb = await buildBudgetsEquipesWorkbook({
+      annee: 2026, mois: 5, lieux, moisBudgets,
+    })
+    // 04-05 = lundi → fermé (pas de budget jds=1)
+    const lundiSheet = wb.getWorksheet('04-05')
+    // Le bandeau "JOUR FERMÉ" est sur la ligne 9
+    expect(lundiSheet.getCell(9, 1).value).toContain('FERMÉ')
+    // 05-05 = mardi → ouvert
+    const mardiSheet = wb.getWorksheet('05-05')
+    expect(mardiSheet.getCell(9, 1).value).toBeFalsy()
+  })
+
+  it('le Synthèse contient une ligne par jour avec Ouvert/Fermé', async () => {
+    const wb = await buildBudgetsEquipesWorkbook({
+      annee: 2026, mois: 5, lieux, moisBudgets,
+    })
+    const synth = wb.getWorksheet('Synthèse')
+    // Ligne 2 = 01-05 (vendredi 1er mai = ouvert)
+    expect(synth.getCell(2, 3).value).toBe('Ouvert')
+    // Ligne 5 = 04-05 (lundi = fermé)
+    expect(synth.getCell(5, 3).value).toBe('Fermé')
+  })
+
+  it('pré-remplit le ticket budget sur les jours ouverts', async () => {
+    const wb = await buildBudgetsEquipesWorkbook({
+      annee: 2026, mois: 5, lieux, moisBudgets,
+    })
+    const mardiSheet = wb.getWorksheet('05-05') // Mardi
+    // Row 7 = Ticket Budget, col 2 = Salle / Déjeuner
+    // Ticket = (4000 + 1500 + 500) / 25 = 6000 / 25 = 240
+    expect(mardiSheet.getCell(7, 2).value).toBe(240)
+  })
+})

--- a/lib/__tests__/budgetsExcelTemplate.test.ts
+++ b/lib/__tests__/budgetsExcelTemplate.test.ts
@@ -125,6 +125,21 @@ describe('buildBudgetsEquipesWorkbook', () => {
     expect(synth.getCell(5, 3).value).toBe('Fermé')
   })
 
+  it('le Synthèse a une colonne Exception (D) avec formule Cumul utilisant SUMIF', async () => {
+    const wb = await buildBudgetsEquipesWorkbook({
+      annee: 2026, mois: 5, lieux, moisBudgets,
+    })
+    const synth = wb.getWorksheet('Synthèse')
+    // Header colonne 4 = Exception
+    expect(synth.getCell(1, 4).value).toBe('Exception')
+    // Ligne 2 (1er mai, ouvert) : K2 doit être une formule SUMIF
+    const cumulBudget = synth.getCell(2, 11).value
+    expect(cumulBudget).toHaveProperty('formula')
+    expect(cumulBudget.formula).toContain('SUMIF')
+    expect(cumulBudget.formula).toContain('D$2:D2')
+    expect(cumulBudget.formula).toContain('H$2:H2')
+  })
+
   it('pré-remplit le ticket budget sur les jours ouverts', async () => {
     const wb = await buildBudgetsEquipesWorkbook({
       annee: 2026, mois: 5, lieux, moisBudgets,

--- a/lib/__tests__/budgetsExcelTemplate.test.ts
+++ b/lib/__tests__/budgetsExcelTemplate.test.ts
@@ -149,4 +149,18 @@ describe('buildBudgetsEquipesWorkbook', () => {
     // Ticket = (4000 + 1500 + 500) / 25 = 6000 / 25 = 240
     expect(mardiSheet.getCell(7, 2).value).toBe(240)
   })
+
+  it('pré-remplit la colonne Exception depuis joursFermes', async () => {
+    const wb = await buildBudgetsEquipesWorkbook({
+      annee: 2026, mois: 5, lieux, moisBudgets,
+      joursFermes: { '2026-05-01': '1er mai', '2026-05-08': 'Victoire 1945' },
+    })
+    const synth = wb.getWorksheet('Synthèse')
+    // Ligne 2 = 01-05 → motif "1er mai" en col D
+    expect(synth.getCell(2, 4).value).toBe('1er mai')
+    // Ligne 9 = 08-05 → motif "Victoire 1945"
+    expect(synth.getCell(9, 4).value).toBe('Victoire 1945')
+    // Ligne 3 = 02-05 → pas de motif (vide)
+    expect(synth.getCell(3, 4).value).toBeFalsy()
+  })
 })

--- a/lib/budgetsExcelTemplate.js
+++ b/lib/budgetsExcelTemplate.js
@@ -374,7 +374,7 @@ function buildSynthesisBlocks(ws, { isOpen, lieux, services, moisBudgets, isoJds
 
 // ─── Sheet Synthèse mensuelle ───────────────────────────────────────────────
 
-function buildSynthesisSheet(wb, { annee, mois, days, lieux, services, moisBudgets }) {
+function buildSynthesisSheet(wb, { annee, mois, days, lieux, services, moisBudgets, joursFermes = {} }) {
   const ws = wb.addWorksheet('Synthèse', { properties: { tabColor: { argb: COLOR.green } } })
   // Colonnes :
   //   A=Date, B=Jour, C=Ouverture, D=Exception (manuel : "Férié", "Fermé"…),
@@ -424,9 +424,16 @@ function buildSynthesisSheet(wb, { annee, mois, days, lieux, services, moisBudge
     row.getCell(3).value = d.isOpen ? 'Ouvert' : 'Fermé'
     row.getCell(3).font = { color: { argb: d.isOpen ? COLOR.greenDark : COLOR.greyDark }, bold: true }
     row.getCell(3).alignment = { horizontal: 'center' }
-    // D: Exception (cellule vide, saisie manuelle)
+    // D: Exception — pré-rempli depuis ca_jours_fermes si la date matche,
+    //               sinon vide (l'user peut taper directement dans Excel).
+    const isoDate = formatDateIso(d.date)
+    const exceptionMotif = joursFermes[isoDate] || ''
+    row.getCell(4).value = exceptionMotif
     row.getCell(4).alignment = { horizontal: 'center' }
     row.getCell(4).fill = fillColor(COLOR.yellowSoft)
+    if (exceptionMotif) {
+      row.getCell(4).font = { bold: true, color: { argb: COLOR.greenDark } }
+    }
 
     if (d.isOpen) {
       // Calcule budgets (valeurs statiques)
@@ -514,6 +521,12 @@ export function formatDateFr(date) {
   return `${d}/${m}/${date.getFullYear()}`
 }
 
+export function formatDateIso(date) {
+  const d = String(date.getDate()).padStart(2, '0')
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  return `${date.getFullYear()}-${m}-${d}`
+}
+
 // ─── Builder principal ─────────────────────────────────────────────────────
 
 // opts:
@@ -523,7 +536,7 @@ export function formatDateFr(date) {
 //   joursOverride : { [mois]: { [jds]: { [svcCode]: number } } } (optionnel, pour cohérence)
 //   clientNom : string (titre du workbook)
 export async function buildBudgetsEquipesWorkbook(opts) {
-  const { annee, mois, lieux: rawLieux, moisBudgets, clientNom = 'Skalcook' } = opts
+  const { annee, mois, lieux: rawLieux, moisBudgets, joursFermes = {}, clientNom = 'Skalcook' } = opts
   // Filtre lieux actifs + label par défaut = nom uppercase
   const lieux = (rawLieux || []).filter((l) => l.actif !== false).map((l) => ({
     ...l,
@@ -551,7 +564,7 @@ export async function buildBudgetsEquipesWorkbook(opts) {
   }
 
   // Crée d'abord la sheet Synthèse pour que les onglets jour puissent y référer.
-  buildSynthesisSheet(wb, { annee, mois, days, lieux, services, moisBudgets })
+  buildSynthesisSheet(wb, { annee, mois, days, lieux, services, moisBudgets, joursFermes })
 
   // Puis crée chaque onglet jour
   days.forEach((d, idx) => {

--- a/lib/budgetsExcelTemplate.js
+++ b/lib/budgetsExcelTemplate.js
@@ -357,13 +357,15 @@ function buildSynthesisBlocks(ws, { isOpen, lieux, services, moisBudgets, isoJds
     valBudget: budgetCouvJour,
   })
 
-  // Mensuel — bloc 5 (row 24-26) : utilise des références au Synthèse
+  // Mensuel — bloc 5 (row 24-26) : utilise des références au Synthèse.
+  // Depuis l'ajout de la colonne Exception (D), les cumuls Budget/Réel
+  // sont en colonnes K/L (et non plus J/K).
   // synthRowIndex = numéro de ligne dans Synthèse (header en row 1, data dès row 2)
   buildBlock(24, 3, {
     titleReel: 'MENSUEL REEL',
     titleBudget: 'BUDGET MENSUEL',
-    formulaReel: `Synthèse!K${synthRowIndex}`,
-    valBudget: { formula: `Synthèse!J${synthRowIndex}`, result: 0 },
+    formulaReel: `Synthèse!L${synthRowIndex}`,
+    valBudget: { formula: `Synthèse!K${synthRowIndex}`, result: 0 },
     formatEur: true,
   })
   ws.getColumn(2).width = 20 // labels gauche
@@ -374,11 +376,18 @@ function buildSynthesisBlocks(ws, { isOpen, lieux, services, moisBudgets, isoJds
 
 function buildSynthesisSheet(wb, { annee, mois, days, lieux, services, moisBudgets }) {
   const ws = wb.addWorksheet('Synthèse', { properties: { tabColor: { argb: COLOR.green } } })
-  // Colonnes A=Date, B=Jour, C=Ouverture, D=Couverts Réel, E=CA Réel Jour,
-  //          F=Couverts Budget, G=CA Budget Jour, H=Δ Couv, I=Δ CA,
-  //          J=Cumul Budget, K=Cumul Réel, L=Δ Cumul, M=Δ Cumul %
+  // Colonnes :
+  //   A=Date, B=Jour, C=Ouverture, D=Exception (manuel : "Férié", "Fermé"…),
+  //   E=Couv. réel, F=CA réel, G=Couv. budget, H=CA budget,
+  //   I=Δ couv., J=Δ CA,
+  //   K=Cumul budget, L=Cumul réel, M=Δ Cumul, N=Δ %
+  //
+  // La colonne D (Exception) permet d'exclure manuellement certains jours
+  // du cumul (1er mai, fermeture exceptionnelle…). SUMIF dans K/L ignore
+  // les lignes où D est non vide → tu reprends la main sur les jours à
+  // ignorer sans casser les formules.
   const headers = [
-    'Date', 'Jour', 'Ouverture',
+    'Date', 'Jour', 'Ouverture', 'Exception',
     'Couv. réel', 'CA réel',
     'Couv. budget', 'CA budget',
     'Δ couv.', 'Δ CA',
@@ -393,10 +402,13 @@ function buildSynthesisSheet(wb, { annee, mois, days, lieux, services, moisBudge
     cell.fill = fillColor(COLOR.yellow)
     cell.border = thinBorder()
   })
+  // Note dans le header Exception
+  r1.getCell(4).note = 'Tape "Férié", "Fermé" ou autre pour exclure ce jour des cumuls. Les Δ Cumul et Δ % se recalculent automatiquement.'
   ws.getColumn(1).width = 12
   ws.getColumn(2).width = 10
   ws.getColumn(3).width = 12
-  for (let c = 4; c <= 13; c++) ws.getColumn(c).width = 14
+  ws.getColumn(4).width = 14 // Exception
+  for (let c = 5; c <= 14; c++) ws.getColumn(c).width = 14
 
   days.forEach((d, idx) => {
     const rowIdx = idx + 2 // row 2 = first day
@@ -412,6 +424,9 @@ function buildSynthesisSheet(wb, { annee, mois, days, lieux, services, moisBudge
     row.getCell(3).value = d.isOpen ? 'Ouvert' : 'Fermé'
     row.getCell(3).font = { color: { argb: d.isOpen ? COLOR.greenDark : COLOR.greyDark }, bold: true }
     row.getCell(3).alignment = { horizontal: 'center' }
+    // D: Exception (cellule vide, saisie manuelle)
+    row.getCell(4).alignment = { horizontal: 'center' }
+    row.getCell(4).fill = fillColor(COLOR.yellowSoft)
 
     if (d.isOpen) {
       // Calcule budgets (valeurs statiques)
@@ -424,30 +439,33 @@ function buildSynthesisSheet(wb, { annee, mois, days, lieux, services, moisBudge
           budgetCouv += Number(cell?.couverts_cible || 0)
         }
       }
-      // D: Couv réel (référence pavé COUVERT JOURNEE = row 20 col 4 dans la sheet jour)
-      row.getCell(4).value = { formula: `${sheetRef}!D20`, result: 0 }
-      // E: CA réel (référence pavé CA JOURNEE = row 11 col 4)
-      row.getCell(5).value = { formula: `${sheetRef}!D11`, result: 0 }
-      // F: Couv budget
-      row.getCell(6).value = budgetCouv
-      // G: CA budget
-      row.getCell(7).value = budgetCa
-      // H: Δ couv
-      row.getCell(8).value = { formula: `D${rowIdx}-F${rowIdx}`, result: 0 }
-      // I: Δ CA
+      // E: Couv réel (référence pavé COUVERT JOURNEE = row 20 col 4)
+      row.getCell(5).value = { formula: `${sheetRef}!D20`, result: 0 }
+      // F: CA réel (référence pavé CA JOURNEE = row 11 col 4)
+      row.getCell(6).value = { formula: `${sheetRef}!D11`, result: 0 }
+      // G: Couv budget
+      row.getCell(7).value = budgetCouv
+      // H: CA budget
+      row.getCell(8).value = budgetCa
+      // I: Δ couv
       row.getCell(9).value = { formula: `E${rowIdx}-G${rowIdx}`, result: 0 }
-      // J: Cumul budget = SOMME(G$2:G{rowIdx})
-      row.getCell(10).value = { formula: `SUM(G$2:G${rowIdx})`, result: 0 }
-      // K: Cumul réel
-      row.getCell(11).value = { formula: `SUM(E$2:E${rowIdx})`, result: 0 }
-      // L: Δ Cumul
-      row.getCell(12).value = { formula: `K${rowIdx}-J${rowIdx}`, result: 0 }
-      // M: Δ %
-      row.getCell(13).value = { formula: `IFERROR(L${rowIdx}/J${rowIdx},0)`, result: 0 }
-      row.getCell(13).numFmt = '0.0%'
+      // J: Δ CA
+      row.getCell(10).value = { formula: `F${rowIdx}-H${rowIdx}`, result: 0 }
+      // K: Cumul budget = SUMIF(D$2:D{row}, "", H$2:H{row})
+      // → ignore les lignes où Exception (D) est non vide
+      row.getCell(11).value = { formula: `SUMIF(D$2:D${rowIdx},"",H$2:H${rowIdx})`, result: 0 }
+      // L: Cumul réel
+      row.getCell(12).value = { formula: `SUMIF(D$2:D${rowIdx},"",F$2:F${rowIdx})`, result: 0 }
+      // M: Δ Cumul
+      row.getCell(13).value = { formula: `L${rowIdx}-K${rowIdx}`, result: 0 }
+      // N: Δ %
+      row.getCell(14).value = { formula: `IFERROR(M${rowIdx}/K${rowIdx},0)`, result: 0 }
+      row.getCell(14).numFmt = '0.0%'
     } else {
-      // Lignes fermées : grisées, pas de formules
-      for (let c = 1; c <= 13; c++) {
+      // Lignes fermées : grisées, pas de formules sauf cumul qui se base sur
+      // les jours ouverts qui précèdent
+      for (let c = 1; c <= 14; c++) {
+        if (c === 4) continue // garde la couleur Exception
         const cell = row.getCell(c)
         cell.fill = fillColor(COLOR.greySoft)
         cell.font = { ...(cell.font || {}), color: { argb: COLOR.greyDark } }
@@ -455,36 +473,36 @@ function buildSynthesisSheet(wb, { annee, mois, days, lieux, services, moisBudge
     }
 
     // Formats numériques
-    row.getCell(5).numFmt = '#,##0 "€"'
-    row.getCell(7).numFmt = '#,##0 "€"'
-    row.getCell(9).numFmt = '#,##0 "€"'
+    row.getCell(6).numFmt = '#,##0 "€"'
+    row.getCell(8).numFmt = '#,##0 "€"'
     row.getCell(10).numFmt = '#,##0 "€"'
     row.getCell(11).numFmt = '#,##0 "€"'
     row.getCell(12).numFmt = '#,##0 "€"'
+    row.getCell(13).numFmt = '#,##0 "€"'
 
     // Borders
-    for (let c = 1; c <= 13; c++) row.getCell(c).border = thinBorder()
+    for (let c = 1; c <= 14; c++) row.getCell(c).border = thinBorder()
   })
 
-  // Ligne Total Annuel
+  // Ligne Total mensuel
   const totalRow = days.length + 2
   const tr = ws.getRow(totalRow)
   tr.getCell(1).value = `Total ${MOIS_LABEL[mois]} ${annee}`
   tr.getCell(1).font = { bold: true }
   tr.getCell(1).fill = fillColor(COLOR.yellow)
-  // F:G:J:K totals (sum)
-  tr.getCell(6).value = { formula: `SUM(F2:F${totalRow - 1})`, result: 0 }
-  tr.getCell(7).value = { formula: `SUM(G2:G${totalRow - 1})`, result: 0 }
-  tr.getCell(10).value = { formula: `J${totalRow - 1}`, result: 0 }
+  // Cumul budget / réel : reprend la dernière valeur (qui agrège déjà tout le mois)
+  tr.getCell(7).value = { formula: `SUMIF(D2:D${totalRow - 1},"",G2:G${totalRow - 1})`, result: 0 }
+  tr.getCell(8).value = { formula: `SUMIF(D2:D${totalRow - 1},"",H2:H${totalRow - 1})`, result: 0 }
   tr.getCell(11).value = { formula: `K${totalRow - 1}`, result: 0 }
-  tr.getCell(12).value = { formula: `K${totalRow}-J${totalRow}`, result: 0 }
-  tr.getCell(13).value = { formula: `IFERROR(L${totalRow}/J${totalRow},0)`, result: 0 }
-  tr.getCell(13).numFmt = '0.0%'
-  for (let c = 1; c <= 13; c++) {
+  tr.getCell(12).value = { formula: `L${totalRow - 1}`, result: 0 }
+  tr.getCell(13).value = { formula: `L${totalRow}-K${totalRow}`, result: 0 }
+  tr.getCell(14).value = { formula: `IFERROR(M${totalRow}/K${totalRow},0)`, result: 0 }
+  tr.getCell(14).numFmt = '0.0%'
+  for (let c = 1; c <= 14; c++) {
     tr.getCell(c).border = thinBorder()
     tr.getCell(c).font = { ...(tr.getCell(c).font || {}), bold: true }
     if (!tr.getCell(c).fill) tr.getCell(c).fill = fillColor(COLOR.yellowSoft)
-    tr.getCell(c).numFmt = tr.getCell(c).numFmt || (c >= 5 && c !== 8 ? '#,##0 "€"' : '#,##0')
+    tr.getCell(c).numFmt = tr.getCell(c).numFmt || (c >= 6 && c !== 9 ? '#,##0 "€"' : '#,##0')
   }
 }
 

--- a/lib/budgetsExcelTemplate.js
+++ b/lib/budgetsExcelTemplate.js
@@ -13,8 +13,11 @@
 // API : await buildBudgetsEquipesWorkbook(opts) → exceljs.Workbook
 //        const buf = await wb.xlsx.writeBuffer()
 //        // côté client : Blob + URL.createObjectURL + a.click()
-
-import ExcelJS from 'exceljs'
+//
+// ExcelJS est lazy-importé dans buildBudgetsEquipesWorkbook : la lib pèse
+// ~500 KB et n'est utile que lorsque l'utilisateur clique réellement sur
+// le bouton d'export. Importer statiquement gonflerait inutilement le
+// bundle de la page /controle-gestion/ventes/budgets.
 
 const JOURS_FR_LONG = ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi']
 const JOURS_FR_SHORT = ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam']
@@ -536,6 +539,10 @@ export function formatDateIso(date) {
 //   joursOverride : { [mois]: { [jds]: { [svcCode]: number } } } (optionnel, pour cohérence)
 //   clientNom : string (titre du workbook)
 export async function buildBudgetsEquipesWorkbook(opts) {
+  // Lazy import — exceljs ne chargera la lib que quand on construit
+  // effectivement un workbook (au clic du bouton, pas au load de la page).
+  const ExcelJS = (await import('exceljs')).default
+
   const { annee, mois, lieux: rawLieux, moisBudgets, joursFermes = {}, clientNom = 'Skalcook' } = opts
   // Filtre lieux actifs + label par défaut = nom uppercase
   const lieux = (rawLieux || []).filter((l) => l.actif !== false).map((l) => ({

--- a/lib/budgetsExcelTemplate.js
+++ b/lib/budgetsExcelTemplate.js
@@ -453,10 +453,12 @@ function buildSynthesisSheet(wb, { annee, mois, days, lieux, services, moisBudge
       row.getCell(5).value = { formula: `${sheetRef}!D20`, result: 0 }
       // F: CA réel (référence pavé CA JOURNEE = row 11 col 4)
       row.getCell(6).value = { formula: `${sheetRef}!D11`, result: 0 }
-      // G: Couv budget
-      row.getCell(7).value = budgetCouv
-      // H: CA budget
-      row.getCell(8).value = budgetCa
+      // G: Couv budget — IF(Exception vide, valeur, 0)
+      //   → quand l'user tape "Férié" dans D, le budget tombe à 0
+      //   automatiquement. Δ couv et Cumul budget restent cohérents.
+      row.getCell(7).value = { formula: `IF(D${rowIdx}="",${budgetCouv},0)`, result: budgetCouv }
+      // H: CA budget — idem
+      row.getCell(8).value = { formula: `IF(D${rowIdx}="",${budgetCa},0)`, result: budgetCa }
       // I: Δ couv
       row.getCell(9).value = { formula: `E${rowIdx}-G${rowIdx}`, result: 0 }
       // J: Δ CA

--- a/lib/budgetsExcelTemplate.js
+++ b/lib/budgetsExcelTemplate.js
@@ -1,0 +1,569 @@
+// Template Excel "équipes" : généré depuis /controle-gestion/ventes/budgets,
+// envoyé en début de mois aux équipes pour qu'elles remplissent le CA réel
+// jour par jour. Reproduit le format historique Marsan (un onglet par jour
+// + un onglet Synthèse mensuelle), avec :
+//   - Budgets pré-remplis (cellules jaunes : Ticket Budget, Budget Couvert,
+//     Budget CA, Budget Mensuel)
+//   - Cellules de saisie vides pour Couverts / CA TTC / Autres CA
+//   - Formules automatiques : Ticket Moyen, Écart, Cumul Mensuel
+//   - Jours fermés grisés (pas de budget sur ce jour-de-semaine)
+//
+// Builder pur (pas de Supabase ni React) → testable et réutilisable.
+//
+// API : await buildBudgetsEquipesWorkbook(opts) → exceljs.Workbook
+//        const buf = await wb.xlsx.writeBuffer()
+//        // côté client : Blob + URL.createObjectURL + a.click()
+
+import ExcelJS from 'exceljs'
+
+const JOURS_FR_LONG = ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi']
+const JOURS_FR_SHORT = ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam']
+const MOIS_LABEL = ['', 'Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin', 'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre']
+
+// Couleurs ARGB (alpha, R, G, B) — palette inspirée du template Marsan.
+const COLOR = {
+  yellow: 'FFFFFF00',
+  yellowSoft: 'FFFFF9C4',
+  green: 'FFC8E6C9',
+  greenDark: 'FF1B5E20',
+  greySoft: 'FFEEEEEE',
+  greyDark: 'FFBDBDBD',
+  pinkSoft: 'FFFFE0E0',
+  redDark: 'FFC62828',
+  border: 'FFB0B0B0',
+}
+
+function jsWeekdayToIso(jsWeekday) {
+  return jsWeekday === 0 ? 7 : jsWeekday
+}
+
+function joursDansMois(annee, mois, jdsTarget) {
+  const lastDay = new Date(annee, mois, 0).getDate()
+  let count = 0
+  for (let d = 1; d <= lastDay; d++) {
+    const date = new Date(annee, mois - 1, d)
+    const dow = jsWeekdayToIso(date.getDay())
+    if (dow === jdsTarget) count++
+  }
+  return count
+}
+
+function nbJoursOverride(annee, mois, jds, svcCode, joursOverride) {
+  const ov = joursOverride?.[mois]?.[jds]?.[svcCode]
+  if (ov != null && ov !== '') return Number(ov)
+  return joursDansMois(annee, mois, jds)
+}
+
+// Construit le total CA TTC budgétaire pour une cellule (jds, lieu, svc).
+function cellBudgetTotal(cell) {
+  if (!cell) return 0
+  return (
+    Number(cell.ca_food_cible || 0) +
+    Number(cell.ca_bev_20_cible || 0) +
+    Number(cell.ca_bev_10_cible || 0) +
+    Number(cell.ca_autre_cible || 0)
+  )
+}
+
+// Détermine si un jour calendaire est "ouvert" : au moins une cellule
+// budget non nulle parmi tous les (lieu, service) pour ce jour-de-semaine.
+function isDayOpen(isoJds, lieux, services, moisBudgets) {
+  for (const lieu of lieux) {
+    for (const svc of services) {
+      const cell = moisBudgets[`${isoJds}_${lieu.id}_${svc.code}`]
+      if (cell && (Number(cell.couverts_cible || 0) > 0 || cellBudgetTotal(cell) > 0)) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+// Crée un border thin gris autour d'une cellule.
+function thinBorder() {
+  return {
+    top:    { style: 'thin', color: { argb: COLOR.border } },
+    left:   { style: 'thin', color: { argb: COLOR.border } },
+    right:  { style: 'thin', color: { argb: COLOR.border } },
+    bottom: { style: 'thin', color: { argb: COLOR.border } },
+  }
+}
+
+function fillColor(argb) {
+  return { type: 'pattern', pattern: 'solid', fgColor: { argb } }
+}
+
+// ─── Sheet par jour ─────────────────────────────────────────────────────────
+
+// Construit l'onglet d'un jour donné. Renvoie le nom de l'onglet créé.
+function buildDaySheet(wb, { date, isoJds, isOpen, lieux, services, moisBudgets, synthRowIndex }) {
+  const sheetName = `${String(date.getDate()).padStart(2, '0')}-${String(date.getMonth() + 1).padStart(2, '0')}`
+  const ws = wb.addWorksheet(sheetName, {
+    pageSetup: { paperSize: 9, orientation: 'landscape' },
+    properties: { tabColor: { argb: isOpen ? undefined : COLOR.greyDark } },
+  })
+
+  // Layout : colonne A = label rangée. Pour chaque lieu : 3 colonnes (Déj / Dîn / Tot).
+  // → totalCols = 1 + lieux.length × 3
+  const totalCols = 1 + lieux.length * services.length + lieux.length // services = 2 → 3 cols (déj, dîn, tot) par lieu
+
+  // Largeur colonnes
+  ws.getColumn(1).width = 20
+  for (let i = 2; i <= totalCols; i++) ws.getColumn(i).width = 11
+
+  const cellGrey = (cell) => {
+    if (!isOpen) {
+      cell.fill = fillColor(COLOR.greySoft)
+      cell.font = { ...(cell.font || {}), color: { argb: COLOR.greyDark } }
+    }
+  }
+
+  // ── Ligne 1 : Date + en-têtes lieux fusionnés ────────────────────────────
+  const r1 = ws.getRow(1)
+  r1.getCell(1).value = formatDateFr(date)
+  r1.getCell(1).font = { bold: true, size: 11 }
+  r1.getCell(1).alignment = { vertical: 'middle', horizontal: 'center' }
+  r1.getCell(1).fill = fillColor(COLOR.yellowSoft)
+  r1.getCell(1).border = thinBorder()
+  // Header lieu fusionné sur 3 colonnes (déj + dîn + tot)
+  let col = 2
+  for (const lieu of lieux) {
+    const startCol = col
+    const endCol = col + 2 // 3 colonnes
+    ws.mergeCells(1, startCol, 1, endCol)
+    const lieuCell = ws.getCell(1, startCol)
+    lieuCell.value = lieu.label.toUpperCase()
+    lieuCell.alignment = { vertical: 'middle', horizontal: 'center' }
+    lieuCell.fill = fillColor(COLOR.yellow)
+    lieuCell.font = { bold: true, size: 10 }
+    lieuCell.border = thinBorder()
+    cellGrey(lieuCell)
+    col = endCol + 1
+  }
+  ws.mergeCells(1, 1, 2, 1) // date verticale fusionne 2 lignes
+
+  // ── Ligne 2 : DEJEUNER / DINER / TOT pour chaque lieu ────────────────────
+  const r2 = ws.getRow(2)
+  col = 2
+  for (const _lieu of lieux) {
+    for (const label of ['DEJEUNER', 'DINER', 'TOT']) {
+      const cell = r2.getCell(col)
+      cell.value = label
+      cell.alignment = { vertical: 'middle', horizontal: 'center' }
+      cell.fill = fillColor(COLOR.yellow)
+      cell.font = { bold: true, size: 9 }
+      cell.border = thinBorder()
+      cellGrey(cell)
+      col++
+    }
+  }
+
+  // ── Lignes 3-7 : rangées de saisie ───────────────────────────────────────
+  // 3: Couverts (input)
+  // 4: CA TTC (input)
+  // 5: Autres CA (input)
+  // 6: Ticket Moyen (formula = CA / Couv)
+  // 7: Ticket Budget (pré-rempli, jaune)
+  const rowsConfig = [
+    { row: 3, label: 'Couverts', input: true, computeTot: true },
+    { row: 4, label: 'CA TTC',   input: true, computeTot: true },
+    { row: 5, label: 'Autres CA', input: true, computeTot: true },
+    { row: 6, label: 'Ticket Moyen', computed: true },
+    { row: 7, label: 'Ticket Budget', budget: true },
+  ]
+  for (const cfg of rowsConfig) {
+    const row = ws.getRow(cfg.row)
+    row.getCell(1).value = cfg.label
+    row.getCell(1).font = { bold: true }
+    row.getCell(1).fill = fillColor(COLOR.pinkSoft)
+    row.getCell(1).border = thinBorder()
+    col = 2
+    for (const lieu of lieux) {
+      for (const svc of services) {
+        const cell = row.getCell(col)
+        cell.border = thinBorder()
+        cell.alignment = { horizontal: 'center' }
+        cellGrey(cell)
+        if (cfg.budget && isOpen) {
+          const budgetCell = moisBudgets[`${isoJds}_${lieu.id}_${svc.code}`]
+          const tm = budgetCell && Number(budgetCell.couverts_cible || 0) > 0
+            ? cellBudgetTotal(budgetCell) / Number(budgetCell.couverts_cible)
+            : 0
+          cell.value = Math.round(tm)
+          cell.fill = fillColor(COLOR.yellow)
+          cell.font = { bold: true }
+          cell.numFmt = '0'
+        } else if (cfg.computed && isOpen) {
+          // Ticket Moyen = CA TTC / Couverts (par cellule)
+          const caAddr = ws.getCell(4, col).address
+          const cvAddr = ws.getCell(3, col).address
+          cell.value = { formula: `IFERROR(${caAddr}/${cvAddr},0)`, result: 0 }
+          cell.numFmt = '0'
+        }
+        col++
+      }
+      // Colonne TOT pour ce lieu = somme déj + dîn
+      const totCell = row.getCell(col)
+      totCell.border = thinBorder()
+      totCell.alignment = { horizontal: 'center' }
+      totCell.fill = fillColor(COLOR.greySoft)
+      cellGrey(totCell)
+      if (cfg.computeTot && isOpen) {
+        const dejCol = col - 2
+        const dinCol = col - 1
+        const dejAddr = ws.getCell(cfg.row, dejCol).address
+        const dinAddr = ws.getCell(cfg.row, dinCol).address
+        totCell.value = { formula: `${dejAddr}+${dinAddr}`, result: 0 }
+        totCell.font = { bold: true }
+        totCell.numFmt = '0'
+      } else if (cfg.computed && isOpen) {
+        const caAddr = ws.getCell(4, col).address
+        const cvAddr = ws.getCell(3, col).address
+        totCell.value = { formula: `IFERROR(${caAddr}/${cvAddr},0)`, result: 0 }
+        totCell.numFmt = '0.00'
+      } else if (cfg.budget && isOpen) {
+        // Ticket Budget total : moyenne pondérée si possible, sinon /
+        const dejBudget = moisBudgets[`${isoJds}_${lieu.id}_lunch`]
+        const dinBudget = moisBudgets[`${isoJds}_${lieu.id}_dinner`]
+        const totCouv = Number(dejBudget?.couverts_cible || 0) + Number(dinBudget?.couverts_cible || 0)
+        const totCa = cellBudgetTotal(dejBudget) + cellBudgetTotal(dinBudget)
+        totCell.value = totCouv > 0 ? Math.round(totCa / totCouv) : 0
+        totCell.fill = fillColor(COLOR.yellow)
+        totCell.font = { bold: true }
+        totCell.numFmt = '0'
+      }
+      col++
+    }
+  }
+
+  // ── Pavés synthèse en bas ─────────────────────────────────────────────────
+  buildSynthesisBlocks(ws, {
+    isOpen, lieux, services, moisBudgets, isoJds, synthRowIndex,
+  })
+
+  // Champs custom Marsan : Boîtes à cannelé (en haut à droite)
+  const lastCol = totalCols
+  const cannelLabelCell = ws.getCell(1, lastCol + 2)
+  cannelLabelCell.value = 'Boîtes à cannelé'
+  cannelLabelCell.font = { bold: true }
+  cannelLabelCell.fill = fillColor(COLOR.pinkSoft)
+  cannelLabelCell.border = thinBorder()
+  cannelLabelCell.alignment = { horizontal: 'center' }
+  const cannelValueCell = ws.getCell(1, lastCol + 3)
+  cannelValueCell.border = thinBorder()
+  cannelValueCell.alignment = { horizontal: 'center' }
+  ws.getColumn(lastCol + 2).width = 20
+  ws.getColumn(lastCol + 3).width = 8
+
+  // Bandeau "JOUR FERMÉ" si applicable
+  if (!isOpen) {
+    ws.mergeCells(9, 1, 9, totalCols)
+    const banner = ws.getCell(9, 1)
+    banner.value = 'JOUR FERMÉ (aucun budget défini sur cette journée)'
+    banner.alignment = { horizontal: 'center', vertical: 'middle' }
+    banner.font = { bold: true, size: 12, color: { argb: COLOR.redDark } }
+    banner.fill = fillColor(COLOR.greySoft)
+    banner.border = thinBorder()
+  }
+
+  return sheetName
+}
+
+// ─── Pavés synthèse (en bas de chaque feuille jour) ────────────────────────
+
+function buildSynthesisBlocks(ws, { isOpen, lieux, services, moisBudgets, isoJds, synthRowIndex }) {
+  // Calcule les budgets agrégés pour la journée
+  let budgetCaJour = 0
+  let budgetCouvMidi = 0
+  let budgetCouvSoir = 0
+  for (const lieu of lieux) {
+    for (const svc of services) {
+      const cell = moisBudgets[`${isoJds}_${lieu.id}_${svc.code}`]
+      const cv = Number(cell?.couverts_cible || 0)
+      const ca = cellBudgetTotal(cell)
+      budgetCaJour += ca
+      if (svc.code === 'lunch') budgetCouvMidi += cv
+      else budgetCouvSoir += cv
+    }
+  }
+  const budgetCouvJour = budgetCouvMidi + budgetCouvSoir
+
+  // Helper pour construire un pavé 3-lignes (label / valeur / écart)
+  const buildBlock = (startRow, startCol, { titleReel, titleBudget, formulaReel, valBudget, formatEur = false }) => {
+    const fmt = formatEur ? '#,##0 "€"' : '#,##0'
+    const cells = [
+      { row: startRow,     col: startCol,     v: titleReel,   fill: COLOR.green,    bold: true, align: 'left' },
+      { row: startRow,     col: startCol + 1, v: isOpen ? { formula: formulaReel, result: 0 } : null, fill: COLOR.green,    bold: true, numFmt: fmt },
+      { row: startRow + 1, col: startCol,     v: titleBudget, fill: COLOR.yellow,   bold: true, align: 'left' },
+      { row: startRow + 1, col: startCol + 1, v: isOpen ? valBudget : null,         fill: COLOR.yellow,   bold: true, numFmt: fmt },
+      { row: startRow + 2, col: startCol,     v: 'ECART',     fill: COLOR.pinkSoft, bold: true, align: 'left' },
+      { row: startRow + 2, col: startCol + 1, v: isOpen ? { formula: `${ws.getCell(startRow, startCol + 1).address}-${ws.getCell(startRow + 1, startCol + 1).address}`, result: 0 } : null, fill: COLOR.greySoft, bold: true, numFmt: fmt },
+    ]
+    for (const c of cells) {
+      const cell = ws.getCell(c.row, c.col)
+      if (c.v !== null) cell.value = c.v
+      if (c.fill) cell.fill = fillColor(c.fill)
+      if (c.bold) cell.font = { bold: true }
+      if (c.numFmt) cell.numFmt = c.numFmt
+      cell.alignment = { horizontal: c.align || 'center' }
+      cell.border = thinBorder()
+    }
+  }
+
+  // CA Journée vs Budget — bloc 1 (col B-C, row 10-12)
+  // CA Journée réel = somme de toutes les cellules CA TTC (row 4) tous lieux × svcs
+  const caReelAddrs = []
+  for (let i = 0; i < lieux.length; i++) {
+    const dejCol = 2 + i * 3
+    const dinCol = dejCol + 1
+    caReelAddrs.push(ws.getCell(4, dejCol).address, ws.getCell(4, dinCol).address)
+  }
+  buildBlock(11, 3, {
+    titleReel: 'CA JOURNEE',
+    titleBudget: 'CA BUDGET',
+    formulaReel: `SUM(${caReelAddrs.join(',')})`,
+    valBudget: budgetCaJour,
+    formatEur: true,
+  })
+
+  // Couverts midi / soir — blocs 2 et 3 (row 14-16)
+  // Réel midi = somme col DEJEUNER de chaque lieu (row 3)
+  const couvMidiAddrs = []
+  const couvSoirAddrs = []
+  for (let i = 0; i < lieux.length; i++) {
+    const dejCol = 2 + i * 3
+    const dinCol = dejCol + 1
+    couvMidiAddrs.push(ws.getCell(3, dejCol).address)
+    couvSoirAddrs.push(ws.getCell(3, dinCol).address)
+  }
+  buildBlock(15, 1, {
+    titleReel: 'COUVERT SOIR',
+    titleBudget: 'BUDGET COUVERT SOIR',
+    formulaReel: `SUM(${couvSoirAddrs.join(',')})`,
+    valBudget: budgetCouvSoir,
+  })
+  buildBlock(15, 4, {
+    titleReel: 'COUVERT MIDI',
+    titleBudget: 'BUDGET COUVERT MIDI',
+    formulaReel: `SUM(${couvMidiAddrs.join(',')})`,
+    valBudget: budgetCouvMidi,
+  })
+
+  // Couvert journée — bloc 4 (row 19-21)
+  buildBlock(20, 3, {
+    titleReel: 'COUVERT JOURNEE',
+    titleBudget: 'BUDGET COUVERT',
+    formulaReel: `SUM(${[...couvMidiAddrs, ...couvSoirAddrs].join(',')})`,
+    valBudget: budgetCouvJour,
+  })
+
+  // Mensuel — bloc 5 (row 24-26) : utilise des références au Synthèse
+  // synthRowIndex = numéro de ligne dans Synthèse (header en row 1, data dès row 2)
+  buildBlock(24, 3, {
+    titleReel: 'MENSUEL REEL',
+    titleBudget: 'BUDGET MENSUEL',
+    formulaReel: `Synthèse!K${synthRowIndex}`,
+    valBudget: { formula: `Synthèse!J${synthRowIndex}`, result: 0 },
+    formatEur: true,
+  })
+  ws.getColumn(2).width = 20 // labels gauche
+  ws.getColumn(5).width = 22 // labels droite
+}
+
+// ─── Sheet Synthèse mensuelle ───────────────────────────────────────────────
+
+function buildSynthesisSheet(wb, { annee, mois, days, lieux, services, moisBudgets }) {
+  const ws = wb.addWorksheet('Synthèse', { properties: { tabColor: { argb: COLOR.green } } })
+  // Colonnes A=Date, B=Jour, C=Ouverture, D=Couverts Réel, E=CA Réel Jour,
+  //          F=Couverts Budget, G=CA Budget Jour, H=Δ Couv, I=Δ CA,
+  //          J=Cumul Budget, K=Cumul Réel, L=Δ Cumul, M=Δ Cumul %
+  const headers = [
+    'Date', 'Jour', 'Ouverture',
+    'Couv. réel', 'CA réel',
+    'Couv. budget', 'CA budget',
+    'Δ couv.', 'Δ CA',
+    'Cumul budget', 'Cumul réel', 'Δ Cumul', 'Δ %',
+  ]
+  const r1 = ws.getRow(1)
+  headers.forEach((h, i) => {
+    const cell = r1.getCell(i + 1)
+    cell.value = h
+    cell.font = { bold: true }
+    cell.alignment = { horizontal: 'center' }
+    cell.fill = fillColor(COLOR.yellow)
+    cell.border = thinBorder()
+  })
+  ws.getColumn(1).width = 12
+  ws.getColumn(2).width = 10
+  ws.getColumn(3).width = 12
+  for (let c = 4; c <= 13; c++) ws.getColumn(c).width = 14
+
+  days.forEach((d, idx) => {
+    const rowIdx = idx + 2 // row 2 = first day
+    const row = ws.getRow(rowIdx)
+    const sheetRef = `'${d.sheetName}'`
+
+    // A: Date
+    row.getCell(1).value = formatDateFr(d.date)
+    row.getCell(1).alignment = { horizontal: 'left' }
+    // B: Jour
+    row.getCell(2).value = JOURS_FR_LONG[d.date.getDay()]
+    // C: Ouverture
+    row.getCell(3).value = d.isOpen ? 'Ouvert' : 'Fermé'
+    row.getCell(3).font = { color: { argb: d.isOpen ? COLOR.greenDark : COLOR.greyDark }, bold: true }
+    row.getCell(3).alignment = { horizontal: 'center' }
+
+    if (d.isOpen) {
+      // Calcule budgets (valeurs statiques)
+      let budgetCa = 0
+      let budgetCouv = 0
+      for (const lieu of lieux) {
+        for (const svc of services) {
+          const cell = moisBudgets[`${d.isoJds}_${lieu.id}_${svc.code}`]
+          budgetCa += cellBudgetTotal(cell)
+          budgetCouv += Number(cell?.couverts_cible || 0)
+        }
+      }
+      // D: Couv réel (référence pavé COUVERT JOURNEE = row 20 col 4 dans la sheet jour)
+      row.getCell(4).value = { formula: `${sheetRef}!D20`, result: 0 }
+      // E: CA réel (référence pavé CA JOURNEE = row 11 col 4)
+      row.getCell(5).value = { formula: `${sheetRef}!D11`, result: 0 }
+      // F: Couv budget
+      row.getCell(6).value = budgetCouv
+      // G: CA budget
+      row.getCell(7).value = budgetCa
+      // H: Δ couv
+      row.getCell(8).value = { formula: `D${rowIdx}-F${rowIdx}`, result: 0 }
+      // I: Δ CA
+      row.getCell(9).value = { formula: `E${rowIdx}-G${rowIdx}`, result: 0 }
+      // J: Cumul budget = SOMME(G$2:G{rowIdx})
+      row.getCell(10).value = { formula: `SUM(G$2:G${rowIdx})`, result: 0 }
+      // K: Cumul réel
+      row.getCell(11).value = { formula: `SUM(E$2:E${rowIdx})`, result: 0 }
+      // L: Δ Cumul
+      row.getCell(12).value = { formula: `K${rowIdx}-J${rowIdx}`, result: 0 }
+      // M: Δ %
+      row.getCell(13).value = { formula: `IFERROR(L${rowIdx}/J${rowIdx},0)`, result: 0 }
+      row.getCell(13).numFmt = '0.0%'
+    } else {
+      // Lignes fermées : grisées, pas de formules
+      for (let c = 1; c <= 13; c++) {
+        const cell = row.getCell(c)
+        cell.fill = fillColor(COLOR.greySoft)
+        cell.font = { ...(cell.font || {}), color: { argb: COLOR.greyDark } }
+      }
+    }
+
+    // Formats numériques
+    row.getCell(5).numFmt = '#,##0 "€"'
+    row.getCell(7).numFmt = '#,##0 "€"'
+    row.getCell(9).numFmt = '#,##0 "€"'
+    row.getCell(10).numFmt = '#,##0 "€"'
+    row.getCell(11).numFmt = '#,##0 "€"'
+    row.getCell(12).numFmt = '#,##0 "€"'
+
+    // Borders
+    for (let c = 1; c <= 13; c++) row.getCell(c).border = thinBorder()
+  })
+
+  // Ligne Total Annuel
+  const totalRow = days.length + 2
+  const tr = ws.getRow(totalRow)
+  tr.getCell(1).value = `Total ${MOIS_LABEL[mois]} ${annee}`
+  tr.getCell(1).font = { bold: true }
+  tr.getCell(1).fill = fillColor(COLOR.yellow)
+  // F:G:J:K totals (sum)
+  tr.getCell(6).value = { formula: `SUM(F2:F${totalRow - 1})`, result: 0 }
+  tr.getCell(7).value = { formula: `SUM(G2:G${totalRow - 1})`, result: 0 }
+  tr.getCell(10).value = { formula: `J${totalRow - 1}`, result: 0 }
+  tr.getCell(11).value = { formula: `K${totalRow - 1}`, result: 0 }
+  tr.getCell(12).value = { formula: `K${totalRow}-J${totalRow}`, result: 0 }
+  tr.getCell(13).value = { formula: `IFERROR(L${totalRow}/J${totalRow},0)`, result: 0 }
+  tr.getCell(13).numFmt = '0.0%'
+  for (let c = 1; c <= 13; c++) {
+    tr.getCell(c).border = thinBorder()
+    tr.getCell(c).font = { ...(tr.getCell(c).font || {}), bold: true }
+    if (!tr.getCell(c).fill) tr.getCell(c).fill = fillColor(COLOR.yellowSoft)
+    tr.getCell(c).numFmt = tr.getCell(c).numFmt || (c >= 5 && c !== 8 ? '#,##0 "€"' : '#,##0')
+  }
+}
+
+// ─── Helpers exposés ────────────────────────────────────────────────────────
+
+export function formatDateFr(date) {
+  const d = String(date.getDate()).padStart(2, '0')
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  return `${d}/${m}/${date.getFullYear()}`
+}
+
+// ─── Builder principal ─────────────────────────────────────────────────────
+
+// opts:
+//   annee, mois (1..12)
+//   lieux : [{ id, nom, label, ordre, actif }] — label utilisé dans le header
+//   moisBudgets : { `${jds}_${lieuId}_${svcCode}`: cell } — cellules budget du mois
+//   joursOverride : { [mois]: { [jds]: { [svcCode]: number } } } (optionnel, pour cohérence)
+//   clientNom : string (titre du workbook)
+export async function buildBudgetsEquipesWorkbook(opts) {
+  const { annee, mois, lieux: rawLieux, moisBudgets, clientNom = 'Skalcook' } = opts
+  // Filtre lieux actifs + label par défaut = nom uppercase
+  const lieux = (rawLieux || []).filter((l) => l.actif !== false).map((l) => ({
+    ...l,
+    label: l.label || l.nom || 'Lieu',
+  }))
+  const services = [
+    { code: 'lunch', label: 'Déjeuner' },
+    { code: 'dinner', label: 'Dîner' },
+  ]
+
+  const wb = new ExcelJS.Workbook()
+  wb.creator = clientNom
+  wb.title = `Suivi CA équipes — ${MOIS_LABEL[mois]} ${annee}`
+  wb.created = new Date()
+
+  // Itère sur chaque jour du mois
+  const lastDay = new Date(annee, mois, 0).getDate()
+  const days = []
+  for (let d = 1; d <= lastDay; d++) {
+    const date = new Date(annee, mois - 1, d)
+    const isoJds = jsWeekdayToIso(date.getDay())
+    const isOpen = isDayOpen(isoJds, lieux, services, moisBudgets)
+    const sheetName = `${String(d).padStart(2, '0')}-${String(mois).padStart(2, '0')}`
+    days.push({ date, isoJds, isOpen, sheetName })
+  }
+
+  // Crée d'abord la sheet Synthèse pour que les onglets jour puissent y référer.
+  buildSynthesisSheet(wb, { annee, mois, days, lieux, services, moisBudgets })
+
+  // Puis crée chaque onglet jour
+  days.forEach((d, idx) => {
+    buildDaySheet(wb, {
+      date: d.date,
+      isoJds: d.isoJds,
+      isOpen: d.isOpen,
+      lieux,
+      services,
+      moisBudgets,
+      synthRowIndex: idx + 2, // row in Synthèse (header en row 1)
+    })
+  })
+
+  return wb
+}
+
+// Construit le nom de fichier suggéré : "suivi-ca_2026-05.xlsx"
+export function buildEquipesFilename(annee, mois) {
+  return `suivi-ca_${annee}-${String(mois).padStart(2, '0')}.xlsx`
+}
+
+// Helper non utilisé directement par le builder mais ré-exporté pour les tests
+export {
+  joursDansMois,
+  nbJoursOverride,
+  isDayOpen,
+  cellBudgetTotal,
+  jsWeekdayToIso,
+  JOURS_FR_LONG,
+  JOURS_FR_SHORT,
+  MOIS_LABEL,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@supabase/supabase-js": "^2.99.1",
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.37.0",
+        "exceljs": "^4.4.0",
         "isomorphic-dompurify": "^3.7.1",
         "next": "16.1.6",
         "react": "19.2.3",
@@ -722,6 +723,47 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@fast-csv/format": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/@fast-csv/format/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
+    "node_modules/@fast-csv/parse": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+      "integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "node_modules/@fast-csv/parse/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -3428,6 +3470,81 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3641,6 +3758,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -3691,7 +3814,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -3735,11 +3857,49 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3809,6 +3969,56 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "engines": {
+        "node": ">=0.2.0"
       }
     },
     "node_modules/call-bind": {
@@ -3914,6 +4124,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4005,11 +4227,25 @@
         "node": ">=12.20"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
@@ -4032,6 +4268,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -4042,6 +4284,19 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/cross-spawn": {
@@ -4274,6 +4529,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4400,6 +4661,51 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
@@ -4419,6 +4725,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
       "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.0",
@@ -5119,6 +5434,48 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/exceljs": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
+      "integrity": "sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver": "^5.0.0",
+        "dayjs": "^1.8.34",
+        "fast-csv": "^4.3.1",
+        "jszip": "^3.10.1",
+        "readable-stream": "^3.6.0",
+        "saxes": "^5.0.1",
+        "tmp": "^0.2.0",
+        "unzipper": "^0.10.11",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/exceljs/node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/exceljs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5127,6 +5484,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-csv": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+      "integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@fast-csv/parse": "4.3.6"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5307,6 +5677,18 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5320,6 +5702,22 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/function-bind": {
@@ -5453,6 +5851,27 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -5513,7 +5932,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-bigints": {
@@ -5676,6 +6094,26 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5685,6 +6123,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/immer": {
       "version": "10.2.0",
@@ -5721,6 +6165,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -6433,6 +6888,54 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6463,6 +6966,54 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -6475,6 +7026,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -6757,6 +7317,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "license": "ISC"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -6773,11 +7339,90 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -6903,7 +7548,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -6916,10 +7560,21 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/ms": {
@@ -7077,6 +7732,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/normalize-svg-path": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
@@ -7219,6 +7883,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7332,6 +8005,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -7492,6 +8174,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7590,6 +8278,50 @@
         "redux": {
           "optional": true
         }
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/recharts": {
@@ -7773,6 +8505,19 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/rolldown": {
@@ -7984,6 +8729,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -8452,6 +9203,22 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
@@ -8557,6 +9324,15 @@
       "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
       "license": "MIT"
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8592,6 +9368,15 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ts-algebra": {
@@ -8874,6 +9659,60 @@
         "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/unzipper/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/unzipper/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -9622,6 +10461,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
@@ -9704,6 +10549,41 @@
       "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
       "license": "MIT"
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@supabase/supabase-js": "^2.99.1",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.37.0",
+    "exceljs": "^4.4.0",
     "isomorphic-dompurify": "^3.7.1",
     "next": "16.1.6",
     "react": "19.2.3",

--- a/supabase/migrations/20260511000000_ca_jours_fermes.sql
+++ b/supabase/migrations/20260511000000_ca_jours_fermes.sql
@@ -1,0 +1,45 @@
+-- ============================================================================
+-- ca_jours_fermes : liste de dates marquées comme fermées / fériées / spéciales.
+--
+-- Géré depuis la page /controle-gestion/ventes/budgets (modal "Jours fermés").
+-- Utilisé pour pré-remplir la colonne Exception du fichier Excel équipes :
+-- les dates listées ici apparaîtront avec leur motif dans la Synthèse,
+-- et leurs cumuls Budget/Réel seront exclus automatiquement par les
+-- formules SUMIF.
+--
+-- Une date par client, motif libre ("Férié", "Privatisation", "Vacances"…).
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.ca_jours_fermes (
+  id         uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id  uuid        NOT NULL REFERENCES public.clients (id) ON DELETE CASCADE,
+  date       date        NOT NULL,
+  motif      text        NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT ca_jours_fermes_unique UNIQUE (client_id, date)
+);
+
+COMMENT ON TABLE public.ca_jours_fermes IS
+  'Dates marquées comme fermées / fériées par le client. Utilisé pour pré-remplir la colonne Exception du fichier Excel équipes (et plus tard pour ajuster les cumuls sur /analyses).';
+
+CREATE INDEX IF NOT EXISTS ca_jours_fermes_client_date_idx
+  ON public.ca_jours_fermes (client_id, date);
+
+-- Trigger updated_at (réutilise la fonction posée par 20260506000000_ca_journalier.sql)
+DROP TRIGGER IF EXISTS trg_ca_jours_fermes_updated_at ON public.ca_jours_fermes;
+CREATE TRIGGER trg_ca_jours_fermes_updated_at
+  BEFORE UPDATE ON public.ca_jours_fermes
+  FOR EACH ROW EXECUTE FUNCTION public.ca_set_updated_at();
+
+-- RLS — même pattern que les autres tables CA
+ALTER TABLE public.ca_jours_fermes ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ca_jours_fermes_select ON public.ca_jours_fermes FOR SELECT TO authenticated
+  USING (public.user_has_client_access(client_id));
+CREATE POLICY ca_jours_fermes_insert ON public.ca_jours_fermes FOR INSERT TO authenticated
+  WITH CHECK (public.user_has_client_access(client_id));
+CREATE POLICY ca_jours_fermes_update ON public.ca_jours_fermes FOR UPDATE TO authenticated
+  USING (public.user_has_client_access(client_id))
+  WITH CHECK (public.user_has_client_access(client_id));
+CREATE POLICY ca_jours_fermes_delete ON public.ca_jours_fermes FOR DELETE TO authenticated
+  USING (public.user_has_client_access(client_id));

--- a/supabase/migrations/20260511000001_ca_jours_fermes_hebdo.sql
+++ b/supabase/migrations/20260511000001_ca_jours_fermes_hebdo.sql
@@ -1,0 +1,42 @@
+-- ============================================================================
+-- ca_jours_fermes_hebdo : fermetures hebdomadaires récurrentes (toute l'année).
+--
+-- Complète ca_jours_fermes (qui gère des dates spécifiques) pour le cas
+-- typique du restaurant fermé tous les lundis-mardis, par exemple. Inutile
+-- de saisir 52 fois "Lundi 5 janvier", "Lundi 12 janvier", etc.
+--
+-- Le merge des deux tables se fait côté app (page Budgets) avant de passer
+-- le map joursFermes au builder Excel.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.ca_jours_fermes_hebdo (
+  id           uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id    uuid        NOT NULL REFERENCES public.clients (id) ON DELETE CASCADE,
+  jour_semaine smallint    NOT NULL CHECK (jour_semaine BETWEEN 1 AND 7),
+  motif        text        NOT NULL DEFAULT 'Fermé',
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT ca_jours_fermes_hebdo_unique UNIQUE (client_id, jour_semaine)
+);
+
+COMMENT ON TABLE public.ca_jours_fermes_hebdo IS
+  'Fermetures hebdomadaires récurrentes (ex : tous les lundis). Complète ca_jours_fermes pour les dates ponctuelles. 1=lundi … 7=dimanche (ISO).';
+
+CREATE INDEX IF NOT EXISTS ca_jours_fermes_hebdo_client_idx
+  ON public.ca_jours_fermes_hebdo (client_id);
+
+DROP TRIGGER IF EXISTS trg_ca_jours_fermes_hebdo_updated_at ON public.ca_jours_fermes_hebdo;
+CREATE TRIGGER trg_ca_jours_fermes_hebdo_updated_at
+  BEFORE UPDATE ON public.ca_jours_fermes_hebdo
+  FOR EACH ROW EXECUTE FUNCTION public.ca_set_updated_at();
+
+ALTER TABLE public.ca_jours_fermes_hebdo ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ca_jours_fermes_hebdo_select ON public.ca_jours_fermes_hebdo FOR SELECT TO authenticated
+  USING (public.user_has_client_access(client_id));
+CREATE POLICY ca_jours_fermes_hebdo_insert ON public.ca_jours_fermes_hebdo FOR INSERT TO authenticated
+  WITH CHECK (public.user_has_client_access(client_id));
+CREATE POLICY ca_jours_fermes_hebdo_update ON public.ca_jours_fermes_hebdo FOR UPDATE TO authenticated
+  USING (public.user_has_client_access(client_id))
+  WITH CHECK (public.user_has_client_access(client_id));
+CREATE POLICY ca_jours_fermes_hebdo_delete ON public.ca_jours_fermes_hebdo FOR DELETE TO authenticated
+  USING (public.user_has_client_access(client_id));


### PR DESCRIPTION
## Summary
Bouton 📤 **Excel équipes** sur la page Budgets CA : génère un fichier mensuel à envoyer aux équipes en début de mois. Les équipes le remplissent au fil de l'eau avec les CA réels — la comparaison vs budget se calcule automatiquement.

Reproduit le format historique Marsan (cf. screenshot du brief).

## Contenu du fichier
### 1 onglet par jour (`DD-MM`)
Reproduit la grille de saisie historique :
- **Lignes** : Couverts / CA TTC / Autres CA / Ticket Moyen / Ticket Budget
- **Colonnes** : pour chaque lieu actif, 3 colonnes (Déjeuner / Dîner / Tot)
- **Ticket Budget** pré-rempli (jaune) depuis `ca_budgets`
- **Ticket Moyen** calculé par formule (`=CA/Couverts`)
- **Tot** calculé par formule (`=Déj+Dîn`)
- **Pavés synthèse en bas** : CA Journée vs Budget · Couverts Midi/Soir/Jour vs Budget · **Mensuel Réel vs Budget** → toutes les comparaisons en formules
- **Boîtes à cannelé** en haut à droite (spécifique Marsan)

### 1 onglet « Synthèse »
1 ligne par jour avec : Date · Jour · Ouverture · Couv réel · CA réel · Budget jour · Δ · **Cumul Budget · Cumul Réel · Δ Cumul · Δ %** — tout en formules référençant les onglets jour.

### Jours fermés
Onglet grisé avec bandeau **« JOUR FERMÉ »** quand aucun budget n'est défini pour ce jour-de-semaine.

## Implémentation
- Nouvelle dép : [`exceljs`](https://github.com/exceljs/exceljs) (~500 KB). La lib `xlsx` actuelle ne gère pas les styles (couleurs jaune/vert/gris) ni les formules avancées avec mise en forme conditionnelle.
- [`lib/budgetsExcelTemplate.js`](lib/budgetsExcelTemplate.js) : builder pur (sans Supabase ni React), testable.
- **+14 tests vitest** (126 → 140, tous verts).
- Téléchargement direct côté client via `Blob + URL.createObjectURL` → pas de passage serveur.

## UI
Sélecteur de mois + bouton 📤 dans la TopBar, à côté du bouton Importer Excel. Le mois sélectionné par défaut = mois courant.

## Test plan
- [ ] Aller sur `/controle-gestion/ventes/budgets`, sélectionner Mai 2026, cliquer **📤 Excel équipes** → un fichier `suivi-ca_2026-05.xlsx` se télécharge.
- [ ] Ouvrir le fichier : vérifier la présence de 32 onglets (Synthèse + 31 jours).
- [ ] Sur un onglet jour ouvert (ex : `02-05` samedi) : les cellules Ticket Budget sont jaunes et pré-remplies, le pavé CA Journée affiche `0 €` (pas encore rempli).
- [ ] Remplir manuellement les Couverts et CA TTC → Ticket Moyen et pavés écart se mettent à jour automatiquement.
- [ ] Sur un onglet jour fermé (ex : `04-05` lundi) : la grille est grisée, bandeau « JOUR FERMÉ » visible.
- [ ] Onglet Synthèse : ligne 2 = 01-05, dernière ligne = total Mai. Les formules `Cumul Budget`, `Cumul Réel`, `Δ Cumul` se calculent quand on saisit des données.

🤖 Generated with [Claude Code](https://claude.com/claude-code)