### PR TITLE
feat(rapport-hebdo): page MVP rapport hebdomadaire à envoyer aux équipes

### DIFF
--- a/app/controle-gestion/ventes/rapport-hebdo/page.js
+++ b/app/controle-gestion/ventes/rapport-hebdo/page.js
@@ -1,0 +1,466 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase, getClientId } from '../../../../lib/supabase'
+import { useIsMobile } from '../../../../lib/useIsMobile'
+import { useTheme } from '../../../../lib/useTheme'
+import { useRole } from '../../../../lib/useRole'
+import Navbar from '../../../../components/Navbar'
+import RapportSections from '../../../../components/rapport-hebdo/RapportSections'
+import {
+  buildRapportData,
+  semaineEnCours,
+  semainePrecedente,
+  formatPeriode,
+} from '../../../../lib/rapportHebdo'
+import { buildRapportHtml, downloadHtmlFile, copyHtmlToClipboard } from '../../../../lib/rapportHebdoExport'
+
+const DEBUG_FALLBACK_CLIENT_ID = 'fa725e66-2cad-4ea4-892a-7eb3e90496a7'
+
+export default function RapportHebdoPage() {
+  const router = useRouter()
+  const { c } = useTheme()
+  const isMobile = useIsMobile()
+  const { role, loading: roleLoading } = useRole()
+
+  const [authReady, setAuthReady] = useState(false)
+  const [clientId, setClientId] = useState(null)
+  const [error, setError] = useState('')
+  const [okMsg, setOkMsg] = useState('')
+
+  // Période sélectionnée (par défaut : semaine précédente — le rapport
+  // s'envoie le lundi matin sur la semaine passée).
+  const initialPeriode = useMemo(() => semainePrecedente(), [])
+  const [debut, setDebut] = useState(initialPeriode.debut)
+  const [fin, setFin] = useState(initialPeriode.fin)
+
+  // Données chargées
+  const [lieux, setLieux] = useState([])
+  const [caRows, setCaRows] = useState([])
+  const [budgetRows, setBudgetRows] = useState([])
+  const [loading, setLoading] = useState(false)
+
+  // Commentaire et rapport courant (id si chargé depuis archive)
+  const [commentaire, setCommentaire] = useState('')
+  const [currentRapportId, setCurrentRapportId] = useState(null)
+  const [titre, setTitre] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  // Archives
+  const [archives, setArchives] = useState([])
+  const [archivesLoading, setArchivesLoading] = useState(false)
+
+  // ── Auth ────────────────────────────────────────────────────────────────
+  useEffect(() => {
+    let cancel = false
+    ;(async () => {
+      try {
+        const { data: sessionData } = await supabase.auth.getSession()
+        if (cancel) return
+        if (!sessionData?.session) { router.replace('/'); return }
+        let cid = await getClientId()
+        if (!cid) cid = DEBUG_FALLBACK_CLIENT_ID
+        if (cancel) return
+        setClientId(cid)
+        setAuthReady(true)
+      } catch (e) {
+        if (cancel) return
+        setClientId(DEBUG_FALLBACK_CLIENT_ID)
+        setAuthReady(true)
+      }
+    })()
+    return () => { cancel = true }
+  }, [router])
+
+  // Restreint l'accès aux profils admin / directeur
+  useEffect(() => {
+    if (roleLoading || !role) return
+    if (role !== 'admin' && role !== 'directeur') router.replace('/dashboard')
+  }, [role, roleLoading, router])
+
+  // ── Chargement des données pour la période ──────────────────────────────
+  const loadData = useCallback(async () => {
+    if (!clientId) return
+    setLoading(true)
+    setError('')
+    try {
+      // On a besoin des ca_journalier et ca_budgets pour TOUS les mois
+      // touchés par la période (peut chevaucher 2 mois). On charge sur
+      // un range qui couvre.
+      const [y1, m1] = debut.split('-').map(Number)
+      const [y2, m2] = fin.split('-').map(Number)
+      const annees = Array.from(new Set([y1, y2]))
+
+      const [lieuxRes, caRes, budgetRes] = await Promise.all([
+        supabase
+          .from('lieux_service')
+          .select('id, nom, ordre, actif')
+          .eq('client_id', clientId)
+          .eq('actif', true)
+          .order('ordre').order('nom'),
+        supabase
+          .from('ca_journalier')
+          .select('jour, service, lieu_service_id, couverts, ca_food, ca_bev_20, ca_bev_10, ca_autre')
+          .eq('client_id', clientId)
+          .gte('jour', debut)
+          .lte('jour', fin),
+        supabase
+          .from('ca_budgets')
+          .select('annee, mois, jour_semaine, lieu_service_id, service, couverts_cible, ca_food_cible, ca_bev_20_cible, ca_bev_10_cible, ca_autre_cible')
+          .eq('client_id', clientId)
+          .in('annee', annees),
+      ])
+      if (lieuxRes.error) throw lieuxRes.error
+      if (caRes.error) throw caRes.error
+      if (budgetRes.error) throw budgetRes.error
+      setLieux(lieuxRes.data || [])
+      setCaRows(caRes.data || [])
+      setBudgetRows(budgetRes.data || [])
+      // Pour le cumul mois, on a besoin aussi des CA depuis le 1er du mois
+      // de `fin`. On élargit si nécessaire.
+      const firstOfMonth = `${y2}-${String(m2).padStart(2, '0')}-01`
+      if (firstOfMonth < debut) {
+        const extraCa = await supabase
+          .from('ca_journalier')
+          .select('jour, service, lieu_service_id, couverts, ca_food, ca_bev_20, ca_bev_10, ca_autre')
+          .eq('client_id', clientId)
+          .gte('jour', firstOfMonth)
+          .lt('jour', debut)
+        if (!extraCa.error) setCaRows((prev) => [...(extraCa.data || []), ...prev])
+      }
+      void y1; void m1
+    } catch (e) {
+      setError(e.message || 'Erreur de chargement')
+    } finally {
+      setLoading(false)
+    }
+  }, [clientId, debut, fin])
+
+  useEffect(() => {
+    if (authReady && clientId) loadData()
+  }, [authReady, clientId, loadData])
+
+  // ── Chargement des archives ────────────────────────────────────────────
+  const loadArchives = useCallback(async () => {
+    if (!clientId) return
+    setArchivesLoading(true)
+    try {
+      const { data, error: e } = await supabase
+        .from('ca_rapports_hebdo')
+        .select('id, debut, fin, titre, commentaire, created_at, updated_at')
+        .eq('client_id', clientId)
+        .order('debut', { ascending: false })
+        .limit(50)
+      if (e) throw e
+      setArchives(data || [])
+    } catch (e) {
+      setError(e.message || 'Erreur de chargement archives')
+    } finally {
+      setArchivesLoading(false)
+    }
+  }, [clientId])
+
+  useEffect(() => { if (authReady && clientId) loadArchives() }, [authReady, clientId, loadArchives])
+
+  // ── Données dérivées ────────────────────────────────────────────────────
+  const lieuxMap = useMemo(() => new Map(lieux.map((l) => [l.id, l.nom])), [lieux])
+  const data = useMemo(() => buildRapportData({ caRows, budgetRows, lieuxMap, debut, fin }),
+    [caRows, budgetRows, lieuxMap, debut, fin])
+
+  // ── Actions ─────────────────────────────────────────────────────────────
+  const handleSemainePrec = () => {
+    setCurrentRapportId(null); setCommentaire(''); setTitre('')
+    const p = semainePrecedente()
+    setDebut(p.debut); setFin(p.fin)
+  }
+  const handleSemaineCour = () => {
+    setCurrentRapportId(null); setCommentaire(''); setTitre('')
+    const p = semaineEnCours()
+    setDebut(p.debut); setFin(p.fin)
+  }
+
+  const handleSave = async () => {
+    if (!clientId) return
+    setSaving(true)
+    setError('')
+    setOkMsg('')
+    try {
+      if (currentRapportId) {
+        const { error: e } = await supabase
+          .from('ca_rapports_hebdo')
+          .update({ debut, fin, commentaire, titre: titre || null })
+          .eq('id', currentRapportId)
+        if (e) throw e
+        setOkMsg('Rapport mis à jour.')
+      } else {
+        const { data: ins, error: e } = await supabase
+          .from('ca_rapports_hebdo')
+          .insert({ client_id: clientId, debut, fin, commentaire, titre: titre || null })
+          .select('id')
+          .single()
+        if (e) throw e
+        setCurrentRapportId(ins.id)
+        setOkMsg('Rapport sauvegardé.')
+      }
+      await loadArchives()
+    } catch (e) {
+      setError(e.message || 'Erreur de sauvegarde')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleLoad = (rapport) => {
+    setCurrentRapportId(rapport.id)
+    setDebut(rapport.debut)
+    setFin(rapport.fin)
+    setCommentaire(rapport.commentaire || '')
+    setTitre(rapport.titre || '')
+    setOkMsg('')
+    setError('')
+  }
+
+  const handleDelete = async (id) => {
+    if (!confirm('Supprimer ce rapport ?')) return
+    try {
+      const { error: e } = await supabase.from('ca_rapports_hebdo').delete().eq('id', id)
+      if (e) throw e
+      if (id === currentRapportId) setCurrentRapportId(null)
+      await loadArchives()
+    } catch (e) {
+      setError(e.message || 'Erreur de suppression')
+    }
+  }
+
+  const handleNouveau = () => {
+    setCurrentRapportId(null)
+    setCommentaire('')
+    setTitre('')
+    setOkMsg('')
+    setError('')
+  }
+
+  const handleCopyEmail = async () => {
+    setError(''); setOkMsg('')
+    try {
+      const html = buildRapportHtml({ data, debut, fin, commentaire, titre })
+      await copyHtmlToClipboard(html)
+      setOkMsg('Rapport copié dans le presse-papier — colle dans Gmail / Outlook.')
+    } catch (e) {
+      setError(e.message || 'Erreur lors de la copie')
+    }
+  }
+
+  const handleDownloadHtml = () => {
+    setError(''); setOkMsg('')
+    try {
+      const html = buildRapportHtml({ data, debut, fin, commentaire, titre })
+      downloadHtmlFile(html, `rapport-ca_${debut}_${fin}.html`)
+    } catch (e) {
+      setError(e.message || 'Erreur lors du téléchargement')
+    }
+  }
+
+  if (!authReady) {
+    return (
+      <div style={{ minHeight: '100vh', background: c.fond, display: 'flex', alignItems: 'center', justifyContent: 'center', color: c.texteMuted, fontSize: 14 }}>
+        Chargement…
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ minHeight: '100vh', background: c.fond }}>
+      <Navbar section="cuisine" />
+      <div style={{ padding: isMobile ? 16 : 24, maxWidth: 1400, margin: '0 auto' }}>
+        {/* Header */}
+        <div style={{ marginBottom: 16, display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 12, flexWrap: 'wrap' }}>
+          <div>
+            <h1 style={{ margin: '0 0 4px', fontSize: isMobile ? 22 : 26, fontWeight: 600, color: c.texte }}>
+              Rapport hebdomadaire
+            </h1>
+            <p style={{ margin: 0, fontSize: 14, color: c.texteMuted }}>
+              {formatPeriode(debut, fin)}
+              {currentRapportId && <span style={{ marginLeft: 8, color: c.accent, fontWeight: 500 }}>• rapport archivé</span>}
+            </p>
+          </div>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            <button onClick={handleSemainePrec} style={btnSecondary(c)}>Semaine précédente</button>
+            <button onClick={handleSemaineCour} style={btnSecondary(c)}>Semaine en cours</button>
+            <button onClick={handleNouveau} style={btnSecondary(c)} title="Nouveau rapport vide">+ Nouveau</button>
+          </div>
+        </div>
+
+        {/* Filtres période */}
+        <div style={{
+          background: c.blanc, border: `0.5px solid ${c.bordure}`, borderRadius: 12,
+          padding: isMobile ? 12 : 16, marginBottom: 20,
+          display: 'flex', flexWrap: 'wrap', gap: 12, alignItems: 'center',
+        }}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, color: c.texteMuted }}>
+            Du
+            <input type="date" value={debut} onChange={(e) => setDebut(e.target.value)}
+              style={dateInputStyle(c)} />
+          </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, color: c.texteMuted }}>
+            au
+            <input type="date" value={fin} onChange={(e) => setFin(e.target.value)}
+              style={dateInputStyle(c)} />
+          </label>
+          <input type="text" value={titre} onChange={(e) => setTitre(e.target.value)}
+            placeholder="Titre optionnel (ex: Rapport semaine 19)"
+            style={{ ...dateInputStyle(c), flex: 1, minWidth: 200 }} />
+        </div>
+
+        {error && <p style={{ color: '#B91C1C', fontSize: 14, marginBottom: 12 }}>{error}</p>}
+        {okMsg && <p style={{ color: '#15803D', fontSize: 14, marginBottom: 12 }}>{okMsg}</p>}
+
+        <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 280px', gap: isMobile ? 16 : 20 }}>
+          {/* Rapport rendu */}
+          <div style={{
+            background: c.blanc, border: `0.5px solid ${c.bordure}`, borderRadius: 12,
+            padding: isMobile ? 16 : 24,
+          }}>
+            <p style={{ margin: '0 0 14px', fontSize: 14, color: c.texte }}>
+              Bonjour à tous,
+            </p>
+            <p style={{ margin: '0 0 14px', fontSize: 14, color: c.texte }}>
+              Ci-dessous le rapport du CA pour la <strong>période {formatPeriode(debut, fin)}</strong> ainsi
+              que le cumul depuis le début du mois :
+            </p>
+
+            {loading ? (
+              <p style={{ color: c.texteMuted, fontSize: 14 }}>Chargement des données…</p>
+            ) : (
+              <RapportSections c={c} data={data} debut={debut} fin={fin} />
+            )}
+
+            {/* Commentaires */}
+            <div style={{ marginTop: 24 }}>
+              <h3 style={{
+                fontSize: 14, fontWeight: 600, color: c.accent,
+                margin: '0 0 8px', textTransform: 'uppercase', letterSpacing: 0.4,
+              }}>
+                Commentaires
+              </h3>
+              <textarea
+                value={commentaire}
+                onChange={(e) => setCommentaire(e.target.value)}
+                placeholder="Précisions / analyses qualitatives à inclure dans l'email…"
+                rows={6}
+                style={{
+                  width: '100%',
+                  padding: '10px 12px', borderRadius: 8,
+                  border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte,
+                  fontSize: 14, fontFamily: 'inherit', resize: 'vertical', lineHeight: 1.5,
+                }}
+              />
+            </div>
+
+            {/* Actions */}
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 16 }}>
+              <button onClick={handleSave} disabled={saving} style={btnPrimary(c, saving)}>
+                {saving ? 'Sauvegarde…' : currentRapportId ? '💾 Mettre à jour' : '💾 Sauvegarder'}
+              </button>
+              <button onClick={handleCopyEmail} style={btnSecondary(c)}>
+                📋 Copier pour email
+              </button>
+              <button onClick={handleDownloadHtml} style={btnSecondary(c)}>
+                📥 Télécharger HTML
+              </button>
+            </div>
+          </div>
+
+          {/* Sidebar archives */}
+          <aside style={{
+            background: c.blanc, border: `0.5px solid ${c.bordure}`, borderRadius: 12,
+            padding: 12, alignSelf: 'start',
+          }}>
+            <div style={{ fontSize: 12, color: c.texteMuted, fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.4, marginBottom: 10 }}>
+              Archives
+            </div>
+            {archivesLoading ? (
+              <div style={{ fontSize: 12, color: c.texteMuted }}>Chargement…</div>
+            ) : archives.length === 0 ? (
+              <div style={{ fontSize: 12, color: c.texteMuted, padding: '12px 0' }}>
+                Aucun rapport sauvegardé. Crée-en un depuis cette page.
+              </div>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                {archives.map((r) => (
+                  <ArchiveRow
+                    key={r.id}
+                    c={c}
+                    rapport={r}
+                    active={r.id === currentRapportId}
+                    onLoad={() => handleLoad(r)}
+                    onDelete={() => handleDelete(r.id)}
+                  />
+                ))}
+              </div>
+            )}
+          </aside>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ArchiveRow({ c, rapport, active, onLoad, onDelete }) {
+  return (
+    <div style={{
+      padding: '8px 10px', borderRadius: 6,
+      border: `1px solid ${active ? c.accent : c.bordure}`,
+      background: active ? c.accentClair : 'transparent',
+      cursor: 'pointer',
+    }}
+      onClick={onLoad}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 6 }}>
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div style={{ fontSize: 12, fontWeight: 600, color: c.texte, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {rapport.titre || formatPeriode(rapport.debut, rapport.fin)}
+          </div>
+          <div style={{ fontSize: 11, color: c.texteMuted }}>
+            {rapport.debut} → {rapport.fin}
+          </div>
+        </div>
+        <button
+          onClick={(e) => { e.stopPropagation(); onDelete() }}
+          style={{
+            background: 'transparent', border: 'none', color: c.texteMuted,
+            cursor: 'pointer', fontSize: 14, padding: '2px 6px',
+          }}
+          title="Supprimer"
+        >
+          🗑
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function btnPrimary(c, disabled) {
+  return {
+    padding: '8px 14px', borderRadius: 8, fontSize: 13,
+    border: 'none', background: c.accent, color: c.texte,
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    fontWeight: 600, opacity: disabled ? 0.6 : 1,
+  }
+}
+
+function btnSecondary(c) {
+  return {
+    padding: '8px 14px', borderRadius: 8, fontSize: 13,
+    border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte,
+    cursor: 'pointer',
+  }
+}
+
+function dateInputStyle(c) {
+  return {
+    padding: '7px 10px', borderRadius: 8, fontSize: 13,
+    border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte,
+  }
+}

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -204,6 +204,7 @@ export default function Navbar({ section = 'cuisine' }) {
             { label: 'Mercuriale',    path: '/controle-gestion/mercuriale' },
             ...(role === 'admin' || role === 'directeur' ? [{ label: 'Analyses',      path: '/controle-gestion/analyses' }] : []),
             { label: 'Suivi CA',      path: '/controle-gestion/ventes' },
+            ...(role === 'admin' || role === 'directeur' ? [{ label: 'Rapport hebdo',  path: '/controle-gestion/ventes/rapport-hebdo' }] : []),
             { label: 'Budgets CA',    path: '/controle-gestion/ventes/budgets' },
             ...(role === 'admin' ? [{ label: 'Import ventes', path: '/controle-gestion/import' }] : []),
           ]

--- a/components/rapport-hebdo/RapportSections.js
+++ b/components/rapport-hebdo/RapportSections.js
@@ -1,0 +1,244 @@
+'use client'
+
+// Rendu des sections du rapport hebdo (UI pure : prend les data dérivées par
+// lib/rapportHebdo.js et les affiche au format proche du mail historique
+// Marsan). Utilisé par la page in-app ET par l'export HTML autonome.
+
+import {
+  formatEur, formatPct, formatPctSimple, formatNombre, formatPeriode,
+} from '../../lib/rapportHebdo'
+
+const SERVICE_LABEL = { lunch: 'déjeuner', dinner: 'dîner' }
+
+export function SectionCaTtc({ c, data, periodeLabel, cumulLabel }) {
+  const { ca, caMois } = data
+  return (
+    <div style={{ marginBottom: 20 }}>
+      <p style={{ margin: '0 0 10px', fontSize: 14, color: c.texte }}>
+        <strong>Le CATTC réalisé {periodeLabel}</strong> s&apos;élève à{' '}
+        <strong>{formatEur(ca.real)}</strong> pour un budget de{' '}
+        <strong>{formatEur(ca.budget)}</strong>
+        {ca.ratio != null && <> soit <strong style={{ color: ca.ratio >= 0 ? c.vert : c.rouge }}>
+          {formatPct(ca.ratio)}
+        </strong></>}
+      </p>
+      <p style={{ margin: '0 0 10px', fontSize: 14, color: c.texte }}>
+        Le CATTC réalisé {cumulLabel} s&apos;élève à{' '}
+        <strong>{formatEur(caMois.real)}</strong> pour un budget de{' '}
+        <strong>{formatEur(caMois.budget)}</strong>
+        {caMois.ratio != null && <> soit <strong style={{ color: caMois.ratio >= 0 ? c.vert : c.rouge }}>
+          {formatPct(caMois.ratio)}
+        </strong></>}
+      </p>
+    </div>
+  )
+}
+
+export function SectionTicketMoyenLieux({ c, tmLieux, titre }) {
+  if (tmLieux.length === 0) return null
+  return (
+    <Section c={c} titre={titre || 'Ticket moyen par lieu × service'}>
+      <ul style={ulStyle}>
+        {tmLieux.map((r) => (
+          <li key={`${r.lieu_id}_${r.service}`} style={liStyle}>
+            Ticket moyen <strong>{r.lieu_label} {SERVICE_LABEL[r.service]}</strong>{' '}
+            <strong>{r.real_tm != null ? formatEur(r.real_tm) : '—'}</strong>{' '}
+            pour un budget de{' '}
+            <strong>{r.budget_tm != null ? formatEur(r.budget_tm) : '—'}</strong>
+            {r.ratio_tm != null && <>, soit{' '}
+              <strong style={{ color: r.ratio_tm >= 0 ? c.vert : c.rouge }}>{formatPct(r.ratio_tm)}</strong>
+            </>}
+          </li>
+        ))}
+      </ul>
+    </Section>
+  )
+}
+
+export function SectionTmFoodBev({ c, tmFb, titre }) {
+  const fmtLine = (label, real, budget, ratio) => (
+    <li style={liStyle}>
+      Ticket moyen <strong>{label}</strong>{' '}
+      <strong>{real != null ? formatEur(real) : '—'}</strong>{' '}
+      pour un budget de <strong>{budget != null ? formatEur(budget) : '—'}</strong>
+      {ratio != null && <>, soit <strong style={{ color: ratio >= 0 ? c.vert : c.rouge }}>{formatPct(ratio)}</strong></>}
+    </li>
+  )
+  return (
+    <Section c={c} titre={titre || 'Ticket moyen Food et Beverage par service'}>
+      <ul style={ulStyle}>
+        {fmtLine('Food midi',      tmFb.midi.real_tm_food, tmFb.midi.budget_tm_food, tmFb.midi.ratio_food)}
+        {fmtLine('Beverage midi',  tmFb.midi.real_tm_bev,  tmFb.midi.budget_tm_bev,  tmFb.midi.ratio_bev)}
+        {fmtLine('Food soir',      tmFb.soir.real_tm_food, tmFb.soir.budget_tm_food, tmFb.soir.ratio_food)}
+        {fmtLine('Beverage soir',  tmFb.soir.real_tm_bev,  tmFb.soir.budget_tm_bev,  tmFb.soir.ratio_bev)}
+        {fmtLine('Food total',     tmFb.total.real_tm_food, tmFb.total.budget_tm_food, tmFb.total.ratio_food)}
+        {fmtLine('Beverage Total', tmFb.total.real_tm_bev,  tmFb.total.budget_tm_bev,  tmFb.total.ratio_bev)}
+      </ul>
+    </Section>
+  )
+}
+
+export function SectionMixFoodBev({ c, mix, titre }) {
+  return (
+    <Section c={c} titre={titre || 'Ticket moyen Food et Beverage en % vs TM total'}>
+      <ul style={ulStyle}>
+        <li style={liStyle}>Ticket moyen <strong>Food midi</strong> <strong>{formatPctSimple(mix.midi.food_pct)}</strong> du total</li>
+        <li style={liStyle}>Ticket moyen <strong>Beverage midi</strong> <strong>{formatPctSimple(mix.midi.bev_pct)}</strong> du total</li>
+        <li style={liStyle}>Ticket moyen <strong>Food soir</strong> <strong>{formatPctSimple(mix.soir.food_pct)}</strong> du total</li>
+        <li style={liStyle}>Ticket moyen <strong>Beverage soir</strong> <strong>{formatPctSimple(mix.soir.bev_pct)}</strong> du total</li>
+        <li style={liStyle}>Ticket moyen <strong>Food total</strong> <strong>{formatPctSimple(mix.total.food_pct)}</strong> du total</li>
+        <li style={liStyle}>Ticket moyen <strong>Beverage</strong> <strong>{formatPctSimple(mix.total.bev_pct)}</strong> du total</li>
+      </ul>
+    </Section>
+  )
+}
+
+export function SectionCouverts({ c, couverts, titre }) {
+  return (
+    <Section c={c} titre={titre || 'Nombre de couverts'}>
+      <ul style={ulStyle}>
+        <li style={liStyle}>
+          <strong>Déjeuner</strong> : <strong>{formatNombre(couverts.midi.real)}</strong> couverts pour un budget de{' '}
+          <strong>{formatNombre(couverts.midi.budget)}</strong>
+          {couverts.midi.ratio != null && <> soit <strong style={{ color: couverts.midi.ratio >= 0 ? c.vert : c.rouge }}>{formatPct(couverts.midi.ratio)}</strong></>}
+        </li>
+        <li style={liStyle}>
+          <strong>Dîner</strong> : <strong>{formatNombre(couverts.soir.real)}</strong> couverts pour un budget de{' '}
+          <strong>{formatNombre(couverts.soir.budget)}</strong>
+          {couverts.soir.ratio != null && <> soit <strong style={{ color: couverts.soir.ratio >= 0 ? c.vert : c.rouge }}>{formatPct(couverts.soir.ratio)}</strong></>}
+        </li>
+      </ul>
+    </Section>
+  )
+}
+
+export function SectionCouvertsJpJ({ c, jours, titre }) {
+  if (!jours || jours.length === 0) return null
+  const cellPad = '6px 10px'
+  const head = { padding: cellPad, background: c.fond, color: c.texteMuted, fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.3, borderBottom: `1px solid ${c.bordure}`, textAlign: 'right' }
+  const cell = { padding: cellPad, fontSize: 13, color: c.texte, borderBottom: `0.5px solid ${c.bordure}`, textAlign: 'right' }
+  // Couleur cellule écart % : vert / orange / rouge
+  const ratioBg = (ratio) => {
+    if (ratio == null) return null
+    if (ratio >= 0) return c.vertClair
+    if (ratio > -10) return c.orangeClair
+    return c.rougeClair
+  }
+  const ratioColor = (ratio) => {
+    if (ratio == null) return c.texteMuted
+    if (ratio >= 0) return c.vert
+    if (ratio > -10) return c.orange
+    return c.rouge
+  }
+  // Total
+  const total = jours.reduce((acc, j) => {
+    acc.midi.real += j.midi.real
+    acc.midi.budget += j.midi.budget
+    acc.soir.real += j.soir.real
+    acc.soir.budget += j.soir.budget
+    return acc
+  }, { midi: { real: 0, budget: 0 }, soir: { real: 0, budget: 0 } })
+  total.midi.delta = total.midi.real - total.midi.budget
+  total.midi.ratio = total.midi.budget > 0 ? (total.midi.delta / total.midi.budget) * 100 : null
+  total.soir.delta = total.soir.real - total.soir.budget
+  total.soir.ratio = total.soir.budget > 0 ? (total.soir.delta / total.soir.budget) * 100 : null
+  return (
+    <Section c={c} titre={titre || 'Couverts jour par jour Réel VS Budget'}>
+      <div style={{ overflowX: 'auto', border: `0.5px solid ${c.bordure}`, borderRadius: 8 }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 600 }}>
+          <thead>
+            <tr>
+              <th style={{ ...head, textAlign: 'left' }} rowSpan={2}>Jour</th>
+              <th style={head} colSpan={4}>MIDI</th>
+              <th style={head} colSpan={4}>SOIR</th>
+            </tr>
+            <tr>
+              <th style={head}>Reel</th>
+              <th style={head}>Budget</th>
+              <th style={head}>Écart Nb</th>
+              <th style={head}>Écart %</th>
+              <th style={head}>Reel</th>
+              <th style={head}>Budget</th>
+              <th style={head}>Écart Nb</th>
+              <th style={head}>Écart %</th>
+            </tr>
+          </thead>
+          <tbody>
+            {jours.map((j) => (
+              <tr key={j.iso}>
+                <td style={{ ...cell, textAlign: 'left', fontWeight: 500 }}>{j.jour_fr}</td>
+                <td style={cell}>{formatNombre(j.midi.real)}</td>
+                <td style={cell}>{formatNombre(j.midi.budget)}</td>
+                <td style={cell}>{j.midi.delta !== 0 ? formatNombre(j.midi.delta) : '—'}</td>
+                <td style={{ ...cell, background: ratioBg(j.midi.ratio), color: ratioColor(j.midi.ratio), fontWeight: 600 }}>
+                  {formatPct(j.midi.ratio)}
+                </td>
+                <td style={cell}>{formatNombre(j.soir.real)}</td>
+                <td style={cell}>{formatNombre(j.soir.budget)}</td>
+                <td style={cell}>{j.soir.delta !== 0 ? formatNombre(j.soir.delta) : '—'}</td>
+                <td style={{ ...cell, background: ratioBg(j.soir.ratio), color: ratioColor(j.soir.ratio), fontWeight: 600 }}>
+                  {formatPct(j.soir.ratio)}
+                </td>
+              </tr>
+            ))}
+            <tr style={{ background: c.fond, fontWeight: 600 }}>
+              <td style={{ ...cell, textAlign: 'left' }}>Total</td>
+              <td style={cell}>{formatNombre(total.midi.real)}</td>
+              <td style={cell}>{formatNombre(total.midi.budget)}</td>
+              <td style={cell}></td>
+              <td style={{ ...cell, background: ratioBg(total.midi.ratio), color: ratioColor(total.midi.ratio) }}>
+                {formatPct(total.midi.ratio)}
+              </td>
+              <td style={cell}>{formatNombre(total.soir.real)}</td>
+              <td style={cell}>{formatNombre(total.soir.budget)}</td>
+              <td style={cell}></td>
+              <td style={{ ...cell, background: ratioBg(total.soir.ratio), color: ratioColor(total.soir.ratio) }}>
+                {formatPct(total.soir.ratio)}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </Section>
+  )
+}
+
+// ── Helpers communs ────────────────────────────────────────────────────────
+
+function Section({ c, titre, children }) {
+  return (
+    <div style={{ marginBottom: 24 }}>
+      <h3 style={{
+        fontSize: 14, fontWeight: 600, color: c.accent,
+        margin: '0 0 10px', textTransform: 'uppercase', letterSpacing: 0.4,
+      }}>
+        {titre}
+      </h3>
+      {children}
+    </div>
+  )
+}
+
+const ulStyle = { margin: 0, paddingLeft: 20, fontSize: 14, color: '#000', lineHeight: '1.7' }
+const liStyle = { marginBottom: 4 }
+
+// ── Export agrégé pour utilisation par la page ─────────────────────────────
+
+export default function RapportSections({ c, data, debut, fin }) {
+  const periodeLabel = formatPeriode(debut, fin)
+  // Cumul mois : du 1er au fin (ou jour de la période fin)
+  const finDate = new Date(fin)
+  const monthName = ['janvier','février','mars','avril','mai','juin','juillet','août','septembre','octobre','novembre','décembre'][finDate.getMonth()]
+  const cumulLabel = `depuis le début du mois (au ${formatPeriode(fin, fin).replace('du ', '')})`
+  void monthName
+  return (
+    <div>
+      <SectionCaTtc c={c} data={data} periodeLabel={periodeLabel} cumulLabel={cumulLabel} />
+      <SectionTicketMoyenLieux c={c} tmLieux={data.tmLieux} titre={`Ticket moyen ${periodeLabel}`} />
+      <SectionTmFoodBev c={c} tmFb={data.tmFb} titre={`Ticket moyen Food et Beverage ${periodeLabel} pour le midi et le soir`} />
+      <SectionMixFoodBev c={c} mix={data.mix} titre={`Ticket moyen Food et Beverage en % vs TM total ${periodeLabel} midi et soir`} />
+      <SectionCouverts c={c} couverts={data.couverts} titre={`Nombre de couverts ${periodeLabel}`} />
+      <SectionCouvertsJpJ c={c} jours={data.couvertsJpJ} titre={`Couverts jour par jour Réel VS Budget ${periodeLabel}`} />
+    </div>
+  )
+}

--- a/lib/__tests__/rapportHebdo.test.ts
+++ b/lib/__tests__/rapportHebdo.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest'
+import {
+  caTtcVsBudget,
+  caTtcCumulMois,
+  tmParLieuService,
+  tmFoodBevParService,
+  mixFoodBev,
+  couvertsParService,
+  couvertsJourParJour,
+  buildRapportData,
+  semaineEnCours,
+  semainePrecedente,
+  formatEur,
+  formatPct,
+  formatPeriode,
+} from '../rapportHebdo'
+
+const lieuxMap = new Map([
+  ['L1', 'Salle à manger'],
+  ['L2', 'Table de partage'],
+])
+
+const caRows = [
+  // Mardi 5 mai 2026 - Salle Lunch : 25 couv, 6000 € (food 4000 + bev20 1500 + bev10 500)
+  { jour: '2026-05-05', service: 'lunch',  lieu_service_id: 'L1', couverts: 25, ca_food: 4000, ca_bev_20: 1500, ca_bev_10: 500, ca_autre: 0 },
+  // Mardi 5 mai - Salle Dinner : 40 couv, 12000 € (food 8000 + bev20 3500 + bev10 500)
+  { jour: '2026-05-05', service: 'dinner', lieu_service_id: 'L1', couverts: 40, ca_food: 8000, ca_bev_20: 3500, ca_bev_10: 500, ca_autre: 0 },
+]
+
+// Budget : Salle (L1) ouvert mardi (jds=2)
+const budgetRows = [
+  { annee: 2026, mois: 5, jour_semaine: 2, lieu_service_id: 'L1', service: 'lunch',
+    couverts_cible: 30, ca_food_cible: 5000, ca_bev_20_cible: 2000, ca_bev_10_cible: 500, ca_autre_cible: 0 },
+  { annee: 2026, mois: 5, jour_semaine: 2, lieu_service_id: 'L1', service: 'dinner',
+    couverts_cible: 45, ca_food_cible: 9000, ca_bev_20_cible: 4000, ca_bev_10_cible: 500, ca_autre_cible: 0 },
+]
+
+describe('caTtcVsBudget', () => {
+  it('somme réel et budget sur la période + écart', () => {
+    const res = caTtcVsBudget(caRows, budgetRows, '2026-05-05', '2026-05-05')
+    expect(res.real).toBe(18000)         // 6000 + 12000
+    expect(res.budget).toBe(21000)       // (5000+2000+500) + (9000+4000+500)
+    expect(res.delta).toBe(-3000)
+    expect(res.ratio).toBeCloseTo(-14.28, 1)
+  })
+
+  it('ignore les lignes hors période', () => {
+    const res = caTtcVsBudget(caRows, budgetRows, '2026-05-01', '2026-05-04')
+    expect(res.real).toBe(0)
+  })
+})
+
+describe('caTtcCumulMois', () => {
+  it('cumule depuis le 1er du mois jusqu\'à fin', () => {
+    const res = caTtcCumulMois(caRows, budgetRows, '2026-05-09')
+    // Réel : 18000 (seulement mardi)
+    expect(res.real).toBe(18000)
+    // Budget : tous les mardis dans la période 01-09 mai. Mardi 5 seulement → 21000
+    expect(res.budget).toBe(21000)
+  })
+})
+
+describe('tmParLieuService', () => {
+  it('1 ligne par (lieu, service) avec TM réel et budget', () => {
+    const res = tmParLieuService(caRows, budgetRows, lieuxMap, '2026-05-05', '2026-05-05')
+    expect(res).toHaveLength(2)
+    const lunch = res.find((r) => r.service === 'lunch')
+    expect(lunch.lieu_label).toBe('Salle à manger')
+    expect(lunch.real_tm).toBe(240)      // 6000 / 25
+    expect(lunch.budget_tm).toBe(250)    // 7500 / 30
+    expect(lunch.delta_tm).toBe(-10)
+    expect(lunch.ratio_tm).toBeCloseTo(-4, 1)
+  })
+})
+
+describe('tmFoodBevParService', () => {
+  it('food et bev par service + total', () => {
+    const res = tmFoodBevParService(caRows, budgetRows, '2026-05-05', '2026-05-05')
+    // Midi : food=4000/25=160, bev=2000/25=80
+    expect(res.midi.real_tm_food).toBe(160)
+    expect(res.midi.real_tm_bev).toBe(80)
+    // Budget midi : food=5000/30≈166.67, bev=2500/30≈83.33
+    expect(res.midi.budget_tm_food).toBeCloseTo(166.67, 1)
+    expect(res.midi.budget_tm_bev).toBeCloseTo(83.33, 1)
+    // Soir : food=8000/40=200, bev=4000/40=100
+    expect(res.soir.real_tm_food).toBe(200)
+    expect(res.soir.real_tm_bev).toBe(100)
+  })
+})
+
+describe('mixFoodBev', () => {
+  it('pourcentages Food/Bev du TM total', () => {
+    const tm = tmFoodBevParService(caRows, budgetRows, '2026-05-05', '2026-05-05')
+    const mix = mixFoodBev(tm)
+    // Midi : food 160 / (160+80) = 66.67 %
+    expect(mix.midi.food_pct).toBeCloseTo(66.67, 1)
+    expect(mix.midi.bev_pct).toBeCloseTo(33.33, 1)
+  })
+})
+
+describe('couvertsParService', () => {
+  it('couverts midi/soir/total réel vs budget', () => {
+    const res = couvertsParService(caRows, budgetRows, '2026-05-05', '2026-05-05')
+    expect(res.midi.real).toBe(25)
+    expect(res.midi.budget).toBe(30)
+    expect(res.midi.delta).toBe(-5)
+    expect(res.soir.real).toBe(40)
+    expect(res.total.real).toBe(65)
+    expect(res.total.budget).toBe(75)
+  })
+})
+
+describe('couvertsJourParJour', () => {
+  it('1 ligne par date entre debut et fin', () => {
+    const res = couvertsJourParJour(caRows, budgetRows, '2026-05-05', '2026-05-07')
+    expect(res).toHaveLength(3)
+    expect(res[0].iso).toBe('2026-05-05')
+    expect(res[0].jour_fr).toBe('Mardi')
+    expect(res[0].midi.real).toBe(25)
+    expect(res[0].soir.real).toBe(40)
+    // Mercredi 6 mai : pas de budget jds=3 → real et budget = 0
+    expect(res[1].midi.real).toBe(0)
+    expect(res[1].midi.budget).toBe(0)
+  })
+})
+
+describe('buildRapportData', () => {
+  it('renvoie toutes les sections en un appel', () => {
+    const r = buildRapportData({
+      caRows, budgetRows, lieuxMap,
+      debut: '2026-05-05', fin: '2026-05-05',
+    })
+    expect(r.ca.real).toBe(18000)
+    expect(r.couverts.total.real).toBe(65)
+    expect(r.tmLieux).toHaveLength(2)
+    expect(r.couvertsJpJ).toHaveLength(1)
+  })
+})
+
+describe('semaineEnCours / semainePrecedente', () => {
+  it('lundi-dimanche de la semaine courante', () => {
+    // Mer 6 mai 2026
+    const ref = new Date(2026, 4, 6)
+    expect(semaineEnCours(ref)).toEqual({ debut: '2026-05-04', fin: '2026-05-10' })
+  })
+
+  it('semaine précédente', () => {
+    const ref = new Date(2026, 4, 6)
+    expect(semainePrecedente(ref)).toEqual({ debut: '2026-04-27', fin: '2026-05-03' })
+  })
+})
+
+describe('formatters', () => {
+  it('formatEur arrondi', () => {
+    expect(formatEur(12345)).toMatch(/12\s345/)
+    expect(formatEur(0)).toBe('0 €')
+  })
+  it('formatPct avec signe', () => {
+    expect(formatPct(12.5)).toContain('+')
+    expect(formatPct(-3.14)).toContain('-')
+    expect(formatPct(null)).toBe('—')
+  })
+  it('formatPeriode condensé même mois', () => {
+    expect(formatPeriode('2026-05-05', '2026-05-09')).toBe('du 05 au 09 mai')
+  })
+  it('formatPeriode même date', () => {
+    expect(formatPeriode('2026-05-05', '2026-05-05')).toBe('du 05 mai')
+  })
+})

--- a/lib/rapportHebdo.js
+++ b/lib/rapportHebdo.js
@@ -1,0 +1,494 @@
+// Helpers de calcul pour le rapport hebdomadaire (page /controle-gestion/
+// ventes/rapport-hebdo). Reproduit les sections du mail récap historique :
+// CA TTC réel vs budget, tickets moyens par lieu × service, mix Food/Bev,
+// couverts par service, tableau couverts jour-par-jour.
+//
+// Pas de React ni Supabase ici : on prend les rows brutes en entrée et on
+// renvoie des objets dérivés (testable, réutilisable côté export HTML).
+
+import { TVA_FOOD, TVA_BEV_20, TVA_BEV_10, TVA_AUTRE } from './caAnalyses'
+
+// ── Constantes ─────────────────────────────────────────────────────────────
+
+const JOURS_FR_LONG = ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi']
+const MOIS_LABEL_FR = [
+  '', 'janvier', 'février', 'mars', 'avril', 'mai', 'juin',
+  'juillet', 'août', 'septembre', 'octobre', 'novembre', 'décembre',
+]
+
+function jsWeekdayToIso(jsWeekday) {
+  return jsWeekday === 0 ? 7 : jsWeekday
+}
+
+function fromIso(iso) {
+  const [y, m, d] = iso.split('-').map(Number)
+  return new Date(y, m - 1, d)
+}
+
+function toIso(date) {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+// Itère chaque date ISO entre debut et fin inclus.
+function* eachDayIso(debut, fin) {
+  const start = fromIso(debut)
+  const end = fromIso(fin)
+  const cur = new Date(start)
+  while (cur <= end) {
+    yield {
+      iso: toIso(cur),
+      jsWeekday: cur.getDay(),
+      isoJds: jsWeekdayToIso(cur.getDay()),
+      day: cur.getDate(),
+    }
+    cur.setDate(cur.getDate() + 1)
+  }
+}
+
+// ── Filtrage ────────────────────────────────────────────────────────────────
+
+export function filterCaJournalier(rows, debut, fin) {
+  return (rows || []).filter((r) => r.jour >= debut && r.jour <= fin)
+}
+
+// ── Section 1 : CA TTC réel vs budget ──────────────────────────────────────
+
+// Construit le budget journalier total par jour ISO pour le mois donné.
+// Override mensuel (mois = m) prioritaire sur le défaut (mois = NULL) au
+// niveau de la cellule (jds, lieu, service). Mêmes règles que PR 1.
+function budgetByIsoJdsForMonth(budgetRows, annee, mois) {
+  const cellMap = new Map() // key = `${jds}_${lieu}_${svc}`
+  for (const b of (budgetRows || [])) {
+    if (b.annee != null && Number(b.annee) !== Number(annee)) continue
+    const key = `${b.jour_semaine}_${b.lieu_service_id}_${b.service}`
+    const isOverride = b.mois === mois
+    const existing = cellMap.get(key)
+    if (isOverride) {
+      cellMap.set(key, b)
+    } else if (!existing) {
+      cellMap.set(key, b)
+    }
+  }
+  const out = new Map()
+  for (const cell of cellMap.values()) {
+    const total =
+      Number(cell.ca_food_cible || 0) +
+      Number(cell.ca_bev_20_cible || 0) +
+      Number(cell.ca_bev_10_cible || 0) +
+      Number(cell.ca_autre_cible || 0)
+    out.set(cell.jour_semaine, (out.get(cell.jour_semaine) || 0) + total)
+  }
+  return out
+}
+
+// Renvoie le budget cumulé sur [debut, fin] (itération calendaire stricte,
+// on n'applique pas les overrides nb_jours par souci de simplicité PR A).
+export function periodBudget(budgetRows, debut, fin) {
+  // Cache par mois pour éviter le calcul N fois
+  const cache = new Map()
+  const getMap = (annee, mois) => {
+    const key = `${annee}_${mois}`
+    if (!cache.has(key)) cache.set(key, budgetByIsoJdsForMonth(budgetRows, annee, mois))
+    return cache.get(key)
+  }
+  let total = 0
+  for (const d of eachDayIso(debut, fin)) {
+    const date = fromIso(d.iso)
+    const map = getMap(date.getFullYear(), date.getMonth() + 1)
+    total += map.get(d.isoJds) || 0
+  }
+  return total
+}
+
+// Sommes réel et budget sur une période. Renvoie { real, budget, ratio }.
+export function caTtcVsBudget(caRows, budgetRows, debut, fin) {
+  const filtered = filterCaJournalier(caRows, debut, fin)
+  let real = 0
+  for (const r of filtered) {
+    real += Number(r.ca_food || 0) + Number(r.ca_bev_20 || 0) + Number(r.ca_bev_10 || 0) + Number(r.ca_autre || 0)
+  }
+  const budget = periodBudget(budgetRows, debut, fin)
+  const delta = real - budget
+  const ratio = budget > 0 ? (delta / budget) * 100 : null
+  return { real, budget, delta, ratio }
+}
+
+// Cumul mois (1er du mois au jour de fin). Utilise le mois de `fin`.
+export function caTtcCumulMois(caRows, budgetRows, fin) {
+  const finDate = fromIso(fin)
+  const debut = `${finDate.getFullYear()}-${String(finDate.getMonth() + 1).padStart(2, '0')}-01`
+  return caTtcVsBudget(caRows, budgetRows, debut, fin)
+}
+
+// ── Section 2 : Tickets moyens par lieu × service ──────────────────────────
+
+// Renvoie [{ lieu_label, service, real_tm, budget_tm, ratio }] trié.
+// `lieuxMap` : Map<lieu_service_id, label>
+export function tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin) {
+  const filtered = filterCaJournalier(caRows, debut, fin)
+  // Réel : agrège couverts et CA par (lieu, service)
+  const realMap = new Map()
+  for (const r of filtered) {
+    const key = `${r.lieu_service_id}_${r.service}`
+    if (!realMap.has(key)) realMap.set(key, { couverts: 0, ca: 0 })
+    const acc = realMap.get(key)
+    acc.couverts += Number(r.couverts || 0)
+    acc.ca += Number(r.ca_food || 0) + Number(r.ca_bev_20 || 0) + Number(r.ca_bev_10 || 0) + Number(r.ca_autre || 0)
+  }
+  // Budget : agrège sur chaque jour ouvré du période × jds matchant
+  const budgetMap = new Map() // key = `${lieu}_${svc}` → { couverts_cible, ca_cible }
+  const cacheBudgetByMonth = new Map()
+  const getCellsForMonth = (annee, mois) => {
+    const key = `${annee}_${mois}`
+    if (!cacheBudgetByMonth.has(key)) {
+      const cells = new Map() // key = `${jds}_${lieu}_${svc}`
+      for (const b of (budgetRows || [])) {
+        if (b.annee != null && Number(b.annee) !== Number(annee)) continue
+        const ck = `${b.jour_semaine}_${b.lieu_service_id}_${b.service}`
+        const isOverride = b.mois === mois
+        if (isOverride) cells.set(ck, b)
+        else if (!cells.has(ck)) cells.set(ck, b)
+      }
+      cacheBudgetByMonth.set(key, cells)
+    }
+    return cacheBudgetByMonth.get(key)
+  }
+  for (const d of eachDayIso(debut, fin)) {
+    const date = fromIso(d.iso)
+    const cells = getCellsForMonth(date.getFullYear(), date.getMonth() + 1)
+    for (const cell of cells.values()) {
+      if (cell.jour_semaine !== d.isoJds) continue
+      const key = `${cell.lieu_service_id}_${cell.service}`
+      if (!budgetMap.has(key)) budgetMap.set(key, { couverts_cible: 0, ca_cible: 0 })
+      const acc = budgetMap.get(key)
+      acc.couverts_cible += Number(cell.couverts_cible || 0)
+      acc.ca_cible +=
+        Number(cell.ca_food_cible || 0) +
+        Number(cell.ca_bev_20_cible || 0) +
+        Number(cell.ca_bev_10_cible || 0) +
+        Number(cell.ca_autre_cible || 0)
+    }
+  }
+  // Construit la sortie : 1 ligne par (lieu, service) qui apparaît dans
+  // réel ou budget.
+  const keys = new Set([...realMap.keys(), ...budgetMap.keys()])
+  const out = []
+  for (const key of keys) {
+    const [lieuId, service] = key.split('_')
+    const real = realMap.get(key) || { couverts: 0, ca: 0 }
+    const budget = budgetMap.get(key) || { couverts_cible: 0, ca_cible: 0 }
+    const realTm = real.couverts > 0 ? real.ca / real.couverts : null
+    const budgetTm = budget.couverts_cible > 0 ? budget.ca_cible / budget.couverts_cible : null
+    const delta = realTm != null && budgetTm != null ? realTm - budgetTm : null
+    const ratio = realTm != null && budgetTm != null && budgetTm > 0 ? (delta / budgetTm) * 100 : null
+    out.push({
+      lieu_id: lieuId,
+      lieu_label: lieuxMap.get(lieuId) || lieuId,
+      service,
+      real_couverts: real.couverts,
+      real_ca: real.ca,
+      real_tm: realTm,
+      budget_couverts: budget.couverts_cible,
+      budget_ca: budget.ca_cible,
+      budget_tm: budgetTm,
+      delta_tm: delta,
+      ratio_tm: ratio,
+    })
+  }
+  // Tri : par label lieu puis service (lunch < dinner)
+  out.sort((a, b) => {
+    const cmp = (a.lieu_label || '').localeCompare(b.lieu_label || '', 'fr')
+    if (cmp !== 0) return cmp
+    return a.service === 'lunch' ? -1 : 1
+  })
+  return out
+}
+
+// ── Section 3 : Tickets moyens Food/Beverage par service ───────────────────
+
+// Renvoie { midi: { food, bev, total }, soir: {...}, total: {...} }
+// où chaque objet contient { real_tm, budget_tm, ratio }
+export function tmFoodBevParService(caRows, budgetRows, debut, fin) {
+  const filtered = filterCaJournalier(caRows, debut, fin)
+  // Réel par service
+  const real = {
+    lunch: { couverts: 0, food: 0, bev: 0 },
+    dinner: { couverts: 0, food: 0, bev: 0 },
+  }
+  for (const r of filtered) {
+    const svc = r.service === 'lunch' ? 'lunch' : 'dinner'
+    real[svc].couverts += Number(r.couverts || 0)
+    real[svc].food += Number(r.ca_food || 0)
+    real[svc].bev += Number(r.ca_bev_20 || 0) + Number(r.ca_bev_10 || 0)
+  }
+  // Budget par service — on parcourt les jours du période et on agrège
+  const budget = {
+    lunch: { couverts: 0, food: 0, bev: 0 },
+    dinner: { couverts: 0, food: 0, bev: 0 },
+  }
+  const cache = new Map()
+  for (const d of eachDayIso(debut, fin)) {
+    const date = fromIso(d.iso)
+    const annee = date.getFullYear()
+    const mois = date.getMonth() + 1
+    const ck = `${annee}_${mois}`
+    let cells = cache.get(ck)
+    if (!cells) {
+      cells = new Map()
+      for (const b of (budgetRows || [])) {
+        if (b.annee != null && Number(b.annee) !== Number(annee)) continue
+        const k = `${b.jour_semaine}_${b.lieu_service_id}_${b.service}`
+        const isOverride = b.mois === mois
+        if (isOverride) cells.set(k, b)
+        else if (!cells.has(k)) cells.set(k, b)
+      }
+      cache.set(ck, cells)
+    }
+    for (const cell of cells.values()) {
+      if (cell.jour_semaine !== d.isoJds) continue
+      const svc = cell.service === 'lunch' ? 'lunch' : 'dinner'
+      budget[svc].couverts += Number(cell.couverts_cible || 0)
+      budget[svc].food += Number(cell.ca_food_cible || 0)
+      budget[svc].bev += Number(cell.ca_bev_20_cible || 0) + Number(cell.ca_bev_10_cible || 0)
+    }
+  }
+  const make = (real, budget) => {
+    const realTmFood = real.couverts > 0 ? real.food / real.couverts : null
+    const realTmBev = real.couverts > 0 ? real.bev / real.couverts : null
+    const budgetTmFood = budget.couverts > 0 ? budget.food / budget.couverts : null
+    const budgetTmBev = budget.couverts > 0 ? budget.bev / budget.couverts : null
+    return {
+      real_tm_food: realTmFood,
+      real_tm_bev: realTmBev,
+      budget_tm_food: budgetTmFood,
+      budget_tm_bev: budgetTmBev,
+      delta_food: realTmFood != null && budgetTmFood != null ? realTmFood - budgetTmFood : null,
+      delta_bev: realTmBev != null && budgetTmBev != null ? realTmBev - budgetTmBev : null,
+      ratio_food: realTmFood != null && budgetTmFood != null && budgetTmFood > 0
+        ? ((realTmFood - budgetTmFood) / budgetTmFood) * 100 : null,
+      ratio_bev: realTmBev != null && budgetTmBev != null && budgetTmBev > 0
+        ? ((realTmBev - budgetTmBev) / budgetTmBev) * 100 : null,
+    }
+  }
+  const midi = make(real.lunch, budget.lunch)
+  const soir = make(real.dinner, budget.dinner)
+  const total = make(
+    { couverts: real.lunch.couverts + real.dinner.couverts, food: real.lunch.food + real.dinner.food, bev: real.lunch.bev + real.dinner.bev },
+    { couverts: budget.lunch.couverts + budget.dinner.couverts, food: budget.lunch.food + budget.dinner.food, bev: budget.lunch.bev + budget.dinner.bev },
+  )
+  return { midi, soir, total }
+}
+
+// ── Section 4 : Mix Food/Bev en % du TM ────────────────────────────────────
+
+// Renvoie { midi: { food_pct, bev_pct }, soir, total } basé sur le réel.
+export function mixFoodBev(tmFoodBev) {
+  const calcPct = (svc) => {
+    const food = svc.real_tm_food || 0
+    const bev = svc.real_tm_bev || 0
+    const total = food + bev
+    if (total === 0) return { food_pct: null, bev_pct: null }
+    return { food_pct: (food / total) * 100, bev_pct: (bev / total) * 100 }
+  }
+  return {
+    midi: calcPct(tmFoodBev.midi),
+    soir: calcPct(tmFoodBev.soir),
+    total: calcPct(tmFoodBev.total),
+  }
+}
+
+// ── Section 5 : Couverts midi/soir ─────────────────────────────────────────
+
+export function couvertsParService(caRows, budgetRows, debut, fin) {
+  const filtered = filterCaJournalier(caRows, debut, fin)
+  let realLunch = 0
+  let realDinner = 0
+  for (const r of filtered) {
+    if (r.service === 'lunch') realLunch += Number(r.couverts || 0)
+    else realDinner += Number(r.couverts || 0)
+  }
+  // Budget : somme couverts_cible par service sur la période
+  let budgetLunch = 0
+  let budgetDinner = 0
+  const cache = new Map()
+  for (const d of eachDayIso(debut, fin)) {
+    const date = fromIso(d.iso)
+    const annee = date.getFullYear()
+    const mois = date.getMonth() + 1
+    const ck = `${annee}_${mois}`
+    let cells = cache.get(ck)
+    if (!cells) {
+      cells = new Map()
+      for (const b of (budgetRows || [])) {
+        if (b.annee != null && Number(b.annee) !== Number(annee)) continue
+        const k = `${b.jour_semaine}_${b.lieu_service_id}_${b.service}`
+        const isOverride = b.mois === mois
+        if (isOverride) cells.set(k, b)
+        else if (!cells.has(k)) cells.set(k, b)
+      }
+      cache.set(ck, cells)
+    }
+    for (const cell of cells.values()) {
+      if (cell.jour_semaine !== d.isoJds) continue
+      if (cell.service === 'lunch') budgetLunch += Number(cell.couverts_cible || 0)
+      else budgetDinner += Number(cell.couverts_cible || 0)
+    }
+  }
+  const make = (real, budget) => ({
+    real,
+    budget,
+    delta: real - budget,
+    ratio: budget > 0 ? ((real - budget) / budget) * 100 : null,
+  })
+  return {
+    midi: make(realLunch, budgetLunch),
+    soir: make(realDinner, budgetDinner),
+    total: make(realLunch + realDinner, budgetLunch + budgetDinner),
+  }
+}
+
+// ── Section 6 : Couverts jour-par-jour (tableau) ───────────────────────────
+
+// Renvoie [{ iso, jour_fr, midi: {real, budget, delta, ratio}, soir: {...} }, ...]
+export function couvertsJourParJour(caRows, budgetRows, debut, fin) {
+  const filtered = filterCaJournalier(caRows, debut, fin)
+  // Par jour, par service : couverts réels
+  const realByDay = new Map()
+  for (const r of filtered) {
+    if (!realByDay.has(r.jour)) realByDay.set(r.jour, { lunch: 0, dinner: 0 })
+    const acc = realByDay.get(r.jour)
+    if (r.service === 'lunch') acc.lunch += Number(r.couverts || 0)
+    else acc.dinner += Number(r.couverts || 0)
+  }
+  // Budget par jour : agrège tous les lieux pour ce jour-de-semaine
+  const out = []
+  const cache = new Map()
+  for (const d of eachDayIso(debut, fin)) {
+    const date = fromIso(d.iso)
+    const annee = date.getFullYear()
+    const mois = date.getMonth() + 1
+    const ck = `${annee}_${mois}`
+    let cells = cache.get(ck)
+    if (!cells) {
+      cells = new Map()
+      for (const b of (budgetRows || [])) {
+        if (b.annee != null && Number(b.annee) !== Number(annee)) continue
+        const k = `${b.jour_semaine}_${b.lieu_service_id}_${b.service}`
+        const isOverride = b.mois === mois
+        if (isOverride) cells.set(k, b)
+        else if (!cells.has(k)) cells.set(k, b)
+      }
+      cache.set(ck, cells)
+    }
+    let budgetLunch = 0
+    let budgetDinner = 0
+    for (const cell of cells.values()) {
+      if (cell.jour_semaine !== d.isoJds) continue
+      if (cell.service === 'lunch') budgetLunch += Number(cell.couverts_cible || 0)
+      else budgetDinner += Number(cell.couverts_cible || 0)
+    }
+    const real = realByDay.get(d.iso) || { lunch: 0, dinner: 0 }
+    out.push({
+      iso: d.iso,
+      jour_fr: JOURS_FR_LONG[d.jsWeekday],
+      isoJds: d.isoJds,
+      midi: {
+        real: real.lunch,
+        budget: budgetLunch,
+        delta: real.lunch - budgetLunch,
+        ratio: budgetLunch > 0 ? ((real.lunch - budgetLunch) / budgetLunch) * 100 : null,
+      },
+      soir: {
+        real: real.dinner,
+        budget: budgetDinner,
+        delta: real.dinner - budgetDinner,
+        ratio: budgetDinner > 0 ? ((real.dinner - budgetDinner) / budgetDinner) * 100 : null,
+      },
+    })
+  }
+  return out
+}
+
+// ── Agrégateur : construit tout le rapport en un appel ─────────────────────
+
+export function buildRapportData({ caRows, budgetRows, lieuxMap, debut, fin }) {
+  const ca = caTtcVsBudget(caRows, budgetRows, debut, fin)
+  const caMois = caTtcCumulMois(caRows, budgetRows, fin)
+  const tmLieux = tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin)
+  const tmFb = tmFoodBevParService(caRows, budgetRows, debut, fin)
+  const mix = mixFoodBev(tmFb)
+  const couverts = couvertsParService(caRows, budgetRows, debut, fin)
+  const couvertsJpJ = couvertsJourParJour(caRows, budgetRows, debut, fin)
+  return { ca, caMois, tmLieux, tmFb, mix, couverts, couvertsJpJ }
+}
+
+// ── Formatters ──────────────────────────────────────────────────────────────
+
+export function formatEur(n) {
+  if (n == null || isNaN(n) || n === 0) return '0 €'
+  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 }).format(n)
+}
+
+export function formatEur2(n) {
+  if (n == null || isNaN(n)) return '—'
+  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 }).format(Math.round(n))
+}
+
+export function formatPct(pct) {
+  if (pct == null || !isFinite(pct)) return '—'
+  const sign = pct > 0 ? '+ ' : pct < 0 ? '- ' : ''
+  return `${sign}${Math.abs(pct).toFixed(pct < 1 && pct > -1 ? 1 : 1)} %`
+}
+
+export function formatPctSimple(pct) {
+  if (pct == null || !isFinite(pct)) return '—'
+  return `${pct.toFixed(0)} %`
+}
+
+export function formatNombre(n) {
+  if (n == null || isNaN(n)) return '0'
+  return new Intl.NumberFormat('fr-FR').format(Math.round(n))
+}
+
+export function formatDateFr(iso) {
+  const [y, m, d] = iso.split('-').map(Number)
+  return `${String(d).padStart(2, '0')} ${MOIS_LABEL_FR[m]}`
+}
+
+export function formatPeriode(debut, fin) {
+  if (debut === fin) return `du ${formatDateFr(debut)}`
+  const dDeb = fromIso(debut).getDate()
+  const dFin = fromIso(fin).getDate()
+  const mDeb = fromIso(debut).getMonth() + 1
+  const mFin = fromIso(fin).getMonth() + 1
+  if (mDeb === mFin) {
+    return `du ${String(dDeb).padStart(2, '0')} au ${String(dFin).padStart(2, '0')} ${MOIS_LABEL_FR[mFin]}`
+  }
+  return `du ${formatDateFr(debut)} au ${formatDateFr(fin)}`
+}
+
+// Lundi-dimanche de la semaine courante (ISO : lundi=début)
+export function semaineEnCours(today = new Date()) {
+  const d = new Date(today)
+  const jsWeekday = d.getDay() // 0=dim, 1=lun, ..., 6=sam
+  // Lundi de la semaine courante
+  const offsetToMonday = jsWeekday === 0 ? -6 : 1 - jsWeekday
+  const lundi = new Date(d)
+  lundi.setDate(d.getDate() + offsetToMonday)
+  const dimanche = new Date(lundi)
+  dimanche.setDate(lundi.getDate() + 6)
+  return { debut: toIso(lundi), fin: toIso(dimanche) }
+}
+
+// Semaine précédente (lundi-dimanche)
+export function semainePrecedente(today = new Date()) {
+  const { debut, fin } = semaineEnCours(today)
+  const debutPrev = new Date(fromIso(debut)); debutPrev.setDate(debutPrev.getDate() - 7)
+  const finPrev = new Date(fromIso(fin)); finPrev.setDate(finPrev.getDate() - 7)
+  return { debut: toIso(debutPrev), fin: toIso(finPrev) }
+}
+
+export { TVA_FOOD, TVA_BEV_20, TVA_BEV_10, TVA_AUTRE, JOURS_FR_LONG, MOIS_LABEL_FR }

