### PR TITLE
feat(lieux): regroupement analytique par parent_lieu_service_id

### DIFF
--- a/app/controle-gestion/analyses/page.js
+++ b/app/controle-gestion/analyses/page.js
@@ -142,7 +142,7 @@ export default function AnalysesPage() {
       const [lieuxRes, layoutRes] = await Promise.all([
         supabase
           .from('lieux_service')
-          .select('id, nom, ordre')
+          .select('id, nom, ordre, parent_lieu_service_id')
           .eq('client_id', cid)
           .eq('actif', true)
           .order('ordre').order('nom'),
@@ -316,41 +316,60 @@ export default function AnalysesPage() {
   const filterJoursActive = joursSelected.length > 0 && joursSelected.length < ALL_JOURS.length
   const joursSet = useMemo(() => new Set(joursSelected), [joursSelected])
 
+  // ── Grouping par parent_lieu_service_id ──────────────────────────────────
+  // Certains lieux sont des enfants analytiques (ex : Table du chef →
+  // Salle à manger). On les remap pour que les agrégations et le filtre
+  // les groupent sous leur parent. Le FilterBar n'affiche que les parents
+  // (les enfants sont implicitement inclus quand on filtre le parent).
+  const lieuxAffiches = useMemo(() => lieux.filter((l) => !l.parent_lieu_service_id), [lieux])
+  const lieuToParent = useMemo(() => {
+    const m = new Map()
+    for (const l of lieux) m.set(l.id, l.parent_lieu_service_id || l.id)
+    return m
+  }, [lieux])
+  const remapRow = useCallback(
+    (r) => ({ ...r, lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id }),
+    [lieuToParent]
+  )
+
   const filterRows = useCallback((rows) => {
-    const filterLieu = lieuxSelected.length > 0 && lieuxSelected.length < lieux.length
+    const filterLieu = lieuxSelected.length > 0 && lieuxSelected.length < lieuxAffiches.length
     const filterService = servicesSelected.length > 0 && servicesSelected.length < ALL_SERVICES.length
-    if (!filterLieu && !filterService && !filterJoursActive) return rows
+    if (!filterLieu && !filterService && !filterJoursActive) return rows.map(remapRow)
     const lieuxSet = new Set(lieuxSelected)
     const servicesSet = new Set(servicesSelected)
-    return rows.filter((r) => {
-      if (filterLieu && !lieuxSet.has(r.lieu_service_id)) return false
-      if (filterService && !servicesSet.has(r.service)) return false
+    return rows.reduce((acc, raw) => {
+      const r = remapRow(raw)
+      if (filterLieu && !lieuxSet.has(r.lieu_service_id)) return acc
+      if (filterService && !servicesSet.has(r.service)) return acc
       if (filterJoursActive) {
         const date = new Date(`${r.jour}T00:00:00`)
         const isoJds = date.getDay() === 0 ? 7 : date.getDay()
-        if (!joursSet.has(isoJds)) return false
+        if (!joursSet.has(isoJds)) return acc
       }
-      return true
-    })
-  }, [lieuxSelected, servicesSelected, lieux.length, filterJoursActive, joursSet])
+      acc.push(r)
+      return acc
+    }, [])
+  }, [lieuxSelected, servicesSelected, lieuxAffiches.length, filterJoursActive, joursSet, remapRow])
 
   const filterBudgets = useCallback((budgetRowsByYear) => {
-    const filterLieu = lieuxSelected.length > 0 && lieuxSelected.length < lieux.length
+    const filterLieu = lieuxSelected.length > 0 && lieuxSelected.length < lieuxAffiches.length
     const filterService = servicesSelected.length > 0 && servicesSelected.length < ALL_SERVICES.length
-    if (!filterLieu && !filterService && !filterJoursActive) return budgetRowsByYear
     const lieuxSet = new Set(lieuxSelected)
     const servicesSet = new Set(servicesSelected)
     const out = {}
     for (const [annee, rows] of Object.entries(budgetRowsByYear)) {
-      out[annee] = rows.filter((r) => {
-        if (filterLieu && !lieuxSet.has(r.lieu_service_id)) return false
-        if (filterService && !servicesSet.has(r.service)) return false
-        if (filterJoursActive && !joursSet.has(r.jour_semaine)) return false
-        return true
-      })
+      out[annee] = rows.reduce((acc, raw) => {
+        const r = remapRow(raw)
+        if (filterLieu && !lieuxSet.has(r.lieu_service_id)) return acc
+        if (filterService && !servicesSet.has(r.service)) return acc
+        if (filterJoursActive && !joursSet.has(r.jour_semaine)) return acc
+        acc.push(r)
+        return acc
+      }, [])
     }
     return out
-  }, [lieuxSelected, servicesSelected, lieux.length, filterJoursActive, joursSet])
+  }, [lieuxSelected, servicesSelected, lieuxAffiches.length, filterJoursActive, joursSet, remapRow])
 
   // ── Totals + days + budget ───────────────────────────────────────────────
   const filteredRows = useMemo(() => filterRows(rawCa), [rawCa, filterRows])
