### PR TITLE
feat(rapport-hebdo): mention "Autre CA" (privatisations, frais)

### DIFF
--- a/components/rapport-hebdo/RapportSections.js
+++ b/components/rapport-hebdo/RapportSections.js
@@ -11,7 +11,7 @@ import {
 const SERVICE_LABEL = { lunch: 'déjeuner', dinner: 'dîner' }
 
 export function SectionCaTtc({ c, data, periodeLabel, cumulLabel }) {
-  const { ca, caMois } = data
+  const { ca, caMois, autreCa, autreCaMois } = data
   return (
     <div style={{ marginBottom: 20 }}>
       <p style={{ margin: '0 0 10px', fontSize: 14, color: c.texte }}>
@@ -21,6 +21,11 @@ export function SectionCaTtc({ c, data, periodeLabel, cumulLabel }) {
         {ca.ratio != null && <> soit <strong style={{ color: ca.ratio >= 0 ? c.vert : c.rouge }}>
           {formatPct(ca.ratio)}
         </strong></>}
+        {autreCa > 0 && (
+          <span style={{ color: c.texteMuted, fontStyle: 'italic' }}>
+            {' '}— dont <strong>{formatEur(autreCa)}</strong> d&apos;Autre CA (privatisations, frais)
+          </span>
+        )}
       </p>
       <p style={{ margin: '0 0 10px', fontSize: 14, color: c.texte }}>
         Le CATTC réalisé {cumulLabel} s&apos;élève à{' '}
@@ -29,8 +34,36 @@ export function SectionCaTtc({ c, data, periodeLabel, cumulLabel }) {
         {caMois.ratio != null && <> soit <strong style={{ color: caMois.ratio >= 0 ? c.vert : c.rouge }}>
           {formatPct(caMois.ratio)}
         </strong></>}
+        {autreCaMois > 0 && (
+          <span style={{ color: c.texteMuted, fontStyle: 'italic' }}>
+            {' '}— dont <strong>{formatEur(autreCaMois)}</strong> d&apos;Autre CA
+          </span>
+        )}
       </p>
     </div>
+  )
+}
+
+// Option C — Liste détaillée des "Autres CA" par lieu × service.
+// N'affiche rien si aucun lieu n'a saisi d'autre CA sur la période.
+export function SectionAutresCa({ c, autreCaDetail, autreCa, titre }) {
+  if (!autreCaDetail || autreCaDetail.length === 0) return null
+  return (
+    <Section c={c} titre={titre || 'Autres CA (privatisations, frais…)'}>
+      <ul style={ulStyle}>
+        {autreCaDetail.map((r) => (
+          <li key={`${r.lieu_id}_${r.service}`} style={liStyle}>
+            <strong>{r.lieu_label} {SERVICE_LABEL[r.service]}</strong> :{' '}
+            <strong>{formatEur(r.ca_autre)}</strong>
+          </li>
+        ))}
+        {autreCaDetail.length > 1 && (
+          <li style={{ ...liStyle, marginTop: 6, paddingTop: 6, borderTop: `0.5px solid ${c.bordure}`, fontWeight: 600 }}>
+            Total <strong>{formatEur(autreCa)}</strong>
+          </li>
+        )}
+      </ul>
+    </Section>
   )
 }
 
@@ -318,6 +351,12 @@ export default function RapportSections({ c, data, debut, fin, articles, article
       <SectionMixFoodBev c={c} mix={data.mix} titre={`Ticket moyen Food et Beverage en % vs TM total ${periodeLabel} midi et soir`} />
       <SectionCouverts c={c} couverts={data.couverts} titre={`Nombre de couverts ${periodeLabel}`} />
       <SectionCouvertsJpJ c={c} jours={data.couvertsJpJ} titre={`Couverts jour par jour Réel VS Budget ${periodeLabel}`} />
+      <SectionAutresCa
+        c={c}
+        autreCaDetail={data.autreCaDetail}
+        autreCa={data.autreCa}
+        titre={`Autres CA (privatisations, frais…) ${periodeLabel}`}
+      />
       {articles && articles.length > 0 && (
         <SectionArticles
           c={c}

--- a/lib/__tests__/rapportHebdo.test.ts
+++ b/lib/__tests__/rapportHebdo.test.ts
@@ -7,6 +7,9 @@ import {
   mixFoodBev,
   couvertsParService,
   couvertsJourParJour,
+  autreCaSurPeriode,
+  autreCaCumulMois,
+  autreCaParLieuService,
   buildRapportData,
   semaineEnCours,
   semainePrecedente,
@@ -134,6 +137,63 @@ describe('buildRapportData', () => {
     expect(r.couverts.total.real).toBe(65)
     expect(r.tmLieux).toHaveLength(2)
     expect(r.couvertsJpJ).toHaveLength(1)
+    // Pas d'autre CA dans la fixture → 0 et liste vide
+    expect(r.autreCa).toBe(0)
+    expect(r.autreCaMois).toBe(0)
+    expect(r.autreCaDetail).toEqual([])
+  })
+})
+
+describe('autreCa helpers', () => {
+  // Fixture dédiée — privatisations à La Cave / Salle (1 mer + 1 sam)
+  const rowsAutre = [
+    { jour: '2026-05-06', service: 'lunch',  lieu_service_id: 'L2', couverts: 12,
+      ca_food: 2100, ca_bev_20: 1018, ca_bev_10: 196, ca_autre: 600 },
+    { jour: '2026-05-09', service: 'dinner', lieu_service_id: 'L1', couverts: 36,
+      ca_food: 9793, ca_bev_20: 4492, ca_bev_10: 414, ca_autre: 250 },
+    // ca_autre = 0 → ignoré dans la liste détaillée
+    { jour: '2026-05-09', service: 'lunch',  lieu_service_id: 'L1', couverts: 25,
+      ca_food: 3691, ca_bev_20: 1519, ca_bev_10: 351, ca_autre: 0 },
+    // Hors période (mois suivant) → ignoré
+    { jour: '2026-06-02', service: 'dinner', lieu_service_id: 'L2', couverts: 5,
+      ca_food: 1000, ca_bev_20: 0, ca_bev_10: 0, ca_autre: 999 },
+  ]
+
+  it('autreCaSurPeriode somme ca_autre des lignes dans la période', () => {
+    expect(autreCaSurPeriode(rowsAutre, '2026-05-04', '2026-05-10')).toBe(850)
+  })
+
+  it('autreCaSurPeriode = 0 si rien à reporter', () => {
+    expect(autreCaSurPeriode(rowsAutre, '2026-05-01', '2026-05-03')).toBe(0)
+  })
+
+  it('autreCaCumulMois remonte au 1er du mois de `fin`', () => {
+    // fin = 9 mai → cumul du 01-09 mai inclut les deux lignes (600 + 250)
+    expect(autreCaCumulMois(rowsAutre, '2026-05-09')).toBe(850)
+    // fin = 06 mai → seul le mercredi compte (la ligne du 09 est postérieure)
+    expect(autreCaCumulMois(rowsAutre, '2026-05-06')).toBe(600)
+  })
+
+  it('autreCaParLieuService liste uniquement les ca_autre > 0, triée', () => {
+    const res = autreCaParLieuService(rowsAutre, lieuxMap, '2026-05-04', '2026-05-10')
+    expect(res).toHaveLength(2)
+    // Tri alphabétique : "Salle à manger" avant "Table de partage"
+    expect(res[0]).toMatchObject({ lieu_label: 'Salle à manger', service: 'dinner', ca_autre: 250 })
+    expect(res[1]).toMatchObject({ lieu_label: 'Table de partage', service: 'lunch', ca_autre: 600 })
+  })
+
+  it('autreCaParLieuService renvoie [] si aucune ligne avec ca_autre', () => {
+    expect(autreCaParLieuService(caRows, lieuxMap, '2026-05-05', '2026-05-05')).toEqual([])
+  })
+
+  it('buildRapportData expose autreCa, autreCaMois et autreCaDetail', () => {
+    const r = buildRapportData({
+      caRows: rowsAutre, budgetRows: [], lieuxMap,
+      debut: '2026-05-04', fin: '2026-05-10',
+    })
+    expect(r.autreCa).toBe(850)
+    expect(r.autreCaMois).toBe(850)
+    expect(r.autreCaDetail).toHaveLength(2)
   })
 })
 

--- a/lib/rapportHebdo.js
+++ b/lib/rapportHebdo.js
@@ -426,6 +426,60 @@ export function couvertsJourParJour(caRows, budgetRows, debut, fin, joursFermesI
   return out
 }
 
+// ── Section 7 : Autres CA (privatisations, frais, etc.) ───────────────────
+//
+// Le champ `ca_autre` est déjà inclus dans le total CA TTC (voir
+// caTtcVsBudget). Ces helpers permettent en plus de l'isoler pour le
+// montrer explicitement dans le rapport — pratique pour comprendre d'où
+// vient un écart au budget (ex : 600 € de privatisation un mercredi à La
+// Cave).
+
+// Total ca_autre réel sur la période [debut, fin].
+export function autreCaSurPeriode(caRows, debut, fin) {
+  const filtered = filterCaJournalier(caRows, debut, fin)
+  let total = 0
+  for (const r of filtered) total += Number(r.ca_autre || 0)
+  return total
+}
+
+// Cumul ca_autre depuis le 1er du mois (mois de `fin`) jusqu'à `fin`.
+export function autreCaCumulMois(caRows, fin) {
+  const finDate = fromIso(fin)
+  const debut = `${finDate.getFullYear()}-${String(finDate.getMonth() + 1).padStart(2, '0')}-01`
+  return autreCaSurPeriode(caRows, debut, fin)
+}
+
+// Liste détaillée [{ lieu_id, lieu_label, service, ca_autre }] des lignes
+// avec ca_autre > 0 sur la période. Triée par label lieu puis service
+// (lunch avant dinner). Permet d'afficher une section "Autres CA" qui
+// indique exactement où ces montants ont été saisis.
+export function autreCaParLieuService(caRows, lieuxMap, debut, fin) {
+  const filtered = filterCaJournalier(caRows, debut, fin)
+  const map = new Map()
+  for (const r of filtered) {
+    const v = Number(r.ca_autre || 0)
+    if (v === 0) continue
+    const key = `${r.lieu_service_id}_${r.service}`
+    map.set(key, (map.get(key) || 0) + v)
+  }
+  const out = []
+  for (const [key, ca_autre] of map.entries()) {
+    const [lieuId, service] = key.split('_')
+    out.push({
+      lieu_id: lieuId,
+      lieu_label: lieuxMap.get(lieuId) || lieuId,
+      service,
+      ca_autre,
+    })
+  }
+  out.sort((a, b) => {
+    const cmp = (a.lieu_label || '').localeCompare(b.lieu_label || '', 'fr')
+    if (cmp !== 0) return cmp
+    return a.service === 'lunch' ? -1 : 1
+  })
+  return out
+}
+
 // ── Agrégateur : construit tout le rapport en un appel ─────────────────────
 
 export function buildRapportData({ caRows, budgetRows, lieuxMap, debut, fin, joursFermesIso = null }) {
@@ -436,7 +490,13 @@ export function buildRapportData({ caRows, budgetRows, lieuxMap, debut, fin, jou
   const mix = mixFoodBev(tmFb)
   const couverts = couvertsParService(caRows, budgetRows, debut, fin, joursFermesIso)
   const couvertsJpJ = couvertsJourParJour(caRows, budgetRows, debut, fin, joursFermesIso)
-  return { ca, caMois, tmLieux, tmFb, mix, couverts, couvertsJpJ }
+  const autreCa = autreCaSurPeriode(caRows, debut, fin)
+  const autreCaMois = autreCaCumulMois(caRows, fin)
+  const autreCaDetail = autreCaParLieuService(caRows, lieuxMap, debut, fin)
+  return {
+    ca, caMois, tmLieux, tmFb, mix, couverts, couvertsJpJ,
+    autreCa, autreCaMois, autreCaDetail,
+  }
 }
 
 // ── Formatters ──────────────────────────────────────────────────────────────

--- a/lib/rapportHebdoExport.js
+++ b/lib/rapportHebdoExport.js
@@ -67,6 +67,7 @@ export function buildRapportHtml({ data, debut, fin, commentaire, titre, article
     renderMixFoodBev(data.mix, periode),
     renderCouverts(data.couverts, periode),
     renderCouvertsJpJ(data.couvertsJpJ, periode),
+    renderAutresCa(data.autreCaDetail, data.autreCa, periode),
     renderArticles(articles, articlesVentes, data.couverts, periode),
     renderCommentaire(commentaire),
   ].filter(Boolean).join('\n')
@@ -82,10 +83,16 @@ ${sections}
 }
 
 function renderIntro(data, periode) {
-  const { ca, caMois } = data
+  const { ca, caMois, autreCa, autreCaMois } = data
+  const dontSem = autreCa > 0
+    ? ` <em style="color: ${COLOR.muted};">— dont <strong>${formatEur(autreCa)}</strong> d'Autre CA (privatisations, frais)</em>`
+    : ''
+  const dontMois = autreCaMois > 0
+    ? ` <em style="color: ${COLOR.muted};">— dont <strong>${formatEur(autreCaMois)}</strong> d'Autre CA</em>`
+    : ''
   return `
-<p style="${styles.p}"><strong>Le CATTC réalisé ${esc(periode)}</strong> s'élève à <strong>${formatEur(ca.real)}</strong> pour un budget de <strong>${formatEur(ca.budget)}</strong>${ca.ratio != null ? ` soit <span style="${colorRatio(ca.ratio)}">${formatPct(ca.ratio)}</span>` : ''}.</p>
-<p style="${styles.p}">Le CATTC réalisé <strong>depuis le début du mois</strong> s'élève à <strong>${formatEur(caMois.real)}</strong> pour un budget de <strong>${formatEur(caMois.budget)}</strong>${caMois.ratio != null ? ` soit <span style="${colorRatio(caMois.ratio)}">${formatPct(caMois.ratio)}</span>` : ''}.</p>`
+<p style="${styles.p}"><strong>Le CATTC réalisé ${esc(periode)}</strong> s'élève à <strong>${formatEur(ca.real)}</strong> pour un budget de <strong>${formatEur(ca.budget)}</strong>${ca.ratio != null ? ` soit <span style="${colorRatio(ca.ratio)}">${formatPct(ca.ratio)}</span>` : ''}${dontSem}.</p>
+<p style="${styles.p}">Le CATTC réalisé <strong>depuis le début du mois</strong> s'élève à <strong>${formatEur(caMois.real)}</strong> pour un budget de <strong>${formatEur(caMois.budget)}</strong>${caMois.ratio != null ? ` soit <span style="${colorRatio(caMois.ratio)}">${formatPct(caMois.ratio)}</span>` : ''}${dontMois}.</p>`
 }
 
 function renderTmLieux(tmLieux, periode) {
@@ -181,6 +188,17 @@ function renderCouvertsJpJ(jours, periode) {
     </tr>
   </tbody>
 </table>`
+}
+
+function renderAutresCa(autreCaDetail, autreCa, periode) {
+  if (!autreCaDetail || autreCaDetail.length === 0) return ''
+  const lines = autreCaDetail.map((r) => `
+    <li style="${styles.li}"><strong>${esc(r.lieu_label)} ${esc(SERVICE_LABEL[r.service])}</strong> : <strong>${formatEur(r.ca_autre)}</strong></li>`).join('')
+  const totalLine = autreCaDetail.length > 1
+    ? `<li style="${styles.li}; margin-top: 6px; padding-top: 6px; border-top: 1px solid ${COLOR.bordure}; font-weight: 700;">Total <strong>${formatEur(autreCa)}</strong></li>`
+    : ''
+  return `<h3 style="${styles.h3}">Autres CA (privatisations, frais…) ${esc(periode)}</h3>
+<ul style="${styles.ul}">${lines}${totalLine}</ul>`
 }
 
 function renderArticles(articles, articlesVentes, couverts, periode) {


### PR DESCRIPTION
## Summary

- **Option A** : suffixe italique « — dont X € d'Autre CA » sur les lignes CA TTC semaine et CA TTC mois (n'apparaît que si > 0).
- **Option C** : nouvelle section dédiée « Autres CA (privatisations, frais…) » qui liste par (lieu × service) les montants saisis, affichée juste après le tableau couverts jour-par-jour.

## Pourquoi

Jusqu'ici, le champ `ca_autre` était silencieusement inclus dans tous les totaux mais n'apparaissait nulle part dans le rapport. Quand une privatisation à 600 € faisait gonfler le CA d'une cellule, impossible de comprendre d'où venait l'écart au budget.

## Détail technique

- 3 helpers purs dans `lib/rapportHebdo.js` (`autreCaSurPeriode`, `autreCaCumulMois`, `autreCaParLieuService`) exposés via `buildRapportData`
- `SectionCaTtc` enrichie + nouveau `SectionAutresCa` dans `RapportSections.js`
- `renderIntro` + `renderAutresCa` dans `rapportHebdoExport.js` → HTML export et copie presse-papier incluent eux aussi la mention
- 6 nouveaux tests unitaires → 163 verts au total

## Test plan

- [ ] Aller sur `/controle-gestion/ventes/rapport-hebdo` sur la semaine du 04-10 mai 2026
- [ ] Vérifier qu'on voit « — dont 600 € d'Autre CA » à côté du CA TTC de la semaine
- [ ] Vérifier qu'une section « Autres CA » apparaît avec « Table de partage déjeuner : 600 € »
- [ ] Copier le rapport en HTML et vérifier que la mention apparaît aussi dans le mail collé

🤖 Generated with [Claude Code](https://claude.com/claude-code)