--- a/lib/rapportHebdoExport.js
+++ b/lib/rapportHebdoExport.js
@@ -1,0 +1,225 @@
+// Export du rapport hebdo en HTML autonome, soit téléchargé soit copié
+// dans le presse-papier pour collage direct dans Gmail / Outlook.
+//
+// Le HTML utilise des styles inline (mail clients ignorent les <style> et
+// les classes CSS externes) et reproduit la mise en forme du mail
+// historique Marsan : titres en couleur, listes à puces, tableau couleur
+// pour les écarts couverts.
+
+import {
+  formatEur, formatPct, formatPctSimple, formatNombre, formatPeriode,
+} from './rapportHebdo'
+
+const SERVICE_LABEL = { lunch: 'déjeuner', dinner: 'dîner' }
+
+const COLOR = {
+  texte:    '#000',
+  muted:    '#666',
+  accent:   '#1565C0',
+  vert:     '#1B5E20',
+  rouge:    '#C62828',
+  orange:   '#D97706',
+  vertBg:   '#C8E6C9',
+  rougeBg:  '#FFCDD2',
+  orangeBg: '#FFE0B2',
+  fond:     '#F5F5F5',
+  bordure:  '#CCCCCC',
+}
+
+const styles = {
+  body: 'font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; font-size: 14px; color: #000; line-height: 1.6;',
+  h3:   `font-size: 14px; font-weight: 600; color: ${COLOR.accent}; margin: 20px 0 10px; text-transform: uppercase; letter-spacing: 0.4px;`,
+  ul:   'margin: 0; padding-left: 22px; line-height: 1.7;',
+  li:   'margin-bottom: 4px;',
+  p:    'margin: 0 0 10px;',
+  strong: 'font-weight: 700;',
+  vert: `color: ${COLOR.vert}; font-weight: 700;`,
+  rouge: `color: ${COLOR.rouge}; font-weight: 700;`,
+  table: 'width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 13px;',
+  th:    `padding: 6px 10px; background: ${COLOR.fond}; color: ${COLOR.muted}; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.3px; border: 1px solid ${COLOR.bordure}; text-align: right;`,
+  td:    `padding: 6px 10px; font-size: 13px; color: ${COLOR.texte}; border: 1px solid ${COLOR.bordure}; text-align: right;`,
+  tdLeft: `padding: 6px 10px; font-size: 13px; color: ${COLOR.texte}; border: 1px solid ${COLOR.bordure}; text-align: left; font-weight: 600;`,
+}
+
+function colorRatio(ratio) {
+  if (ratio == null) return ''
+  return ratio >= 0 ? styles.vert : styles.rouge
+}
+
+function bgForRatio(ratio) {
+  if (ratio == null) return ''
+  if (ratio >= 0) return `background: ${COLOR.vertBg}; color: ${COLOR.vert};`
+  if (ratio > -10) return `background: ${COLOR.orangeBg}; color: ${COLOR.orange};`
+  return `background: ${COLOR.rougeBg}; color: ${COLOR.rouge};`
+}
+
+function esc(s) {
+  return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+// Construit le HTML complet (body + sections + commentaire).
+export function buildRapportHtml({ data, debut, fin, commentaire, titre }) {
+  const periode = formatPeriode(debut, fin)
+  const sections = [
+    renderIntro(data, periode),
+    renderTmLieux(data.tmLieux, periode),
+    renderTmFoodBev(data.tmFb, periode),
+    renderMixFoodBev(data.mix, periode),
+    renderCouverts(data.couverts, periode),
+    renderCouvertsJpJ(data.couvertsJpJ, periode),
+    renderCommentaire(commentaire),
+  ].filter(Boolean).join('\n')
+
+  return `<!DOCTYPE html>
+<html lang="fr"><head><meta charset="utf-8"><title>${esc(titre || `Rapport CA ${periode}`)}</title></head>
+<body style="${styles.body}">
+<p style="${styles.p}">Bonjour à tous,</p>
+<p style="${styles.p}">Ci-dessous le rapport du CA pour la <strong>période ${esc(periode)}</strong> ainsi que le cumul depuis le début du mois :</p>
+${sections}
+<p style="${styles.p}; margin-top: 24px;">Bonne journée à tous.</p>
+</body></html>`
+}
+
+function renderIntro(data, periode) {
+  const { ca, caMois } = data
+  return `
+<p style="${styles.p}"><strong>Le CATTC réalisé ${esc(periode)}</strong> s'élève à <strong>${formatEur(ca.real)}</strong> pour un budget de <strong>${formatEur(ca.budget)}</strong>${ca.ratio != null ? ` soit <span style="${colorRatio(ca.ratio)}">${formatPct(ca.ratio)}</span>` : ''}.</p>
+<p style="${styles.p}">Le CATTC réalisé <strong>depuis le début du mois</strong> s'élève à <strong>${formatEur(caMois.real)}</strong> pour un budget de <strong>${formatEur(caMois.budget)}</strong>${caMois.ratio != null ? ` soit <span style="${colorRatio(caMois.ratio)}">${formatPct(caMois.ratio)}</span>` : ''}.</p>`
+}
+
+function renderTmLieux(tmLieux, periode) {
+  if (tmLieux.length === 0) return ''
+  const items = tmLieux.map((r) => `
+    <li style="${styles.li}">Ticket moyen <strong>${esc(r.lieu_label)} ${esc(SERVICE_LABEL[r.service])}</strong> <strong>${r.real_tm != null ? formatEur(r.real_tm) : '—'}</strong> pour un budget de <strong>${r.budget_tm != null ? formatEur(r.budget_tm) : '—'}</strong>${r.ratio_tm != null ? `, soit <span style="${colorRatio(r.ratio_tm)}">${formatPct(r.ratio_tm)}</span>` : ''}</li>`).join('')
+  return `<h3 style="${styles.h3}">Ticket moyen ${esc(periode)}</h3><ul style="${styles.ul}">${items}</ul>`
+}
+
+function renderTmFoodBev(tmFb, periode) {
+  const line = (label, real, budget, ratio) => `<li style="${styles.li}">Ticket moyen <strong>${esc(label)}</strong> <strong>${real != null ? formatEur(real) : '—'}</strong> pour un budget de <strong>${budget != null ? formatEur(budget) : '—'}</strong>${ratio != null ? ` soit <span style="${colorRatio(ratio)}">${formatPct(ratio)}</span>` : ''}</li>`
+  const items = [
+    line('Food midi',      tmFb.midi.real_tm_food, tmFb.midi.budget_tm_food, tmFb.midi.ratio_food),
+    line('Beverage midi',  tmFb.midi.real_tm_bev,  tmFb.midi.budget_tm_bev,  tmFb.midi.ratio_bev),
+    line('Food soir',      tmFb.soir.real_tm_food, tmFb.soir.budget_tm_food, tmFb.soir.ratio_food),
+    line('Beverage soir',  tmFb.soir.real_tm_bev,  tmFb.soir.budget_tm_bev,  tmFb.soir.ratio_bev),
+    line('Food total',     tmFb.total.real_tm_food, tmFb.total.budget_tm_food, tmFb.total.ratio_food),
+    line('Beverage Total', tmFb.total.real_tm_bev,  tmFb.total.budget_tm_bev,  tmFb.total.ratio_bev),
+  ].join('')
+  return `<h3 style="${styles.h3}">Ticket moyen Food et Beverage ${esc(periode)} pour le midi et le soir</h3><ul style="${styles.ul}">${items}</ul>`
+}
+
+function renderMixFoodBev(mix, periode) {
+  const items = [
+    `<li style="${styles.li}">Ticket moyen <strong>Food midi</strong> <strong>${formatPctSimple(mix.midi.food_pct)}</strong> du total</li>`,
+    `<li style="${styles.li}">Ticket moyen <strong>Beverage midi</strong> <strong>${formatPctSimple(mix.midi.bev_pct)}</strong> du total</li>`,
+    `<li style="${styles.li}">Ticket moyen <strong>Food soir</strong> <strong>${formatPctSimple(mix.soir.food_pct)}</strong> du total</li>`,
+    `<li style="${styles.li}">Ticket moyen <strong>Beverage soir</strong> <strong>${formatPctSimple(mix.soir.bev_pct)}</strong> du total</li>`,
+    `<li style="${styles.li}">Ticket moyen <strong>Food total</strong> <strong>${formatPctSimple(mix.total.food_pct)}</strong> du total</li>`,
+    `<li style="${styles.li}">Ticket moyen <strong>Beverage</strong> <strong>${formatPctSimple(mix.total.bev_pct)}</strong> du total</li>`,
+  ].join('')
+  return `<h3 style="${styles.h3}">Ticket moyen Food et Beverage en % vs TM total ${esc(periode)} midi et soir</h3><ul style="${styles.ul}">${items}</ul>`
+}
+
+function renderCouverts(couverts, periode) {
+  return `<h3 style="${styles.h3}">Nombre de couverts ${esc(periode)}</h3>
+<ul style="${styles.ul}">
+<li style="${styles.li}"><strong>Déjeuner</strong> : <strong>${formatNombre(couverts.midi.real)}</strong> couverts pour un budget de <strong>${formatNombre(couverts.midi.budget)}</strong>${couverts.midi.ratio != null ? ` soit <span style="${colorRatio(couverts.midi.ratio)}">${formatPct(couverts.midi.ratio)}</span>` : ''}</li>
+<li style="${styles.li}"><strong>Dîner</strong> : <strong>${formatNombre(couverts.soir.real)}</strong> couverts pour un budget de <strong>${formatNombre(couverts.soir.budget)}</strong>${couverts.soir.ratio != null ? ` soit <span style="${colorRatio(couverts.soir.ratio)}">${formatPct(couverts.soir.ratio)}</span>` : ''}</li>
+</ul>`
+}
+
+function renderCouvertsJpJ(jours, periode) {
+  if (!jours || jours.length === 0) return ''
+  const total = jours.reduce((acc, j) => {
+    acc.midi.real += j.midi.real; acc.midi.budget += j.midi.budget
+    acc.soir.real += j.soir.real; acc.soir.budget += j.soir.budget
+    return acc
+  }, { midi: { real: 0, budget: 0 }, soir: { real: 0, budget: 0 } })
+  total.midi.delta = total.midi.real - total.midi.budget
+  total.midi.ratio = total.midi.budget > 0 ? (total.midi.delta / total.midi.budget) * 100 : null
+  total.soir.delta = total.soir.real - total.soir.budget
+  total.soir.ratio = total.soir.budget > 0 ? (total.soir.delta / total.soir.budget) * 100 : null
+
+  const rows = jours.map((j) => `
+<tr>
+  <td style="${styles.tdLeft}">${esc(j.jour_fr)}</td>
+  <td style="${styles.td}">${formatNombre(j.midi.real)}</td>
+  <td style="${styles.td}">${formatNombre(j.midi.budget)}</td>
+  <td style="${styles.td}">${j.midi.delta !== 0 ? formatNombre(j.midi.delta) : '—'}</td>
+  <td style="${styles.td} ${bgForRatio(j.midi.ratio)}; font-weight: 700;">${formatPct(j.midi.ratio)}</td>
+  <td style="${styles.td}">${formatNombre(j.soir.real)}</td>
+  <td style="${styles.td}">${formatNombre(j.soir.budget)}</td>
+  <td style="${styles.td}">${j.soir.delta !== 0 ? formatNombre(j.soir.delta) : '—'}</td>
+  <td style="${styles.td} ${bgForRatio(j.soir.ratio)}; font-weight: 700;">${formatPct(j.soir.ratio)}</td>
+</tr>`).join('')
+
+  return `<h3 style="${styles.h3}">Couverts jour par jour Réel VS Budget ${esc(periode)}</h3>
+<table style="${styles.table}">
+  <thead>
+    <tr>
+      <th style="${styles.th}; text-align: left;" rowspan="2">Jour</th>
+      <th style="${styles.th}" colspan="4">MIDI</th>
+      <th style="${styles.th}" colspan="4">SOIR</th>
+    </tr>
+    <tr>
+      <th style="${styles.th}">Reel</th><th style="${styles.th}">Budget</th><th style="${styles.th}">Écart Nb</th><th style="${styles.th}">Écart %</th>
+      <th style="${styles.th}">Reel</th><th style="${styles.th}">Budget</th><th style="${styles.th}">Écart Nb</th><th style="${styles.th}">Écart %</th>
+    </tr>
+  </thead>
+  <tbody>
+    ${rows}
+    <tr style="background: ${COLOR.fond}; font-weight: 700;">
+      <td style="${styles.tdLeft}">Total</td>
+      <td style="${styles.td}">${formatNombre(total.midi.real)}</td>
+      <td style="${styles.td}">${formatNombre(total.midi.budget)}</td>
+      <td style="${styles.td}"></td>
+      <td style="${styles.td} ${bgForRatio(total.midi.ratio)}">${formatPct(total.midi.ratio)}</td>
+      <td style="${styles.td}">${formatNombre(total.soir.real)}</td>
+      <td style="${styles.td}">${formatNombre(total.soir.budget)}</td>
+      <td style="${styles.td}"></td>
+      <td style="${styles.td} ${bgForRatio(total.soir.ratio)}">${formatPct(total.soir.ratio)}</td>
+    </tr>
+  </tbody>
+</table>`
+}
+
+function renderCommentaire(commentaire) {
+  if (!commentaire || !commentaire.trim()) return ''
+  // Préserve les retours à la ligne
+  const lines = commentaire.split('\n').map((l) => esc(l) || '<br/>').join('<br/>')
+  return `<h3 style="${styles.h3}">Commentaires</h3><p style="${styles.p}">${lines}</p>`
+}
+
+// ── Helpers d'export côté navigateur ────────────────────────────────────────
+
+export function downloadHtmlFile(html, filename) {
+  const blob = new Blob([html], { type: 'text/html;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename || 'rapport.html'
+  a.click()
+  setTimeout(() => URL.revokeObjectURL(url), 1000)
+}
+
+// Copie le HTML dans le presse-papier au format rich-text. Les clients
+// mail (Gmail, Outlook) collent alors avec la mise en forme préservée.
+export async function copyHtmlToClipboard(html) {
+  if (typeof navigator === 'undefined' || !navigator.clipboard) {
+    throw new Error('Presse-papier non disponible')
+  }
+  // Plain text fallback (Gmail le rend dégradé)
+  const plain = html.replace(/<[^>]+>/g, '').replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+  if (window.ClipboardItem) {
+    const blobHtml = new Blob([html], { type: 'text/html' })
+    const blobText = new Blob([plain], { type: 'text/plain' })
+    await navigator.clipboard.write([
+      new ClipboardItem({ 'text/html': blobHtml, 'text/plain': blobText }),
+    ])
+  } else {
+    // Fallback : copie le plain-text uniquement (mais Gmail aime quand
+    // même un peu plus si on a un blob HTML — la plupart des navigateurs
+    // modernes supportent ClipboardItem). Si ClipboardItem absent, on
+    // perd la mise en forme.
+    await navigator.clipboard.writeText(plain)
+  }
+}

--- a/supabase/migrations/20260511000002_ca_rapports_hebdo.sql
+++ b/supabase/migrations/20260511000002_ca_rapports_hebdo.sql
@@ -1,0 +1,46 @@
+-- ============================================================================
+-- ca_rapports_hebdo : rapports hebdomadaires sauvegardés.
+--
+-- L'utilisateur envoie un mail récap chaque lundi avec les chiffres de la
+-- semaine précédente (CA, tickets moyens, couverts, mix Food/Bev, etc.).
+-- Les chiffres sont recalculés au load depuis ca_journalier + ca_budgets,
+-- seuls le commentaire libre et les métadonnées sont persistés ici.
+--
+-- (Une future migration ajoutera articles_ventes JSONB pour tracker les
+-- ventes de menus / suppléments saisis manuellement — out-of-scope PR A.)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.ca_rapports_hebdo (
+  id           uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id    uuid        NOT NULL REFERENCES public.clients (id) ON DELETE CASCADE,
+  debut        date        NOT NULL,
+  fin          date        NOT NULL,
+  commentaire  text        NOT NULL DEFAULT '',
+  titre        text,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+  created_by   uuid        REFERENCES auth.users (id) ON DELETE SET NULL,
+  CONSTRAINT ca_rapports_hebdo_dates_check CHECK (fin >= debut)
+);
+
+COMMENT ON TABLE public.ca_rapports_hebdo IS
+  'Rapports hebdomadaires sauvegardés (CA, tickets, couverts) avec commentaire libre. Permet de retrouver les rapports envoyés par mail aux équipes semaine après semaine.';
+
+CREATE INDEX IF NOT EXISTS ca_rapports_hebdo_client_debut_idx
+  ON public.ca_rapports_hebdo (client_id, debut DESC);
+
+DROP TRIGGER IF EXISTS trg_ca_rapports_hebdo_updated_at ON public.ca_rapports_hebdo;
+CREATE TRIGGER trg_ca_rapports_hebdo_updated_at
+  BEFORE UPDATE ON public.ca_rapports_hebdo
+  FOR EACH ROW EXECUTE FUNCTION public.ca_set_updated_at();
+
+ALTER TABLE public.ca_rapports_hebdo ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ca_rapports_hebdo_select ON public.ca_rapports_hebdo FOR SELECT TO authenticated
+  USING (public.user_has_client_access(client_id));
+CREATE POLICY ca_rapports_hebdo_insert ON public.ca_rapports_hebdo FOR INSERT TO authenticated
+  WITH CHECK (public.user_has_client_access(client_id));
+CREATE POLICY ca_rapports_hebdo_update ON public.ca_rapports_hebdo FOR UPDATE TO authenticated
+  USING (public.user_has_client_access(client_id))
+  WITH CHECK (public.user_has_client_access(client_id));
+CREATE POLICY ca_rapports_hebdo_delete ON public.ca_rapports_hebdo FOR DELETE TO authenticated
+  USING (public.user_has_client_access(client_id));


### PR DESCRIPTION
## Summary
PR A du chantier "Rapport hebdo". Remplace le calcul manuel sous Excel par une page in-app qui génère automatiquement le mail récap envoyé tous les lundis aux équipes.

PR B (à venir) : ventes par menu/supplément, comparaison multi-périodes.

## Sections incluses (Phase 1)
- **CA TTC réel vs budget** (période sélectionnée + cumul depuis le 1er du mois)
- **Ticket moyen par lieu × service** avec écart %
- **Ticket moyen Food/Beverage** par service (midi/soir/total)
- **Mix Food/Beverage en %** du TM total
- **Couverts midi/soir** vs budget
- **Tableau couverts jour par jour** avec mise en forme conditionnelle vert/orange/rouge
- **Commentaires** libres (textarea)

## Migration
- `ca_rapports_hebdo (client_id, debut, fin, commentaire, titre, created_by)` — métadonnées seulement, chiffres recalculés au load
- Appliquée en prod via MCP ✅

## UI
- Nouvelle page `/controle-gestion/ventes/rapport-hebdo` (admin / directeur)
- Sélecteur période + presets « Semaine précédente » (défaut) / « Semaine en cours »
- Sidebar avec archives (chargement / suppression)
- 📋 **Copier pour email** : met le HTML dans le presse-papier avec rich-text, colle direct dans Gmail/Outlook avec mise en forme préservée
- 📥 **Télécharger HTML** : fichier .html autonome

## Tests
+15 nouveaux tests vitest sur lib/rapportHebdo.js (142 → 157 verts).

## Test plan
- [ ] Aller sur `/controle-gestion/ventes/rapport-hebdo` (admin/directeur)
- [ ] Vérifier que la période par défaut = semaine précédente (lundi-dimanche)
- [ ] Les 6 sections affichent des chiffres cohérents avec ce qu'on voit sur `/analyses` ou `/ventes`
- [ ] Modifier le commentaire, cliquer Sauvegarder → apparaît dans la sidebar archives
- [ ] Recharger un rapport ancien → édition possible, bouton « Mettre à jour »
- [ ] Cliquer 📋 Copier pour email → coller dans Gmail → la mise en forme (couleurs, listes, tableau) est préservée
- [ ] Cliquer 📥 Télécharger HTML → ouverture du .html dans le navigateur

🤖 Generated with [Claude Code](https://claude.com/claude-code)