### PR TITLE
feat(rapport-hebdo): articles (menus + suppléments) + comparaison multi-périodes

### DIFF
--- a/app/controle-gestion/ventes/rapport-hebdo/page.js
+++ b/app/controle-gestion/ventes/rapport-hebdo/page.js
@@ -8,6 +8,8 @@ import { useTheme } from '../../../../lib/useTheme'
 import { useRole } from '../../../../lib/useRole'
 import Navbar from '../../../../components/Navbar'
 import RapportSections from '../../../../components/rapport-hebdo/RapportSections'
+import ArticlesModal from '../../../../components/rapport-hebdo/ArticlesModal'
+import ComparaisonPanel from '../../../../components/rapport-hebdo/ComparaisonPanel'
 import {
   buildRapportData,
   semaineEnCours,
@@ -50,6 +52,17 @@ export default function RapportHebdoPage() {
   // Archives
   const [archives, setArchives] = useState([])
   const [archivesLoading, setArchivesLoading] = useState(false)
+
+  // Articles (menus / suppléments) référencés pour ce client
+  const [articles, setArticles] = useState([])
+  // Quantités saisies pour le rapport courant — { article_id: qte }
+  const [articlesVentes, setArticlesVentes] = useState({})
+  const [articlesModalOpen, setArticlesModalOpen] = useState(false)
+
+  // Mode comparaison : si actif, affiche un tableau côte à côte avec des
+  // périodes additionnelles. Données chargées à la volée.
+  const [compareMode, setCompareMode] = useState(false)
+  const [comparePeriodes, setComparePeriodes] = useState([]) // [{ debut, fin }]
 
   // ── Auth ────────────────────────────────────────────────────────────────
   useEffect(() => {
@@ -148,7 +161,7 @@ export default function RapportHebdoPage() {
     try {
       const { data, error: e } = await supabase
         .from('ca_rapports_hebdo')
-        .select('id, debut, fin, titre, commentaire, created_at, updated_at')
+        .select('id, debut, fin, titre, commentaire, articles_ventes, created_at, updated_at')
         .eq('client_id', clientId)
         .order('debut', { ascending: false })
         .limit(50)
@@ -162,6 +175,25 @@ export default function RapportHebdoPage() {
   }, [clientId])
 
   useEffect(() => { if (authReady && clientId) loadArchives() }, [authReady, clientId, loadArchives])
+
+  // ── Chargement des articles ─────────────────────────────────────────────
+  const loadArticles = useCallback(async () => {
+    if (!clientId) return
+    try {
+      const { data, error: e } = await supabase
+        .from('ca_articles')
+        .select('id, nom, type, service, ordre')
+        .eq('client_id', clientId)
+        .eq('actif', true)
+        .order('type').order('service').order('ordre').order('nom')
+      if (e) throw e
+      setArticles(data || [])
+    } catch (e) {
+      console.warn('Erreur chargement articles :', e?.message || e)
+    }
+  }, [clientId])
+
+  useEffect(() => { if (authReady && clientId) loadArticles() }, [authReady, clientId, loadArticles])
 
   // ── Données dérivées ────────────────────────────────────────────────────
   const lieuxMap = useMemo(() => new Map(lieux.map((l) => [l.id, l.nom])), [lieux])
@@ -186,17 +218,22 @@ export default function RapportHebdoPage() {
     setError('')
     setOkMsg('')
     try {
+      const payload = {
+        debut, fin, commentaire,
+        titre: titre || null,
+        articles_ventes: articlesVentes || {},
+      }
       if (currentRapportId) {
         const { error: e } = await supabase
           .from('ca_rapports_hebdo')
-          .update({ debut, fin, commentaire, titre: titre || null })
+          .update(payload)
           .eq('id', currentRapportId)
         if (e) throw e
         setOkMsg('Rapport mis à jour.')
       } else {
         const { data: ins, error: e } = await supabase
           .from('ca_rapports_hebdo')
-          .insert({ client_id: clientId, debut, fin, commentaire, titre: titre || null })
+          .insert({ client_id: clientId, ...payload })
           .select('id')
           .single()
         if (e) throw e
@@ -217,6 +254,7 @@ export default function RapportHebdoPage() {
     setFin(rapport.fin)
     setCommentaire(rapport.commentaire || '')
     setTitre(rapport.titre || '')
+    setArticlesVentes(rapport.articles_ventes || {})
     setOkMsg('')
     setError('')
   }
@@ -237,14 +275,22 @@ export default function RapportHebdoPage() {
     setCurrentRapportId(null)
     setCommentaire('')
     setTitre('')
+    setArticlesVentes({})
     setOkMsg('')
     setError('')
+  }
+
+  const handleChangeArticleQte = (articleId, qte) => {
+    setArticlesVentes((prev) => ({ ...prev, [articleId]: qte }))
   }
 
   const handleCopyEmail = async () => {
     setError(''); setOkMsg('')
     try {
-      const html = buildRapportHtml({ data, debut, fin, commentaire, titre })
+      const html = buildRapportHtml({
+        data, debut, fin, commentaire, titre,
+        articles, articlesVentes,
+      })
       await copyHtmlToClipboard(html)
       setOkMsg('Rapport copié dans le presse-papier — colle dans Gmail / Outlook.')
     } catch (e) {
@@ -255,7 +301,10 @@ export default function RapportHebdoPage() {
   const handleDownloadHtml = () => {
     setError(''); setOkMsg('')
     try {
-      const html = buildRapportHtml({ data, debut, fin, commentaire, titre })
+      const html = buildRapportHtml({
+        data, debut, fin, commentaire, titre,
+        articles, articlesVentes,
+      })
       downloadHtmlFile(html, `rapport-ca_${debut}_${fin}.html`)
     } catch (e) {
       setError(e.message || 'Erreur lors du téléchargement')
@@ -289,6 +338,16 @@ export default function RapportHebdoPage() {
             <button onClick={handleSemainePrec} style={btnSecondary(c)}>Semaine précédente</button>
             <button onClick={handleSemaineCour} style={btnSecondary(c)}>Semaine en cours</button>
             <button onClick={handleNouveau} style={btnSecondary(c)} title="Nouveau rapport vide">+ Nouveau</button>
+            <button onClick={() => setArticlesModalOpen(true)} style={btnSecondary(c)}
+              title="Configurer les menus et suppléments suivis">
+              📋 Articles
+            </button>
+            <button
+              onClick={() => setCompareMode((m) => !m)}
+              style={{ ...btnSecondary(c), background: compareMode ? c.accent : c.blanc, color: compareMode ? c.texte : c.texte, fontWeight: compareMode ? 600 : 400 }}
+              title="Activer le mode comparaison de plusieurs périodes">
+              ⇄ Comparer
+            </button>
           </div>
         </div>
 
@@ -333,7 +392,13 @@ export default function RapportHebdoPage() {
             {loading ? (
               <p style={{ color: c.texteMuted, fontSize: 14 }}>Chargement des données…</p>
             ) : (
-              <RapportSections c={c} data={data} debut={debut} fin={fin} />
+              <RapportSections
+                c={c} data={data} debut={debut} fin={fin}
+                articles={articles}
+                articlesVentes={articlesVentes}
+                editableArticles
+                onChangeQte={handleChangeArticleQte}
+              />
             )}
 
             {/* Commentaires */}
@@ -402,6 +467,27 @@ export default function RapportHebdoPage() {
             )}
           </aside>
         </div>
+
+        {/* Mode comparaison */}
+        {compareMode && (
+          <ComparaisonPanel
+            c={c}
+            isMobile={isMobile}
+            clientId={clientId}
+            currentPeriode={{ debut, fin }}
+            periodes={comparePeriodes}
+            onPeriodesChange={setComparePeriodes}
+          />
+        )}
+
+        {articlesModalOpen && (
+          <ArticlesModal
+            c={c}
+            clientId={clientId}
+            onClose={() => setArticlesModalOpen(false)}
+            onChange={loadArticles}
+          />
+        )}
       </div>
     </div>
   )

--- a/app/controle-gestion/ventes/rapport-hebdo/page.js
+++ b/app/controle-gestion/ventes/rapport-hebdo/page.js
@@ -12,6 +12,7 @@ import ArticlesModal from '../../../../components/rapport-hebdo/ArticlesModal'
 import ComparaisonPanel from '../../../../components/rapport-hebdo/ComparaisonPanel'
 import {
   buildRapportData,
+  buildJoursFermesIso,
   semaineEnCours,
   semainePrecedente,
   formatPeriode,
@@ -41,6 +42,8 @@ export default function RapportHebdoPage() {
   const [lieux, setLieux] = useState([])
   const [caRows, setCaRows] = useState([])
   const [budgetRows, setBudgetRows] = useState([])
+  const [joursFermesRows, setJoursFermesRows] = useState([])
+  const [joursFermesHebdoRows, setJoursFermesHebdoRows] = useState([])
   const [loading, setLoading] = useState(false)
 
   // Commentaire et rapport courant (id si chargé depuis archive)
@@ -105,7 +108,13 @@ export default function RapportHebdoPage() {
       const [y2, m2] = fin.split('-').map(Number)
       const annees = Array.from(new Set([y1, y2]))
 
-      const [lieuxRes, caRes, budgetRes] = await Promise.all([
+      // Pour le cumul mois on a besoin aussi des CA depuis le 1er du mois
+      // de `fin` — calculé en amont pour pouvoir aussi charger les
+      // jours fermés sur cette période étendue.
+      const firstOfMonth = `${y2}-${String(m2).padStart(2, '0')}-01`
+      const debutPourCumul = firstOfMonth < debut ? firstOfMonth : debut
+
+      const [lieuxRes, caRes, budgetRes, jfRes, jfhRes] = await Promise.all([
         supabase
           .from('lieux_service')
           .select('id, nom, ordre, actif')
@@ -116,32 +125,35 @@ export default function RapportHebdoPage() {
           .from('ca_journalier')
           .select('jour, service, lieu_service_id, couverts, ca_food, ca_bev_20, ca_bev_10, ca_autre')
           .eq('client_id', clientId)
-          .gte('jour', debut)
+          .gte('jour', debutPourCumul)
           .lte('jour', fin),
         supabase
           .from('ca_budgets')
           .select('annee, mois, jour_semaine, lieu_service_id, service, couverts_cible, ca_food_cible, ca_bev_20_cible, ca_bev_10_cible, ca_autre_cible')
           .eq('client_id', clientId)
           .in('annee', annees),
+        supabase
+          .from('ca_jours_fermes')
+          .select('date, motif')
+          .eq('client_id', clientId)
+          .gte('date', debutPourCumul)
+          .lte('date', fin),
+        supabase
+          .from('ca_jours_fermes_hebdo')
+          .select('jour_semaine, motif')
+          .eq('client_id', clientId),
       ])
       if (lieuxRes.error) throw lieuxRes.error
       if (caRes.error) throw caRes.error
       if (budgetRes.error) throw budgetRes.error
+      if (jfRes.error) throw jfRes.error
+      if (jfhRes.error) throw jfhRes.error
       setLieux(lieuxRes.data || [])
       setCaRows(caRes.data || [])
       setBudgetRows(budgetRes.data || [])
-      // Pour le cumul mois, on a besoin aussi des CA depuis le 1er du mois
-      // de `fin`. On élargit si nécessaire.
-      const firstOfMonth = `${y2}-${String(m2).padStart(2, '0')}-01`
-      if (firstOfMonth < debut) {
-        const extraCa = await supabase
-          .from('ca_journalier')
-          .select('jour, service, lieu_service_id, couverts, ca_food, ca_bev_20, ca_bev_10, ca_autre')
-          .eq('client_id', clientId)
-          .gte('jour', firstOfMonth)
-          .lt('jour', debut)
-        if (!extraCa.error) setCaRows((prev) => [...(extraCa.data || []), ...prev])
-      }
+      setJoursFermesRows(jfRes.data || [])
+      setJoursFermesHebdoRows(jfhRes.data || [])
+      // (CA cumul mois inclus dans la query principale via debutPourCumul)
       void y1; void m1
     } catch (e) {
       setError(e.message || 'Erreur de chargement')
@@ -197,8 +209,18 @@ export default function RapportHebdoPage() {
 
   // ── Données dérivées ────────────────────────────────────────────────────
   const lieuxMap = useMemo(() => new Map(lieux.map((l) => [l.id, l.nom])), [lieux])
-  const data = useMemo(() => buildRapportData({ caRows, budgetRows, lieuxMap, debut, fin }),
-    [caRows, budgetRows, lieuxMap, debut, fin])
+
+  // Set des dates fermées sur la période — fermetures hebdo + dates
+  // spécifiques marquées sur Budgets CA. Permet d'exclure ces jours du
+  // calcul budget pour rester cohérent avec la projection mensuelle.
+  const joursFermesIso = useMemo(
+    () => buildJoursFermesIso(joursFermesRows, joursFermesHebdoRows, debut, fin),
+    [joursFermesRows, joursFermesHebdoRows, debut, fin]
+  )
+
+  const data = useMemo(() => buildRapportData({
+    caRows, budgetRows, lieuxMap, debut, fin, joursFermesIso,
+  }), [caRows, budgetRows, lieuxMap, debut, fin, joursFermesIso])
 
   // ── Actions ─────────────────────────────────────────────────────────────
   const handleSemainePrec = () => {

--- a/components/rapport-hebdo/ArticlesModal.js
+++ b/components/rapport-hebdo/ArticlesModal.js
@@ -1,0 +1,225 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { supabase } from '../../lib/supabase'
+
+const TYPE_LABEL = { menu: 'Menu', supplement: 'Supplément' }
+const SERVICE_LABEL = { lunch: 'Déjeuner', dinner: 'Dîner', all: 'Les deux' }
+
+// Modal de gestion du référentiel articles (menus + suppléments).
+// CRUD simple : liste éditable, ajout/suppression, ordre par drag (out-of-scope
+// PR B, on garde tri par nom).
+export default function ArticlesModal({ c, clientId, onClose, onChange }) {
+  const [rows, setRows] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [newNom, setNewNom] = useState('')
+  const [newType, setNewType] = useState('menu')
+  const [newService, setNewService] = useState('all')
+
+  const load = useCallback(async () => {
+    if (!clientId) return
+    setLoading(true)
+    try {
+      const { data, error: e } = await supabase
+        .from('ca_articles')
+        .select('id, nom, type, service, ordre, actif')
+        .eq('client_id', clientId)
+        .eq('actif', true)
+        .order('type').order('service').order('ordre').order('nom')
+      if (e) throw e
+      setRows(data || [])
+    } catch (e) {
+      setError(e.message || 'Erreur de chargement')
+    } finally {
+      setLoading(false)
+    }
+  }, [clientId])
+
+  useEffect(() => { load() }, [load])
+
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const handleAdd = async () => {
+    if (!clientId || !newNom.trim()) return
+    setError('')
+    try {
+      const { error: e } = await supabase
+        .from('ca_articles')
+        .insert({ client_id: clientId, nom: newNom.trim(), type: newType, service: newService })
+      if (e) throw e
+      setNewNom('')
+      await load()
+      onChange?.()
+    } catch (e) {
+      setError(e.message || "Erreur lors de l'ajout")
+    }
+  }
+
+  const handleDelete = async (id) => {
+    // Soft delete : on désactive l'article au lieu de le supprimer pour
+    // garder l'historique des rapports qui le référencent encore.
+    if (!confirm('Désactiver cet article ? Il ne sera plus proposé pour la saisie mais reste référencé dans les anciens rapports.')) return
+    try {
+      const { error: e } = await supabase
+        .from('ca_articles')
+        .update({ actif: false })
+        .eq('id', id)
+      if (e) throw e
+      setRows((prev) => prev.filter((r) => r.id !== id))
+      onChange?.()
+    } catch (e) {
+      setError(e.message || 'Erreur de suppression')
+    }
+  }
+
+  const handleEdit = async (id, patch) => {
+    try {
+      const { error: e } = await supabase.from('ca_articles').update(patch).eq('id', id)
+      if (e) throw e
+      setRows((prev) => prev.map((r) => r.id === id ? { ...r, ...patch } : r))
+      onChange?.()
+    } catch (e) {
+      setError(e.message || 'Erreur de mise à jour')
+    }
+  }
+
+  const grouped = rows.reduce((acc, r) => {
+    const key = `${r.type}_${r.service}`
+    if (!acc[key]) acc[key] = []
+    acc[key].push(r)
+    return acc
+  }, {})
+
+  const groups = [
+    { key: 'menu_lunch',      label: 'Menus déjeuner' },
+    { key: 'menu_dinner',     label: 'Menus dîner' },
+    { key: 'menu_all',        label: 'Menus (les deux services)' },
+    { key: 'supplement_lunch',label: 'Suppléments déjeuner' },
+    { key: 'supplement_dinner', label: 'Suppléments dîner' },
+    { key: 'supplement_all',  label: 'Suppléments (les deux services)' },
+  ].filter((g) => grouped[g.key])
+
+  return (
+    <div onClick={onClose}
+      style={{ position: 'fixed', inset: 0, zIndex: 200, background: 'rgba(9,9,11,0.45)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16 }}>
+      <div onClick={(e) => e.stopPropagation()}
+        style={{
+          width: '100%', maxWidth: 640, maxHeight: '90vh', overflowY: 'auto',
+          background: c.blanc, borderRadius: 14,
+          border: `0.5px solid ${c.bordure}`, boxShadow: '0 20px 40px rgba(0,0,0,0.2)',
+          padding: 20,
+        }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 12 }}>
+          <div>
+            <div style={{ fontSize: 17, fontWeight: 600, color: c.texte }}>Articles suivis</div>
+            <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 4 }}>
+              Référentiel partagé des menus et suppléments dont tu remplis les ventes
+              dans chaque rapport hebdo (depuis Lightspeed).
+            </div>
+          </div>
+          <button onClick={onClose} aria-label="Fermer"
+            style={{ background: 'transparent', border: 'none', fontSize: 20, color: c.texteMuted, cursor: 'pointer', lineHeight: 1 }}>
+            ×
+          </button>
+        </div>
+
+        {/* Ajout */}
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 16, flexWrap: 'wrap' }}>
+          <input type="text" value={newNom} onChange={(e) => setNewNom(e.target.value)}
+            placeholder="Nom (ex: Menu 5 services 205)"
+            style={{ flex: 1, minWidth: 200, padding: '7px 10px', borderRadius: 8, fontSize: 13, border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte }} />
+          <select value={newType} onChange={(e) => setNewType(e.target.value)}
+            style={{ padding: '7px 10px', borderRadius: 8, fontSize: 13, border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte }}>
+            <option value="menu">Menu</option>
+            <option value="supplement">Supplément</option>
+          </select>
+          <select value={newService} onChange={(e) => setNewService(e.target.value)}
+            style={{ padding: '7px 10px', borderRadius: 8, fontSize: 13, border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte }}>
+            <option value="all">Les deux services</option>
+            <option value="lunch">Déjeuner</option>
+            <option value="dinner">Dîner</option>
+          </select>
+          <button onClick={handleAdd} disabled={!newNom.trim()}
+            style={{ padding: '7px 14px', borderRadius: 8, fontSize: 13, border: 'none', background: c.accent, color: c.texte, fontWeight: 600, cursor: !newNom.trim() ? 'not-allowed' : 'pointer', opacity: !newNom.trim() ? 0.6 : 1 }}>
+            Ajouter
+          </button>
+        </div>
+
+        {error && (
+          <div style={{ marginBottom: 12, padding: '8px 12px', background: '#FCEBEB', color: '#A32D2D', borderRadius: 8, fontSize: 12 }}>
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div style={{ padding: 32, textAlign: 'center', color: c.texteMuted, fontSize: 13 }}>Chargement…</div>
+        ) : groups.length === 0 ? (
+          <div style={{ padding: 32, textAlign: 'center', color: c.texteMuted, fontSize: 13 }}>
+            Aucun article. Ajoute tes menus et suppléments ci-dessus.
+          </div>
+        ) : (
+          <div style={{ border: `0.5px solid ${c.bordure}`, borderRadius: 10, overflow: 'hidden' }}>
+            {groups.map((g, idx) => (
+              <div key={g.key}>
+                <div style={{
+                  padding: '6px 12px', background: c.fond,
+                  fontSize: 11, fontWeight: 600, color: c.texteMuted,
+                  textTransform: 'uppercase', letterSpacing: 0.4,
+                  borderTop: idx > 0 ? `0.5px solid ${c.bordure}` : 'none',
+                }}>
+                  {g.label}
+                </div>
+                {(grouped[g.key] || []).map((r) => (
+                  <ArticleRow key={r.id} c={c} article={r}
+                    onEdit={(patch) => handleEdit(r.id, patch)}
+                    onDelete={() => handleDelete(r.id)} />
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 16 }}>
+          <button onClick={onClose}
+            style={{ padding: '8px 14px', borderRadius: 8, fontSize: 13, border: `0.5px solid ${c.bordure}`, background: c.blanc, color: c.texteMuted, cursor: 'pointer' }}>
+            Fermer
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ArticleRow({ c, article, onEdit, onDelete }) {
+  const [editing, setEditing] = useState(false)
+  const [nom, setNom] = useState(article.nom)
+  const save = () => { if (nom.trim() && nom !== article.nom) onEdit({ nom: nom.trim() }); setEditing(false) }
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 12px', borderTop: `0.5px solid ${c.bordure}` }}>
+      {editing ? (
+        <input type="text" value={nom} onChange={(e) => setNom(e.target.value)}
+          onBlur={save}
+          onKeyDown={(e) => { if (e.key === 'Enter') save(); if (e.key === 'Escape') { setNom(article.nom); setEditing(false) } }}
+          autoFocus
+          style={{ flex: 1, padding: '4px 8px', borderRadius: 6, fontSize: 13, border: `1px solid ${c.accent}`, background: c.blanc, color: c.texte }} />
+      ) : (
+        <div onClick={() => setEditing(true)}
+          style={{ flex: 1, fontSize: 13, color: c.texte, cursor: 'pointer' }}>
+          {article.nom}
+        </div>
+      )}
+      <span style={{ fontSize: 10, color: c.texteMuted }}>{TYPE_LABEL[article.type]} · {SERVICE_LABEL[article.service]}</span>
+      <button onClick={onDelete}
+        style={{ background: 'transparent', border: `0.5px solid ${c.bordure}`, borderRadius: 6, padding: '3px 8px', fontSize: 11, color: c.texteMuted, cursor: 'pointer' }}
+        title="Désactiver">
+        Supprimer
+      </button>
+    </div>
+  )
+}

--- a/components/rapport-hebdo/ComparaisonPanel.js
+++ b/components/rapport-hebdo/ComparaisonPanel.js
@@ -1,0 +1,211 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { supabase } from '../../lib/supabase'
+import {
+  buildRapportData, formatEur, formatNombre, formatPct, formatPeriode,
+} from '../../lib/rapportHebdo'
+
+// Panel de comparaison multi-périodes : sous l'éditeur de rapport courant.
+// L'utilisateur peut ajouter 1 à N périodes additionnelles et voir un
+// tableau côte à côte des KPIs clés (CA, couverts, TM total).
+//
+// `currentPeriode` : période principale du rapport (rappelée en colonne 1
+// pour servir de référence)
+// `periodes` : tableau de périodes additionnelles [{ debut, fin }]
+// `onPeriodesChange` : setter pour les mettre à jour
+export default function ComparaisonPanel({ c, isMobile, clientId, currentPeriode, periodes, onPeriodesChange }) {
+  // Données chargées par période (Map<key, { caRows, budgetRows, lieuxMap }>)
+  const [datasets, setDatasets] = useState({})
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const allPeriodes = useMemo(() => [
+    { debut: currentPeriode.debut, fin: currentPeriode.fin, isMain: true },
+    ...periodes.map((p) => ({ ...p, isMain: false })),
+  ], [currentPeriode, periodes])
+
+  const loadDataset = useCallback(async (debut, fin) => {
+    const [y1] = debut.split('-').map(Number)
+    const [y2] = fin.split('-').map(Number)
+    const annees = Array.from(new Set([y1, y2]))
+    const [lieuxRes, caRes, budgetRes] = await Promise.all([
+      supabase.from('lieux_service').select('id, nom').eq('client_id', clientId).eq('actif', true),
+      supabase.from('ca_journalier')
+        .select('jour, service, lieu_service_id, couverts, ca_food, ca_bev_20, ca_bev_10, ca_autre')
+        .eq('client_id', clientId).gte('jour', debut).lte('jour', fin),
+      supabase.from('ca_budgets')
+        .select('annee, mois, jour_semaine, lieu_service_id, service, couverts_cible, ca_food_cible, ca_bev_20_cible, ca_bev_10_cible, ca_autre_cible')
+        .eq('client_id', clientId).in('annee', annees),
+    ])
+    if (lieuxRes.error) throw lieuxRes.error
+    if (caRes.error) throw caRes.error
+    if (budgetRes.error) throw budgetRes.error
+    const lieuxMap = new Map((lieuxRes.data || []).map((l) => [l.id, l.nom]))
+    return {
+      caRows: caRes.data || [], budgetRows: budgetRes.data || [], lieuxMap,
+    }
+  }, [clientId])
+
+  useEffect(() => {
+    let cancel = false
+    ;(async () => {
+      setLoading(true); setError('')
+      try {
+        const out = {}
+        for (const p of allPeriodes) {
+          const key = `${p.debut}_${p.fin}`
+          if (datasets[key]) { out[key] = datasets[key]; continue }
+          const ds = await loadDataset(p.debut, p.fin)
+          if (cancel) return
+          out[key] = ds
+        }
+        if (cancel) return
+        setDatasets(out)
+      } catch (e) {
+        if (cancel) return
+        setError(e.message || 'Erreur de chargement comparaison')
+      } finally {
+        if (!cancel) setLoading(false)
+      }
+    })()
+    return () => { cancel = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allPeriodes.map((p) => `${p.debut}_${p.fin}`).join('|'), clientId])
+
+  const addPeriode = () => {
+    // Par défaut : 7 jours avant la dernière période ajoutée
+    const last = periodes[periodes.length - 1] || currentPeriode
+    const finPrev = new Date(last.debut)
+    finPrev.setDate(finPrev.getDate() - 1)
+    const debutPrev = new Date(finPrev)
+    debutPrev.setDate(finPrev.getDate() - 6)
+    const fmt = (d) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+    onPeriodesChange([...periodes, { debut: fmt(debutPrev), fin: fmt(finPrev) }])
+  }
+
+  const removePeriode = (i) => {
+    onPeriodesChange(periodes.filter((_, idx) => idx !== i))
+  }
+
+  const updatePeriode = (i, patch) => {
+    onPeriodesChange(periodes.map((p, idx) => idx === i ? { ...p, ...patch } : p))
+  }
+
+  const reports = useMemo(() => {
+    return allPeriodes.map((p) => {
+      const key = `${p.debut}_${p.fin}`
+      const ds = datasets[key]
+      if (!ds) return { periode: p, data: null }
+      const data = buildRapportData({
+        caRows: ds.caRows,
+        budgetRows: ds.budgetRows,
+        lieuxMap: ds.lieuxMap,
+        debut: p.debut, fin: p.fin,
+      })
+      return { periode: p, data }
+    })
+  }, [allPeriodes, datasets])
+
+  // Rendu : tableau avec une ligne par KPI et une colonne par période
+  const headStyle = { padding: '8px 10px', background: c.fond, fontSize: 11, fontWeight: 600, color: c.texteMuted, textTransform: 'uppercase', letterSpacing: 0.3, borderBottom: `1px solid ${c.bordure}` }
+  const cellStyle = { padding: '8px 10px', fontSize: 13, color: c.texte, borderBottom: `0.5px solid ${c.bordure}` }
+  const kpiNameStyle = { ...cellStyle, fontWeight: 600 }
+  const numStyle = { ...cellStyle, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }
+
+  const kpiRow = (label, picker, fmt, ratioPicker) => (
+    <tr>
+      <td style={kpiNameStyle}>{label}</td>
+      {reports.map((r, i) => {
+        const v = r.data ? picker(r.data) : null
+        const ratio = ratioPicker && r.data ? ratioPicker(r.data) : null
+        return (
+          <td key={i} style={numStyle}>
+            {v != null ? fmt(v) : '—'}
+            {ratio != null && (
+              <span style={{ fontSize: 11, color: ratio >= 0 ? c.vert : c.rouge, marginLeft: 6, fontWeight: 600 }}>
+                {formatPct(ratio)}
+              </span>
+            )}
+          </td>
+        )
+      })}
+    </tr>
+  )
+
+  return (
+    <div style={{ marginTop: 20, background: c.blanc, border: `0.5px solid ${c.bordure}`, borderRadius: 12, padding: isMobile ? 12 : 16 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 12, marginBottom: 12, flexWrap: 'wrap' }}>
+        <div>
+          <h2 style={{ margin: '0 0 4px', fontSize: 17, fontWeight: 600, color: c.texte }}>Comparaison multi-périodes</h2>
+          <p style={{ margin: 0, fontSize: 12, color: c.texteMuted }}>
+            Ajoute jusqu&apos;à plusieurs périodes pour comparer les indicateurs clés côte à côte.
+          </p>
+        </div>
+        <button onClick={addPeriode}
+          style={{ padding: '7px 14px', borderRadius: 8, fontSize: 13, border: 'none', background: c.accent, color: c.texte, fontWeight: 600, cursor: 'pointer' }}>
+          + Ajouter une période
+        </button>
+      </div>
+
+      {/* Sélecteurs périodes additionnelles */}
+      {periodes.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 }}>
+          {periodes.map((p, i) => (
+            <div key={i} style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap', background: c.fond, padding: '8px 10px', borderRadius: 8 }}>
+              <span style={{ fontSize: 11, color: c.texteMuted, minWidth: 80 }}>Période {i + 2} :</span>
+              <input type="date" value={p.debut} onChange={(e) => updatePeriode(i, { debut: e.target.value })}
+                style={{ padding: '5px 8px', borderRadius: 6, fontSize: 12, border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte }} />
+              <span style={{ fontSize: 11, color: c.texteMuted }}>au</span>
+              <input type="date" value={p.fin} onChange={(e) => updatePeriode(i, { fin: e.target.value })}
+                style={{ padding: '5px 8px', borderRadius: 6, fontSize: 12, border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte }} />
+              <div style={{ flex: 1 }} />
+              <button onClick={() => removePeriode(i)}
+                style={{ background: 'transparent', border: `0.5px solid ${c.bordure}`, borderRadius: 6, padding: '3px 8px', fontSize: 11, color: c.texteMuted, cursor: 'pointer' }}>
+                Retirer
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <div style={{ marginBottom: 12, padding: '8px 12px', background: '#FCEBEB', color: '#A32D2D', borderRadius: 8, fontSize: 12 }}>
+          {error}
+        </div>
+      )}
+
+      {loading && (
+        <div style={{ padding: 12, fontSize: 13, color: c.texteMuted }}>Chargement des données…</div>
+      )}
+
+      {/* Tableau */}
+      <div style={{ overflowX: 'auto', border: `0.5px solid ${c.bordure}`, borderRadius: 8 }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr>
+              <th style={{ ...headStyle, textAlign: 'left' }}>Indicateur</th>
+              {allPeriodes.map((p, i) => (
+                <th key={i} style={{ ...headStyle, textAlign: 'right' }}>
+                  {p.isMain ? '⭐ ' : ''}{formatPeriode(p.debut, p.fin)}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {kpiRow('CA TTC réel',          (d) => d.ca.real,         formatEur)}
+            {kpiRow('CA TTC budget',        (d) => d.ca.budget,       formatEur)}
+            {kpiRow('Δ vs budget',          (d) => d.ca.delta,        formatEur, (d) => d.ca.ratio)}
+            {kpiRow('Couverts midi',        (d) => d.couverts.midi.real,    formatNombre, (d) => d.couverts.midi.ratio)}
+            {kpiRow('Couverts soir',        (d) => d.couverts.soir.real,    formatNombre, (d) => d.couverts.soir.ratio)}
+            {kpiRow('Couverts total',       (d) => d.couverts.total.real,   formatNombre, (d) => d.couverts.total.ratio)}
+            {kpiRow('TM Food midi',         (d) => d.tmFb.midi.real_tm_food, formatEur,    (d) => d.tmFb.midi.ratio_food)}
+            {kpiRow('TM Bev midi',          (d) => d.tmFb.midi.real_tm_bev,  formatEur,    (d) => d.tmFb.midi.ratio_bev)}
+            {kpiRow('TM Food soir',         (d) => d.tmFb.soir.real_tm_food, formatEur,    (d) => d.tmFb.soir.ratio_food)}
+            {kpiRow('TM Bev soir',          (d) => d.tmFb.soir.real_tm_bev,  formatEur,    (d) => d.tmFb.soir.ratio_bev)}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/components/rapport-hebdo/ComparaisonPanel.js
+++ b/components/rapport-hebdo/ComparaisonPanel.js
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { supabase } from '../../lib/supabase'
 import {
-  buildRapportData, formatEur, formatNombre, formatPct, formatPeriode,
+  buildRapportData, buildJoursFermesIso, formatEur, formatNombre, formatPct, formatPeriode,
 } from '../../lib/rapportHebdo'
 
 // Panel de comparaison multi-périodes : sous l'éditeur de rapport courant.
@@ -29,7 +29,7 @@ export default function ComparaisonPanel({ c, isMobile, clientId, currentPeriode
     const [y1] = debut.split('-').map(Number)
     const [y2] = fin.split('-').map(Number)
     const annees = Array.from(new Set([y1, y2]))
-    const [lieuxRes, caRes, budgetRes] = await Promise.all([
+    const [lieuxRes, caRes, budgetRes, jfRes, jfhRes] = await Promise.all([
       supabase.from('lieux_service').select('id, nom').eq('client_id', clientId).eq('actif', true),
       supabase.from('ca_journalier')
         .select('jour, service, lieu_service_id, couverts, ca_food, ca_bev_20, ca_bev_10, ca_autre')
@@ -37,13 +37,21 @@ export default function ComparaisonPanel({ c, isMobile, clientId, currentPeriode
       supabase.from('ca_budgets')
         .select('annee, mois, jour_semaine, lieu_service_id, service, couverts_cible, ca_food_cible, ca_bev_20_cible, ca_bev_10_cible, ca_autre_cible')
         .eq('client_id', clientId).in('annee', annees),
+      supabase.from('ca_jours_fermes').select('date, motif').eq('client_id', clientId).gte('date', debut).lte('date', fin),
+      supabase.from('ca_jours_fermes_hebdo').select('jour_semaine, motif').eq('client_id', clientId),
     ])
     if (lieuxRes.error) throw lieuxRes.error
     if (caRes.error) throw caRes.error
     if (budgetRes.error) throw budgetRes.error
+    if (jfRes.error) throw jfRes.error
+    if (jfhRes.error) throw jfhRes.error
     const lieuxMap = new Map((lieuxRes.data || []).map((l) => [l.id, l.nom]))
     return {
-      caRows: caRes.data || [], budgetRows: budgetRes.data || [], lieuxMap,
+      caRows: caRes.data || [],
+      budgetRows: budgetRes.data || [],
+      lieuxMap,
+      joursFermesRows: jfRes.data || [],
+      joursFermesHebdoRows: jfhRes.data || [],
     }
   }, [clientId])
 
@@ -97,11 +105,15 @@ export default function ComparaisonPanel({ c, isMobile, clientId, currentPeriode
       const key = `${p.debut}_${p.fin}`
       const ds = datasets[key]
       if (!ds) return { periode: p, data: null }
+      const joursFermesIso = buildJoursFermesIso(
+        ds.joursFermesRows, ds.joursFermesHebdoRows, p.debut, p.fin,
+      )
       const data = buildRapportData({
         caRows: ds.caRows,
         budgetRows: ds.budgetRows,
         lieuxMap: ds.lieuxMap,
         debut: p.debut, fin: p.fin,
+        joursFermesIso,
       })
       return { periode: p, data }
     })

--- a/components/rapport-hebdo/RapportSections.js
+++ b/components/rapport-hebdo/RapportSections.js
@@ -222,9 +222,88 @@ function Section({ c, titre, children }) {
 const ulStyle = { margin: 0, paddingLeft: 20, fontSize: 14, color: '#000', lineHeight: '1.7' }
 const liStyle = { marginBottom: 4 }
 
+// ── Section Articles (menus + suppléments) ─────────────────────────────────
+
+// Affiche les ventes par menu/supplément groupées par (type, service).
+// Pour chaque article, montre la qté vendue + % vs couverts du service.
+// `articles` : [{ id, nom, type, service }]
+// `articlesVentes` : { [article_id]: quantite }
+// `couverts` : sortie de couvertsParService(...)
+// `editable` : si true, permet d'éditer les qtés inline
+// `onChangeQte` : (articleId, qte) => void
+export function SectionArticles({ c, articles, articlesVentes, couverts, editable, onChangeQte, titre }) {
+  if (!articles || articles.length === 0) return null
+
+  // Regroupe par (type, service)
+  const groups = [
+    { type: 'menu',       service: 'lunch',  label: 'Ventes Menu Déjeuner', svcCouv: couverts.midi.real },
+    { type: 'menu',       service: 'dinner', label: 'Ventes Menu Dîner',    svcCouv: couverts.soir.real },
+    { type: 'menu',       service: 'all',    label: 'Ventes Menu (tous services)', svcCouv: couverts.total.real },
+    { type: 'supplement', service: 'lunch',  label: 'Suppléments Déjeuner', svcCouv: couverts.midi.real },
+    { type: 'supplement', service: 'dinner', label: 'Suppléments Dîner',    svcCouv: couverts.soir.real },
+    { type: 'supplement', service: 'all',    label: 'Suppléments (tous services)', svcCouv: couverts.total.real },
+  ]
+
+  const cellPad = '6px 10px'
+  const head = { padding: cellPad, background: c.fond, color: c.texteMuted, fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.3, borderBottom: `1px solid ${c.bordure}` }
+  const cell = { padding: cellPad, fontSize: 13, color: c.texte, borderBottom: `0.5px solid ${c.bordure}` }
+
+  const blocks = groups.map((g) => {
+    const items = articles.filter((a) => a.type === g.type && a.service === g.service)
+    if (items.length === 0) return null
+    return (
+      <div key={`${g.type}_${g.service}`} style={{ marginBottom: 16 }}>
+        <div style={{ fontSize: 12, fontWeight: 600, color: c.texte, marginBottom: 6 }}>
+          {g.label}
+        </div>
+        <div style={{ overflowX: 'auto', border: `0.5px solid ${c.bordure}`, borderRadius: 8 }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                <th style={{ ...head, textAlign: 'left' }}>Nom de l&apos;article</th>
+                <th style={{ ...head, textAlign: 'right' }}>Qté vendue</th>
+                <th style={{ ...head, textAlign: 'right' }}>% vs couverts</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((a) => {
+                const qte = Number(articlesVentes?.[a.id] || 0)
+                const pct = g.svcCouv > 0 ? (qte / g.svcCouv) * 100 : null
+                return (
+                  <tr key={a.id}>
+                    <td style={{ ...cell, textAlign: 'left' }}>{a.nom}</td>
+                    <td style={{ ...cell, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+                      {editable ? (
+                        <input
+                          type="number" min="0" step="1"
+                          value={qte || ''}
+                          onChange={(e) => onChangeQte && onChangeQte(a.id, e.target.value === '' ? 0 : Number(e.target.value))}
+                          style={{ width: 70, padding: '4px 6px', borderRadius: 4, border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte, fontSize: 13, textAlign: 'right' }}
+                        />
+                      ) : (
+                        formatNombre(qte)
+                      )}
+                    </td>
+                    <td style={{ ...cell, textAlign: 'right', fontVariantNumeric: 'tabular-nums', fontWeight: 600 }}>
+                      {pct != null ? formatPctSimple(pct) : '—'}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    )
+  }).filter(Boolean)
+
+  if (blocks.length === 0) return null
+  return <Section c={c} titre={titre || 'Ventes par article'}>{blocks}</Section>
+}
+
 // ── Export agrégé pour utilisation par la page ─────────────────────────────
 
-export default function RapportSections({ c, data, debut, fin }) {
+export default function RapportSections({ c, data, debut, fin, articles, articlesVentes, editableArticles, onChangeQte }) {
   const periodeLabel = formatPeriode(debut, fin)
   // Cumul mois : du 1er au fin (ou jour de la période fin)
   const finDate = new Date(fin)
@@ -239,6 +318,17 @@ export default function RapportSections({ c, data, debut, fin }) {
       <SectionMixFoodBev c={c} mix={data.mix} titre={`Ticket moyen Food et Beverage en % vs TM total ${periodeLabel} midi et soir`} />
       <SectionCouverts c={c} couverts={data.couverts} titre={`Nombre de couverts ${periodeLabel}`} />
       <SectionCouvertsJpJ c={c} jours={data.couvertsJpJ} titre={`Couverts jour par jour Réel VS Budget ${periodeLabel}`} />
+      {articles && articles.length > 0 && (
+        <SectionArticles
+          c={c}
+          articles={articles}
+          articlesVentes={articlesVentes}
+          couverts={data.couverts}
+          editable={editableArticles}
+          onChangeQte={onChangeQte}
+          titre={`Ventes par article ${periodeLabel}`}
+        />
+      )}
     </div>
   )
 }

--- a/lib/rapportHebdo.js
+++ b/lib/rapportHebdo.js
@@ -84,9 +84,10 @@ function budgetByIsoJdsForMonth(budgetRows, annee, mois) {
   return out
 }
 
-// Renvoie le budget cumulé sur [debut, fin] (itération calendaire stricte,
-// on n'applique pas les overrides nb_jours par souci de simplicité PR A).
-export function periodBudget(budgetRows, debut, fin) {
+// Renvoie le budget cumulé sur [debut, fin].
+// `joursFermesIso` (optionnel) : Set<string> de dates ISO à exclure du
+// cumul budget (fermetures hebdo + dates spécifiques marquées sur Budgets).
+export function periodBudget(budgetRows, debut, fin, joursFermesIso = null) {
   // Cache par mois pour éviter le calcul N fois
   const cache = new Map()
   const getMap = (annee, mois) => {
@@ -96,6 +97,7 @@ export function periodBudget(budgetRows, debut, fin) {
   }
   let total = 0
   for (const d of eachDayIso(debut, fin)) {
+    if (joursFermesIso && joursFermesIso.has(d.iso)) continue
     const date = fromIso(d.iso)
     const map = getMap(date.getFullYear(), date.getMonth() + 1)
     total += map.get(d.isoJds) || 0
@@ -104,30 +106,32 @@ export function periodBudget(budgetRows, debut, fin) {
 }
 
 // Sommes réel et budget sur une période. Renvoie { real, budget, ratio }.
-export function caTtcVsBudget(caRows, budgetRows, debut, fin) {
+// joursFermesIso exclut certaines dates du cumul budget.
+export function caTtcVsBudget(caRows, budgetRows, debut, fin, joursFermesIso = null) {
   const filtered = filterCaJournalier(caRows, debut, fin)
   let real = 0
   for (const r of filtered) {
     real += Number(r.ca_food || 0) + Number(r.ca_bev_20 || 0) + Number(r.ca_bev_10 || 0) + Number(r.ca_autre || 0)
   }
-  const budget = periodBudget(budgetRows, debut, fin)
+  const budget = periodBudget(budgetRows, debut, fin, joursFermesIso)
   const delta = real - budget
   const ratio = budget > 0 ? (delta / budget) * 100 : null
   return { real, budget, delta, ratio }
 }
 
 // Cumul mois (1er du mois au jour de fin). Utilise le mois de `fin`.
-export function caTtcCumulMois(caRows, budgetRows, fin) {
+export function caTtcCumulMois(caRows, budgetRows, fin, joursFermesIso = null) {
   const finDate = fromIso(fin)
   const debut = `${finDate.getFullYear()}-${String(finDate.getMonth() + 1).padStart(2, '0')}-01`
-  return caTtcVsBudget(caRows, budgetRows, debut, fin)
+  return caTtcVsBudget(caRows, budgetRows, debut, fin, joursFermesIso)
 }
 
 // ── Section 2 : Tickets moyens par lieu × service ──────────────────────────
 
 // Renvoie [{ lieu_label, service, real_tm, budget_tm, ratio }] trié.
 // `lieuxMap` : Map<lieu_service_id, label>
-export function tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin) {
+// `joursFermesIso` (optionnel) : Set<string> de dates exclues du budget.
+export function tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin, joursFermesIso = null) {
   const filtered = filterCaJournalier(caRows, debut, fin)
   // Réel : agrège couverts et CA par (lieu, service)
   const realMap = new Map()
@@ -157,6 +161,7 @@ export function tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin) {
     return cacheBudgetByMonth.get(key)
   }
   for (const d of eachDayIso(debut, fin)) {
+    if (joursFermesIso && joursFermesIso.has(d.iso)) continue
     const date = fromIso(d.iso)
     const cells = getCellsForMonth(date.getFullYear(), date.getMonth() + 1)
     for (const cell of cells.values()) {
@@ -211,7 +216,7 @@ export function tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin) {
 
 // Renvoie { midi: { food, bev, total }, soir: {...}, total: {...} }
 // où chaque objet contient { real_tm, budget_tm, ratio }
-export function tmFoodBevParService(caRows, budgetRows, debut, fin) {
+export function tmFoodBevParService(caRows, budgetRows, debut, fin, joursFermesIso = null) {
   const filtered = filterCaJournalier(caRows, debut, fin)
   // Réel par service
   const real = {
@@ -231,6 +236,7 @@ export function tmFoodBevParService(caRows, budgetRows, debut, fin) {
   }
   const cache = new Map()
   for (const d of eachDayIso(debut, fin)) {
+    if (joursFermesIso && joursFermesIso.has(d.iso)) continue
     const date = fromIso(d.iso)
     const annee = date.getFullYear()
     const mois = date.getMonth() + 1
@@ -302,7 +308,7 @@ export function mixFoodBev(tmFoodBev) {
 
 // ── Section 5 : Couverts midi/soir ─────────────────────────────────────────
 
-export function couvertsParService(caRows, budgetRows, debut, fin) {
+export function couvertsParService(caRows, budgetRows, debut, fin, joursFermesIso = null) {
   const filtered = filterCaJournalier(caRows, debut, fin)
   let realLunch = 0
   let realDinner = 0
@@ -315,6 +321,7 @@ export function couvertsParService(caRows, budgetRows, debut, fin) {
   let budgetDinner = 0
   const cache = new Map()
   for (const d of eachDayIso(debut, fin)) {
+    if (joursFermesIso && joursFermesIso.has(d.iso)) continue
     const date = fromIso(d.iso)
     const annee = date.getFullYear()
     const mois = date.getMonth() + 1
@@ -353,7 +360,9 @@ export function couvertsParService(caRows, budgetRows, debut, fin) {
 // ── Section 6 : Couverts jour-par-jour (tableau) ───────────────────────────
 
 // Renvoie [{ iso, jour_fr, midi: {real, budget, delta, ratio}, soir: {...} }, ...]
-export function couvertsJourParJour(caRows, budgetRows, debut, fin) {
+// joursFermesIso : Set<string> de dates pour lesquelles on force budget=0
+// (fermeture hebdo ou date spécifique marquée sur Budgets CA).
+export function couvertsJourParJour(caRows, budgetRows, debut, fin, joursFermesIso = null) {
   const filtered = filterCaJournalier(caRows, debut, fin)
   // Par jour, par service : couverts réels
   const realByDay = new Map()
@@ -385,10 +394,15 @@ export function couvertsJourParJour(caRows, budgetRows, debut, fin) {
     }
     let budgetLunch = 0
     let budgetDinner = 0
-    for (const cell of cells.values()) {
-      if (cell.jour_semaine !== d.isoJds) continue
-      if (cell.service === 'lunch') budgetLunch += Number(cell.couverts_cible || 0)
-      else budgetDinner += Number(cell.couverts_cible || 0)
+    // Si jour fermé : on force le budget à 0 pour rendre la cellule
+    // visuellement neutre (real et budget tous deux à 0 → écart non
+    // pénalisant).
+    if (!(joursFermesIso && joursFermesIso.has(d.iso))) {
+      for (const cell of cells.values()) {
+        if (cell.jour_semaine !== d.isoJds) continue
+        if (cell.service === 'lunch') budgetLunch += Number(cell.couverts_cible || 0)
+        else budgetDinner += Number(cell.couverts_cible || 0)
+      }
     }
     const real = realByDay.get(d.iso) || { lunch: 0, dinner: 0 }
     out.push({
@@ -414,14 +428,14 @@ export function couvertsJourParJour(caRows, budgetRows, debut, fin) {
 
 // ── Agrégateur : construit tout le rapport en un appel ─────────────────────
 
-export function buildRapportData({ caRows, budgetRows, lieuxMap, debut, fin }) {
-  const ca = caTtcVsBudget(caRows, budgetRows, debut, fin)
-  const caMois = caTtcCumulMois(caRows, budgetRows, fin)
-  const tmLieux = tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin)
-  const tmFb = tmFoodBevParService(caRows, budgetRows, debut, fin)
+export function buildRapportData({ caRows, budgetRows, lieuxMap, debut, fin, joursFermesIso = null }) {
+  const ca = caTtcVsBudget(caRows, budgetRows, debut, fin, joursFermesIso)
+  const caMois = caTtcCumulMois(caRows, budgetRows, fin, joursFermesIso)
+  const tmLieux = tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin, joursFermesIso)
+  const tmFb = tmFoodBevParService(caRows, budgetRows, debut, fin, joursFermesIso)
   const mix = mixFoodBev(tmFb)
-  const couverts = couvertsParService(caRows, budgetRows, debut, fin)
-  const couvertsJpJ = couvertsJourParJour(caRows, budgetRows, debut, fin)
+  const couverts = couvertsParService(caRows, budgetRows, debut, fin, joursFermesIso)
+  const couvertsJpJ = couvertsJourParJour(caRows, budgetRows, debut, fin, joursFermesIso)
   return { ca, caMois, tmLieux, tmFb, mix, couverts, couvertsJpJ }
 }
 
@@ -468,6 +482,29 @@ export function formatPeriode(debut, fin) {
     return `du ${String(dDeb).padStart(2, '0')} au ${String(dFin).padStart(2, '0')} ${MOIS_LABEL_FR[mFin]}`
   }
   return `du ${formatDateFr(debut)} au ${formatDateFr(fin)}`
+}
+
+// Construit le Set<dateIso> des jours fermés sur [debut, fin] en mergeant
+// les dates spécifiques (ca_jours_fermes) et les fermetures hebdomadaires
+// (ca_jours_fermes_hebdo). Permet aux helpers du rapport d'exclure ces
+// dates du calcul budget (cumul, par lieu, par service, jour-par-jour).
+//
+// `joursFermesRows`     : rows ca_jours_fermes  [{ date, motif }]
+// `joursFermesHebdoRows`: rows ca_jours_fermes_hebdo [{ jour_semaine, motif }]
+export function buildJoursFermesIso(joursFermesRows, joursFermesHebdoRows, debut, fin) {
+  const out = new Set()
+  // 1) Dates spécifiques (dans la période)
+  for (const r of (joursFermesRows || [])) {
+    if (r.date >= debut && r.date <= fin) out.add(r.date)
+  }
+  // 2) Fermetures hebdo : étend à toutes les dates matchantes du période
+  const hebdoIsoJds = new Set((joursFermesHebdoRows || []).map((r) => Number(r.jour_semaine)))
+  if (hebdoIsoJds.size > 0) {
+    for (const d of eachDayIso(debut, fin)) {
+      if (hebdoIsoJds.has(d.isoJds)) out.add(d.iso)
+    }
+  }
+  return out
 }
 
 // Lundi-dimanche de la semaine courante (ISO : lundi=début)

--- a/lib/rapportHebdoExport.js
+++ b/lib/rapportHebdoExport.js
@@ -58,7 +58,7 @@ function esc(s) {
 }
 
 // Construit le HTML complet (body + sections + commentaire).
-export function buildRapportHtml({ data, debut, fin, commentaire, titre }) {
+export function buildRapportHtml({ data, debut, fin, commentaire, titre, articles, articlesVentes }) {
   const periode = formatPeriode(debut, fin)
   const sections = [
     renderIntro(data, periode),
@@ -67,6 +67,7 @@ export function buildRapportHtml({ data, debut, fin, commentaire, titre }) {
     renderMixFoodBev(data.mix, periode),
     renderCouverts(data.couverts, periode),
     renderCouvertsJpJ(data.couvertsJpJ, periode),
+    renderArticles(articles, articlesVentes, data.couverts, periode),
     renderCommentaire(commentaire),
   ].filter(Boolean).join('\n')
 
@@ -180,6 +181,48 @@ function renderCouvertsJpJ(jours, periode) {
     </tr>
   </tbody>
 </table>`
+}
+
+function renderArticles(articles, articlesVentes, couverts, periode) {
+  if (!articles || articles.length === 0) return ''
+  const groups = [
+    { type: 'menu',       service: 'lunch',  label: 'Ventes Menu Déjeuner', svcCouv: couverts.midi.real },
+    { type: 'menu',       service: 'dinner', label: 'Ventes Menu Dîner',    svcCouv: couverts.soir.real },
+    { type: 'menu',       service: 'all',    label: 'Ventes Menu (tous services)', svcCouv: couverts.total.real },
+    { type: 'supplement', service: 'lunch',  label: 'Suppléments Déjeuner', svcCouv: couverts.midi.real },
+    { type: 'supplement', service: 'dinner', label: 'Suppléments Dîner',    svcCouv: couverts.soir.real },
+    { type: 'supplement', service: 'all',    label: 'Suppléments (tous services)', svcCouv: couverts.total.real },
+  ]
+  const blocks = groups.map((g) => {
+    const items = articles.filter((a) => a.type === g.type && a.service === g.service)
+    if (items.length === 0) return ''
+    const hasAny = items.some((a) => Number(articlesVentes?.[a.id] || 0) > 0)
+    if (!hasAny) return '' // skip si aucune qté
+    const rows = items.map((a) => {
+      const qte = Number(articlesVentes?.[a.id] || 0)
+      const pct = g.svcCouv > 0 ? (qte / g.svcCouv) * 100 : null
+      return `<tr>
+  <td style="${styles.tdLeft}">${esc(a.nom)}</td>
+  <td style="${styles.td}">${formatNombre(qte)}</td>
+  <td style="${styles.td}; font-weight: 700;">${pct != null ? formatPctSimple(pct) : '—'}</td>
+</tr>`
+    }).join('')
+    return `<div style="margin-bottom: 16px;">
+  <div style="font-size: 12px; font-weight: 600; color: ${COLOR.texte}; margin-bottom: 6px;">${esc(g.label)}</div>
+  <table style="${styles.table}">
+    <thead>
+      <tr>
+        <th style="${styles.th}; text-align: left;">Nom de l'article</th>
+        <th style="${styles.th}">Qté vendue</th>
+        <th style="${styles.th}">% vs couverts</th>
+      </tr>
+    </thead>
+    <tbody>${rows}</tbody>
+  </table>
+</div>`
+  }).filter(Boolean).join('\n')
+  if (!blocks) return ''
+  return `<h3 style="${styles.h3}">Ventes par article ${esc(periode)}</h3>${blocks}`
 }
 
 function renderCommentaire(commentaire) {

--- a/supabase/migrations/20260511000003_ca_articles.sql
+++ b/supabase/migrations/20260511000003_ca_articles.sql
@@ -1,0 +1,55 @@
+-- ============================================================================
+-- ca_articles : référentiel des menus et suppléments suivis par le client.
+--
+-- Le restaurant Marsan suit par exemple :
+--   - Menus : 5 services 205, 8 services 260, Menu déjeuner 98, Menu Privat
+--   - Suppléments : Bœuf wagyu, Caviar, Baba
+--
+-- Les quantités vendues par période sont stockées dans la colonne JSONB
+-- articles_ventes de ca_rapports_hebdo (cf. migration suivante) plutôt
+-- que dans une table relationnelle, pour rester simple à manipuler côté UI.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.ca_articles (
+  id         uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id  uuid        NOT NULL REFERENCES public.clients (id) ON DELETE CASCADE,
+  nom        text        NOT NULL,
+  type       text        NOT NULL CHECK (type IN ('menu', 'supplement')),
+  service    text        NOT NULL CHECK (service IN ('lunch', 'dinner', 'all')) DEFAULT 'all',
+  ordre      integer     NOT NULL DEFAULT 0,
+  actif      boolean     NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.ca_articles IS
+  'Référentiel des menus et suppléments suivis pour les rapports hebdo (saisis manuellement depuis Lightspeed).';
+
+CREATE INDEX IF NOT EXISTS ca_articles_client_idx
+  ON public.ca_articles (client_id, actif, type, service, ordre);
+
+DROP TRIGGER IF EXISTS trg_ca_articles_updated_at ON public.ca_articles;
+CREATE TRIGGER trg_ca_articles_updated_at
+  BEFORE UPDATE ON public.ca_articles
+  FOR EACH ROW EXECUTE FUNCTION public.ca_set_updated_at();
+
+ALTER TABLE public.ca_articles ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ca_articles_select ON public.ca_articles FOR SELECT TO authenticated
+  USING (public.user_has_client_access(client_id));
+CREATE POLICY ca_articles_insert ON public.ca_articles FOR INSERT TO authenticated
+  WITH CHECK (public.user_has_client_access(client_id));
+CREATE POLICY ca_articles_update ON public.ca_articles FOR UPDATE TO authenticated
+  USING (public.user_has_client_access(client_id))
+  WITH CHECK (public.user_has_client_access(client_id));
+CREATE POLICY ca_articles_delete ON public.ca_articles FOR DELETE TO authenticated
+  USING (public.user_has_client_access(client_id));
+
+-- ─── Ajout articles_ventes à ca_rapports_hebdo ────────────────────────────────
+-- Map { "article_id": quantite_vendue } pour la période du rapport.
+-- Le JSONB est plus simple à gérer côté UI qu'une table relationnelle pour
+-- ce cas d'usage (lecture/écriture toujours en bloc par rapport).
+ALTER TABLE public.ca_rapports_hebdo
+  ADD COLUMN IF NOT EXISTS articles_ventes jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN public.ca_rapports_hebdo.articles_ventes IS
+  'Quantités vendues par article pour la période. Format : { "article_id": qte }.';


### PR DESCRIPTION
## Summary
PR B du chantier « Rapport hebdo ». Complète [PR A (#76)](https://github.com/antonydespaux-bit/skalcook/pull/76) avec les sections manquantes du mail historique Marsan (ventes par menu / supplément) et un panel d'analyse comparative entre plusieurs périodes.

## Articles (menus & suppléments)
### Migrations (appliquées en prod via MCP ✅)
- Nouvelle table `ca_articles (id, client_id, nom, type, service, ordre, actif)`
- Ajout colonne `articles_ventes` JSONB à `ca_rapports_hebdo`

### UI
- Bouton **📋 Articles** ouvre une modal pour gérer le référentiel client : ajout, renommage inline, désactivation (soft delete pour préserver l'historique)
- Section **« Ventes par article »** rendue dans le rapport (groupée par type × service) : nom + qté éditable + % vs couverts du service correspondant
- Persistance dans `articles_ventes` JSONB du rapport, restauré au chargement d'une archive
- Export HTML inclut la section, skip les groupes vides

## Comparaison multi-périodes
Toggle **⇄ Comparer** : affiche un panel sous le rapport courant.
- Ajout de N périodes additionnelles (par défaut : 7 jours précédents)
- Tableau côte à côte avec 10 KPIs clés : CA TTC réel/budget/Δ, couverts midi/soir/total, TM Food/Bev midi/soir
- Chaque cellule numérique affiche aussi un Δ % vs budget (vert / rouge)
- Cache local pour éviter les rechargements inutiles

Le rapport principal reste centré sur une seule période (l'usage email du lundi matin). La comparaison est une analyse interne accessible en toggle, sans impact sur le mail généré.

## Test plan
- [ ] Ouvrir `/controle-gestion/ventes/rapport-hebdo`
- [ ] Cliquer **📋 Articles** → ajouter quelques menus + suppléments (ex : « Menu 5 services 205 » type Menu service Déjeuner)
- [ ] Fermer la modal → la section « Ventes par article » apparaît dans le rapport
- [ ] Saisir des quantités → le % vs couverts se calcule en live
- [ ] Sauvegarder → recharger un rapport ancien depuis l'archive → les quantités sont restaurées
- [ ] Cliquer 📋 Copier pour email → vérifier que les tableaux articles apparaissent dans le rendu collé
- [ ] Activer ⇄ Comparer → cliquer « + Ajouter une période » → modifier les dates → le tableau comparatif se met à jour
- [ ] Vérifier que la période principale est marquée d'un ⭐ et que les Δ % vs budget s'affichent dans les bonnes couleurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)