@@ -442,12 +461,24 @@ export default function AnalysesPage() {
   // sélectionnées. "Tous" (tableau vide) compte aussi comme split potentiel
   // si plusieurs valeurs existent — dans ce cas on split par défaut sur la
   // dimension lieu (plus parlant que service à 2 valeurs).
-  const lieuxLabels = useMemo(() => new Map(lieux.map((l) => [l.id, l.nom])), [lieux])
+  // lieuxLabels = Map<id, label_du_parent_ou_self> — utilisé par les
+  // helpers d'agrégation. Comme les rows sont déjà remappées vers le
+  // parent, ce Map ne sert qu'à résoudre les labels (uniquement parents
+  // apparaîtront).
+  const lieuxLabels = useMemo(() => {
+    const noms = new Map(lieux.map((l) => [l.id, l.nom]))
+    const out = new Map()
+    for (const l of lieux) {
+      const parentId = l.parent_lieu_service_id || l.id
+      out.set(l.id, noms.get(parentId) || l.nom)
+    }
+    return out
+  }, [lieux])
   const splitByLieu = useMemo(() => {
     if (lieuxSelected.length >= 2) return true
-    if (lieuxSelected.length === 0 && lieux.length >= 2) return true // "Tous" + plusieurs lieux
+    if (lieuxSelected.length === 0 && lieuxAffiches.length >= 2) return true // "Tous" + plusieurs lieux
     return false
-  }, [lieuxSelected.length, lieux.length])
+  }, [lieuxSelected.length, lieuxAffiches.length])
   const splitByService = useMemo(() => {
     if (servicesSelected.length === ALL_SERVICES.length) return true
     if (servicesSelected.length === 0) return false // "Tous" mais pas split par défaut
@@ -484,7 +515,7 @@ export default function AnalysesPage() {
 
   const breakdowns = useMemo(() => {
     const make = (metric) => ({
-      byLieu: lieux.length >= 2 ? buildBreakdown(seriesByLieu, metric) : null,
+      byLieu: lieuxAffiches.length >= 2 ? buildBreakdown(seriesByLieu, metric) : null,
       byService: buildBreakdown(seriesByService, metric),
     })
     return {
@@ -492,7 +523,7 @@ export default function AnalysesPage() {
       caTtc: make('caTtc'),
       caHt: make('caHt'),
     }
-  }, [seriesByLieu, seriesByService, lieux.length])
+  }, [seriesByLieu, seriesByService, lieuxAffiches.length])
 
   // Days par série (pour line charts multi-séries + perf jour-semaine)
   const daysBySerie = useMemo(() => {
@@ -652,7 +683,7 @@ export default function AnalysesPage() {
 
   // ── Actions TopBar : export Excel + impression ───────────────────────────
   const handleExportExcel = () => {
-    const lieuLabel = lieuxSelected.length === 0 || lieuxSelected.length === lieux.length
+    const lieuLabel = lieuxSelected.length === 0 || lieuxSelected.length === lieuxAffiches.length
       ? 'Tous lieux'
       : lieuxSelected.map((id) => lieuxLabels.get(id) || id).join(', ')
     const serviceLabel = servicesSelected.length === 0 || servicesSelected.length === ALL_SERVICES.length
@@ -733,7 +764,7 @@ export default function AnalysesPage() {
           dateDebut={dateDebut} dateFin={dateFin}
           onDateDebut={setDateDebut} onDateFin={setDateFin}
           comparaison={comparaison} onComparaison={setComparaison}
-          lieux={lieux}
+          lieux={lieuxAffiches}
           lieuxSelected={lieuxSelected} onLieuxSelected={setLieuxSelected}
           servicesSelected={servicesSelected} onServicesSelected={setServicesSelected}
           joursSelected={joursSelected} onJoursSelected={setJoursSelected}

--- a/app/controle-gestion/ventes/rapport-hebdo/page.js
+++ b/app/controle-gestion/ventes/rapport-hebdo/page.js
@@ -117,7 +117,7 @@ export default function RapportHebdoPage() {
       const [lieuxRes, caRes, budgetRes, jfRes, jfhRes] = await Promise.all([
         supabase
           .from('lieux_service')
-          .select('id, nom, ordre, actif')
+          .select('id, nom, ordre, actif, parent_lieu_service_id')
           .eq('client_id', clientId)
           .eq('actif', true)
           .order('ordre').order('nom'),
@@ -208,7 +208,35 @@ export default function RapportHebdoPage() {
   useEffect(() => { if (authReady && clientId) loadArticles() }, [authReady, clientId, loadArticles])
 
   // ── Données dérivées ────────────────────────────────────────────────────
-  const lieuxMap = useMemo(() => new Map(lieux.map((l) => [l.id, l.nom])), [lieux])
+  // lieuxMap = Map<id, label_du_parent_ou_self> — les enfants pointent
+  // vers le nom de leur parent pour que les agrégations groupent
+  // analytiquement. Ex : Table du chef → "Salle à manger".
+  const lieuxMap = useMemo(() => {
+    const noms = new Map(lieux.map((l) => [l.id, l.nom]))
+    const out = new Map()
+    for (const l of lieux) {
+      const parentId = l.parent_lieu_service_id || l.id
+      out.set(l.id, noms.get(parentId) || l.nom)
+    }
+    return out
+  }, [lieux])
+
+  // Remap chaque row vers le parent (ou self si pas de parent) — toutes
+  // les fonctions de calcul (tmParLieuService, etc.) groupent par
+  // lieu_service_id qui pointe maintenant vers le parent.
+  const lieuToParent = useMemo(() => {
+    const m = new Map()
+    for (const l of lieux) m.set(l.id, l.parent_lieu_service_id || l.id)
+    return m
+  }, [lieux])
+  const caRowsRemap = useMemo(
+    () => caRows.map((r) => ({ ...r, lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id })),
+    [caRows, lieuToParent]
+  )
+  const budgetRowsRemap = useMemo(
+    () => budgetRows.map((r) => ({ ...r, lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id })),
+    [budgetRows, lieuToParent]
+  )
 
   // Set des dates fermées sur la période — fermetures hebdo + dates
   // spécifiques marquées sur Budgets CA. Permet d'exclure ces jours du
@@ -219,8 +247,8 @@ export default function RapportHebdoPage() {
   )
 
   const data = useMemo(() => buildRapportData({
-    caRows, budgetRows, lieuxMap, debut, fin, joursFermesIso,
-  }), [caRows, budgetRows, lieuxMap, debut, fin, joursFermesIso])
+    caRows: caRowsRemap, budgetRows: budgetRowsRemap, lieuxMap, debut, fin, joursFermesIso,
+  }), [caRowsRemap, budgetRowsRemap, lieuxMap, debut, fin, joursFermesIso])
 
   // ── Actions ─────────────────────────────────────────────────────────────
   const handleSemainePrec = () => {

--- a/components/rapport-hebdo/ComparaisonPanel.js
+++ b/components/rapport-hebdo/ComparaisonPanel.js
@@ -30,7 +30,7 @@ export default function ComparaisonPanel({ c, isMobile, clientId, currentPeriode
     const [y2] = fin.split('-').map(Number)
     const annees = Array.from(new Set([y1, y2]))
     const [lieuxRes, caRes, budgetRes, jfRes, jfhRes] = await Promise.all([
-      supabase.from('lieux_service').select('id, nom').eq('client_id', clientId).eq('actif', true),
+      supabase.from('lieux_service').select('id, nom, parent_lieu_service_id').eq('client_id', clientId).eq('actif', true),
       supabase.from('ca_journalier')
         .select('jour, service, lieu_service_id, couverts, ca_food, ca_bev_20, ca_bev_10, ca_autre')
         .eq('client_id', clientId).gte('jour', debut).lte('jour', fin),
@@ -45,10 +45,18 @@ export default function ComparaisonPanel({ c, isMobile, clientId, currentPeriode
     if (budgetRes.error) throw budgetRes.error
     if (jfRes.error) throw jfRes.error
     if (jfhRes.error) throw jfhRes.error
-    const lieuxMap = new Map((lieuxRes.data || []).map((l) => [l.id, l.nom]))
+    // lieuxMap : remappe les enfants vers le label du parent (Table du chef
+    // → "Salle à manger") pour que les agrégations groupent analytiquement.
+    const noms = new Map((lieuxRes.data || []).map((l) => [l.id, l.nom]))
+    const lieuToParent = new Map((lieuxRes.data || []).map((l) => [l.id, l.parent_lieu_service_id || l.id]))
+    const lieuxMap = new Map((lieuxRes.data || []).map((l) => [
+      l.id, noms.get(l.parent_lieu_service_id || l.id) || l.nom,
+    ]))
+    // Remappe lieu_service_id sur chaque row vers le parent
+    const remap = (r) => ({ ...r, lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id })
     return {
-      caRows: caRes.data || [],
-      budgetRows: budgetRes.data || [],
+      caRows: (caRes.data || []).map(remap),
+      budgetRows: (budgetRes.data || []).map(remap),
       lieuxMap,
       joursFermesRows: jfRes.data || [],
       joursFermesHebdoRows: jfhRes.data || [],

--- a/supabase/migrations/20260512000000_lieux_service_parent.sql
+++ b/supabase/migrations/20260512000000_lieux_service_parent.sql
@@ -1,0 +1,28 @@
+-- ============================================================================
+-- lieux_service : ajout colonne parent_lieu_service_id pour regrouper
+-- analytiquement des lieux qui sont physiquement séparés mais conceptuellement
+-- liés.
+--
+-- Cas Marsan :
+--   - Table du chef est saisie séparément (caisse à part dans le restaurant)
+--     mais analytiquement c'est de la Salle à manger.
+--   - La cave est un alias pour Table de partage (même endroit, deux noms).
+--
+-- Effet attendu côté app :
+--   - Saisie / Budgets / Excel équipes : chaque lieu reste indépendant
+--     (chaque enfant a son budget, sa grille, ses cellules ca_journalier)
+--   - Analyses / Rapport hebdo : agrégations groupent par parent
+--     → la Salle à manger inclut Table du chef, Table de partage inclut
+--       La cave.
+--   - Filtre par parent dans /analyses inclut automatiquement les enfants
+-- ============================================================================
+
+ALTER TABLE public.lieux_service
+  ADD COLUMN IF NOT EXISTS parent_lieu_service_id uuid
+  REFERENCES public.lieux_service (id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.lieux_service.parent_lieu_service_id IS
+  'Si renseigné, ce lieu est analytiquement groupé sous son parent. La saisie reste séparée mais les analyses regroupent.';
+
+CREATE INDEX IF NOT EXISTS lieux_service_parent_idx
+  ON public.lieux_service (parent_lieu_service_id) WHERE parent_lieu_service_id IS NOT NULL;


### PR DESCRIPTION
## Contexte
Cas Marsan :
- La **Table du chef** est saisie séparément (caisse à part dans le restaurant) mais analytiquement c'est de la **Salle à manger**.
- **La cave** est juste un alias pour **Table de partage** (même lieu physique, deux noms).

Pour préserver la séparation de saisie tout en groupant les analyses, ajout d'une relation parent/enfant sur `lieux_service`.

## Migration
- `ALTER lieux_service ADD parent_lieu_service_id uuid` (nullable, FK self)
- Set en BDD :
  - Table du chef → Salle à manger
  - La cave → Table de partage
- **Appliquée en prod via MCP ✅**

## Pages mises à jour
- **`/analyses`** : remap `caRows` + `budgetRows` `lieu_service_id` → parent avant filtrage et agrégation. FilterBar montre uniquement les **3 parents**. Breakdowns et split par lieu groupent automatiquement.
- **`/rapport-hebdo`** : même remap. `tmParLieuService` groupe naturellement par parent.
- **ComparaisonPanel** : remap inclus dans chaque dataset chargé.

## Pages inchangées (saisie séparée préservée)
- `/ventes/budgets` : grille de saisie reste par-lieu enfant
- `/ventes` (Suivi CA) : pas de breakdown par lieu visible, rien à changer
- **Excel équipes** : 1 colonne par lieu enfant (la team voit la saisie séparée comme d'habitude)

## Effet visible
- Sur **`/analyses`** : 3 groupes au lieu de 5 (Salle à manger, Table de partage, Privat)
- Sur le **rapport hebdo** : « Ticket moyen par lieu » affiche 3 lignes au lieu de 5
- Saisie quotidienne et budgets : continuent d'accepter les 5 lieux

## Test plan
- [ ] Sur `/analyses`, vérifier que le sélecteur Lieux n'affiche que 3 lieux (Salle à manger, Table de partage, Privat)
- [ ] Le KPI « Couverts » avec breakdown par lieu doit afficher 3 entrées
- [ ] Le tableau jour-jour (split par lieu) regroupe Table du chef sous Salle à manger
- [ ] Sur le rapport hebdo, la section « Ticket moyen par lieu » montre 3 lignes
- [ ] Sur Budgets CA, les 5 lieux sont toujours sélectionnables (saisie reste séparée)
- [ ] Excel équipes : toujours 5 colonnes de saisie

🤖 Generated with [Claude Code](https://claude.com/claude-code)