### PR TITLE
feat(food-cost): page ratio food cost (inventaires + ajustements)

### DIFF
--- a/app/api/food-cost/ajustement/route.ts
+++ b/app/api/food-cost/ajustement/route.ts
@@ -1,0 +1,44 @@
+import { apiHandler } from '../../../../lib/apiHandler'
+import {
+  createAjustementSchema,
+  patchAjustementSchema,
+  deleteAjustementSchema,
+} from '../../../../lib/validators/foodCost.schema'
+import {
+  createAjustement,
+  patchAjustement,
+  deleteAjustement,
+} from '../../../../lib/services/foodCost.service'
+
+// POST  : crée une ligne d'ajustement rattachée à un rapport
+export const POST = apiHandler({
+  schema: createAjustementSchema,
+  guard: 'memberOfClient',
+  clientIdFrom: 'body.clientId',
+  handler: async ({ data, user, db }) => {
+    const result = await createAjustement(db, data, user!.id)
+    return Response.json(result)
+  },
+})
+
+// PATCH : met à jour libellé / montant / commentaire
+export const PATCH = apiHandler({
+  schema: patchAjustementSchema,
+  guard: 'memberOfClient',
+  clientIdFrom: 'body.clientId',
+  handler: async ({ data, db }) => {
+    const result = await patchAjustement(db, data)
+    return Response.json(result)
+  },
+})
+
+// DELETE : suppression définitive d'une ligne d'ajustement
+export const DELETE = apiHandler({
+  schema: deleteAjustementSchema,
+  guard: 'memberOfClient',
+  clientIdFrom: 'body.clientId',
+  handler: async ({ data, db }) => {
+    const result = await deleteAjustement(db, data)
+    return Response.json(result)
+  },
+})

--- a/app/api/food-cost/rapport/route.ts
+++ b/app/api/food-cost/rapport/route.ts
@@ -1,0 +1,58 @@
+import { apiHandler } from '../../../../lib/apiHandler'
+import {
+  upsertRapportSchema,
+  getRapportSchema,
+  patchRapportSchema,
+  deleteRapportSchema,
+} from '../../../../lib/validators/foodCost.schema'
+import {
+  upsertRapport,
+  getRapport,
+  patchRapport,
+  deleteRapport,
+} from '../../../../lib/services/foodCost.service'
+
+// POST  : upsert d'un rapport pour une période (idempotent)
+export const POST = apiHandler({
+  schema: upsertRapportSchema,
+  guard: 'memberOfClient',
+  clientIdFrom: 'body.clientId',
+  handler: async ({ data, user, db }) => {
+    const result = await upsertRapport(db, data, user!.id)
+    return Response.json(result)
+  },
+})
+
+// GET   : récupère un rapport + ajustements + totaux calculés live
+export const GET = apiHandler({
+  schema: getRapportSchema,
+  guard: 'memberOfClient',
+  clientIdFrom: 'body.clientId',
+  handler: async ({ data, db }) => {
+    const result = await getRapport(db, data)
+    if (!result) return Response.json({ error: 'Rapport introuvable' }, { status: 404 })
+    return Response.json(result)
+  },
+})
+
+// PATCH : maj inventaires + notes
+export const PATCH = apiHandler({
+  schema: patchRapportSchema,
+  guard: 'memberOfClient',
+  clientIdFrom: 'body.clientId',
+  handler: async ({ data, db }) => {
+    const result = await patchRapport(db, data)
+    return Response.json(result)
+  },
+})
+
+// DELETE : soft-delete du rapport
+export const DELETE = apiHandler({
+  schema: deleteRapportSchema,
+  guard: 'adminOrSuperadmin',
+  clientIdFrom: 'body.clientId',
+  handler: async ({ data, db }) => {
+    const result = await deleteRapport(db, data)
+    return Response.json(result)
+  },
+})

--- a/app/controle-gestion/food-cost/page.js
+++ b/app/controle-gestion/food-cost/page.js
@@ -1,0 +1,454 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase, getClientId } from '../../../lib/supabase'
+import { useIsMobile } from '../../../lib/useIsMobile'
+import { useTheme } from '../../../lib/useTheme'
+import { useRole } from '../../../lib/useRole'
+import Navbar from '../../../components/Navbar'
+import { getPeriodDates, toIsoDate } from '../../../lib/caAnalyses'
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function formatEuro(n) {
+  if (n == null || Number.isNaN(Number(n))) return '—'
+  return `${Number(n).toLocaleString('fr-FR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} €`
+}
+
+function formatPct(n) {
+  if (n == null || !Number.isFinite(n)) return '—'
+  return `${n.toFixed(1)} %`
+}
+
+function defaultPeriod() {
+  // Par défaut : mois précédent (couverture complète du dernier mois clos)
+  return getPeriodDates('mois-precedent')
+}
+
+// Debounce simple pour les autosaves
+function useDebouncedCallback(fn, delay) {
+  const [timer, setTimer] = useState(null)
+  return useCallback((...args) => {
+    if (timer) clearTimeout(timer)
+    const t = setTimeout(() => fn(...args), delay)
+    setTimer(t)
+  }, [fn, delay, timer])
+}
+
+// ─── Composant ──────────────────────────────────────────────────────────────
+
+export default function FoodCostPage() {
+  const router = useRouter()
+  const { c } = useTheme()
+  const isMobile = useIsMobile()
+  const { role, loading: roleLoading } = useRole()
+
+  const [authReady, setAuthReady] = useState(false)
+  const [clientId, setClientId] = useState(null)
+  const [error, setError] = useState('')
+
+  // Période
+  const initial = useMemo(() => defaultPeriod(), [])
+  const [periodeDebut, setPeriodeDebut] = useState(initial.debut)
+  const [periodeFin, setPeriodeFin] = useState(initial.fin)
+
+  // Rapport courant
+  const [rapportId, setRapportId] = useState(null)
+  const [inventaireDebut, setInventaireDebut] = useState('')
+  const [inventaireFin, setInventaireFin] = useState('')
+  const [notes, setNotes] = useState('')
+  const [ajustements, setAjustements] = useState([])
+
+  // Totaux calculés serveur
+  const [caFoodHt, setCaFoodHt] = useState(0)
+  const [achatsHt, setAchatsHt] = useState(0)
+
+  const [loading, setLoading] = useState(false)
+  const [savingInv, setSavingInv] = useState(false)
+
+  // Saisie nouvelle ligne d'ajustement
+  const [newLibelle, setNewLibelle] = useState('')
+  const [newMontant, setNewMontant] = useState('')
+  const [newCommentaire, setNewCommentaire] = useState('')
+  const [addingAjustement, setAddingAjustement] = useState(false)
+
+  // ── Auth ────────────────────────────────────────────────────────────────
+  useEffect(() => {
+    let cancel = false
+    ;(async () => {
+      const { data: { session } } = await supabase.auth.getSession()
+      if (cancel) return
+      if (!session) { router.replace('/'); return }
+      const cid = await getClientId()
+      if (cancel) return
+      setClientId(cid)
+      setAuthReady(true)
+    })()
+    return () => { cancel = true }
+  }, [router])
+
+  useEffect(() => {
+    if (roleLoading || !role) return
+    if (role !== 'admin' && role !== 'directeur') router.replace('/dashboard')
+  }, [role, roleLoading, router])
+
+  // ── Charge / crée le rapport pour la période courante ──────────────────
+  const loadRapport = useCallback(async () => {
+    if (!clientId) return
+    setLoading(true)
+    setError('')
+    try {
+      const { data: { session } } = await supabase.auth.getSession()
+      const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` }
+
+      // 1. Upsert (idempotent) → récupère le rapport_id
+      const upsertRes = await fetch('/api/food-cost/rapport', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ clientId, periodeDebut, periodeFin }),
+      })
+      const upsertJson = await upsertRes.json()
+      if (!upsertRes.ok) throw new Error(upsertJson.error || `HTTP ${upsertRes.status}`)
+      const rid = upsertJson.rapport_id
+
+      // 2. GET full data (rapport + ajustements + totaux)
+      const url = new URL('/api/food-cost/rapport', window.location.origin)
+      url.searchParams.set('rapportId', rid)
+      url.searchParams.set('clientId', clientId)
+      const getRes = await fetch(url.toString(), { headers })
+      const getJson = await getRes.json()
+      if (!getRes.ok) throw new Error(getJson.error || `HTTP ${getRes.status}`)
+
+      setRapportId(rid)
+      setInventaireDebut(getJson.rapport.inventaire_debut_ht ?? '')
+      setInventaireFin(getJson.rapport.inventaire_fin_ht ?? '')
+      setNotes(getJson.rapport.notes ?? '')
+      setAjustements(getJson.ajustements ?? [])
+      setCaFoodHt(getJson.totaux.ca_food_ht)
+      setAchatsHt(getJson.totaux.achats_ht)
+    } catch (e) {
+      setError(`Chargement impossible : ${e.message}`)
+    } finally {
+      setLoading(false)
+    }
+  }, [clientId, periodeDebut, periodeFin])
+
+  useEffect(() => {
+    if (!authReady || !clientId) return
+    loadRapport()
+  }, [authReady, clientId, loadRapport])
+
+  // ── Save inventaires + notes (debounced) ───────────────────────────────
+  const patchRapport = useCallback(async (updates) => {
+    if (!rapportId || !clientId) return
+    setSavingInv(true)
+    try {
+      const { data: { session } } = await supabase.auth.getSession()
+      await fetch('/api/food-cost/rapport', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
+        body: JSON.stringify({ rapportId, clientId, ...updates }),
+      })
+    } finally {
+      setSavingInv(false)
+    }
+  }, [rapportId, clientId])
+
+  const debouncedPatch = useDebouncedCallback(patchRapport, 500)
+
+  const onInventaireDebutChange = (v) => {
+    setInventaireDebut(v)
+    debouncedPatch({ inventaireDebutHt: v === '' ? null : Number(v) })
+  }
+  const onInventaireFinChange = (v) => {
+    setInventaireFin(v)
+    debouncedPatch({ inventaireFinHt: v === '' ? null : Number(v) })
+  }
+  const onNotesChange = (v) => {
+    setNotes(v)
+    debouncedPatch({ notes: v })
+  }
+
+  // ── Ajustements CRUD ───────────────────────────────────────────────────
+  const addAjustement = async () => {
+    if (!rapportId || !clientId) return
+    const libelle = newLibelle.trim()
+    const montant = Number(newMontant)
+    if (!libelle) { setError('Libellé requis pour l\'ajustement.'); return }
+    if (!Number.isFinite(montant)) { setError('Montant numérique requis.'); return }
+    setAddingAjustement(true)
+    setError('')
+    try {
+      const { data: { session } } = await supabase.auth.getSession()
+      const res = await fetch('/api/food-cost/ajustement', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
+        body: JSON.stringify({ clientId, rapportId, libelle, montant, commentaire: newCommentaire.trim() }),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || `HTTP ${res.status}`)
+      setAjustements(prev => [...prev, json])
+      setNewLibelle(''); setNewMontant(''); setNewCommentaire('')
+    } catch (e) {
+      setError(`Ajout impossible : ${e.message}`)
+    } finally {
+      setAddingAjustement(false)
+    }
+  }
+
+  const deleteAjustement = async (id) => {
+    if (!window.confirm('Supprimer cet ajustement ?')) return
+    try {
+      const { data: { session } } = await supabase.auth.getSession()
+      await fetch(`/api/food-cost/ajustement?ajustementId=${id}&clientId=${clientId}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      setAjustements(prev => prev.filter(a => a.id !== id))
+    } catch (e) {
+      setError(`Suppression impossible : ${e.message}`)
+    }
+  }
+
+  // ── Presets de période ─────────────────────────────────────────────────
+  const applyPreset = (k) => {
+    const p = getPeriodDates(k)
+    if (!p) return
+    setPeriodeDebut(p.debut)
+    setPeriodeFin(p.fin)
+  }
+
+  // ── Calculs dérivés (live) ─────────────────────────────────────────────
+  const totaux = useMemo(() => {
+    const invD = inventaireDebut === '' || inventaireDebut == null ? 0 : Number(inventaireDebut)
+    const invF = inventaireFin === '' || inventaireFin == null ? 0 : Number(inventaireFin)
+    const sumAjust = ajustements.reduce((s, a) => s + (Number(a.montant) || 0), 0)
+    const coutMatiere = invD + achatsHt - invF + sumAjust
+    const ratio = caFoodHt > 0 ? (coutMatiere / caFoodHt) * 100 : null
+    return { invD, invF, sumAjust, coutMatiere, ratio }
+  }, [inventaireDebut, inventaireFin, ajustements, achatsHt, caFoodHt])
+
+  const hasInventaires = inventaireDebut !== '' && inventaireFin !== ''
+
+  // ── Styles ─────────────────────────────────────────────────────────────
+  if (!authReady) {
+    return (
+      <div style={{ minHeight: '100vh', background: c.fond, display: 'flex', alignItems: 'center', justifyContent: 'center', color: c.texteMuted, fontSize: 14 }}>
+        Chargement…
+      </div>
+    )
+  }
+
+  const card = {
+    background: c.blanc, borderRadius: 12, border: `0.5px solid ${c.bordure}`,
+    padding: isMobile ? 16 : 24, marginBottom: 16,
+  }
+  const input = {
+    padding: '8px 12px', borderRadius: 8, fontSize: 14,
+    border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte, outline: 'none',
+    width: '100%', boxSizing: 'border-box',
+  }
+  const btnPrimary = {
+    padding: '8px 14px', borderRadius: 8, fontSize: 13, border: 'none',
+    background: c.accent, color: c.texte, cursor: 'pointer', fontWeight: 500,
+  }
+  const btnSecondary = {
+    padding: '6px 12px', borderRadius: 8, fontSize: 12,
+    border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte, cursor: 'pointer',
+  }
+
+  // Couleur du ratio : <30 vert, <35 orange clair, <40 orange, ≥40 rouge
+  const ratioColor = totaux.ratio == null
+    ? c.texteMuted
+    : totaux.ratio < 30 ? '#15803D'
+    : totaux.ratio < 35 ? '#CA8A04'
+    : totaux.ratio < 40 ? '#C2410C'
+    : '#B91C1C'
+
+  return (
+    <div style={{ minHeight: '100vh', background: c.fond }}>
+      <Navbar section="cuisine" />
+      <div style={{ padding: isMobile ? 16 : 24, maxWidth: 1100, margin: '0 auto' }}>
+        <h1 style={{ margin: '0 0 4px', fontSize: isMobile ? 22 : 26, fontWeight: 600, color: c.texte }}>
+          Ratio Food Cost
+        </h1>
+        <p style={{ margin: '0 0 20px', fontSize: 14, color: c.texteMuted }}>
+          Coût matière sur CA Food. Inventaires début/fin + ajustements libres.
+        </p>
+
+        {error && (
+          <div style={{ background: '#FEE2E2', color: '#991B1B', padding: '10px 14px', borderRadius: 8, fontSize: 13, marginBottom: 16 }}>
+            {error}
+          </div>
+        )}
+
+        {/* ── Période ───────────────────────────────────────────────────── */}
+        <div style={card}>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center', marginBottom: 12 }}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, color: c.texteMuted }}>
+              Du
+              <input type="date" value={periodeDebut} onChange={(e) => setPeriodeDebut(e.target.value)}
+                style={{ ...input, width: 'auto', padding: '6px 10px' }} />
+            </label>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, color: c.texteMuted }}>
+              au
+              <input type="date" value={periodeFin} onChange={(e) => setPeriodeFin(e.target.value)}
+                style={{ ...input, width: 'auto', padding: '6px 10px' }} />
+            </label>
+            {[
+              { k: 'mois-en-cours',  label: 'Ce mois' },
+              { k: 'mois-precedent', label: 'Mois préc.' },
+              { k: '30j',            label: '30 j' },
+              { k: 'trimestre',      label: 'Trimestre' },
+              { k: 'annee',          label: 'Année' },
+            ].map(p => (
+              <button key={p.k} onClick={() => applyPreset(p.k)} style={btnSecondary}>{p.label}</button>
+            ))}
+          </div>
+          {loading && <div style={{ fontSize: 12, color: c.texteMuted }}>Chargement des données…</div>}
+        </div>
+
+        {/* ── KPI ───────────────────────────────────────────────────────── */}
+        <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : 'repeat(4, 1fr)', gap: 12, marginBottom: 16 }}>
+          <KpiCard label="CA Food HT" value={formatEuro(caFoodHt)} c={c} />
+          <KpiCard label="Achats HT cumulés" value={formatEuro(achatsHt)} c={c} />
+          <KpiCard label="Coût matière" value={formatEuro(totaux.coutMatiere)} c={c} sub={
+            <span style={{ fontSize: 11, color: c.texteMuted }}>
+              inv. début + achats − inv. fin + Σ ajust.
+            </span>
+          } />
+          <KpiCard
+            label="Ratio food cost"
+            value={formatPct(totaux.ratio)}
+            valueColor={ratioColor}
+            c={c}
+            sub={!hasInventaires ? (
+              <span style={{ fontSize: 11, color: '#B45309' }}>⚠ inventaires manquants — ratio approximatif</span>
+            ) : null}
+          />
+        </div>
+
+        {/* ── Inventaires ──────────────────────────────────────────────── */}
+        <div style={card}>
+          <h3 style={{ margin: '0 0 4px', fontSize: 15, fontWeight: 600, color: c.texte }}>
+            Variation de stock
+          </h3>
+          <p style={{ margin: '0 0 14px', fontSize: 12, color: c.texteMuted }}>
+            Valeurs HT. Laisse vide si tu n&apos;as pas fait d&apos;inventaire physique.
+            {savingInv && <span style={{ marginLeft: 8, fontStyle: 'italic' }}>· enregistrement…</span>}
+          </p>
+          <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr', gap: 12 }}>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <span style={{ fontSize: 12, color: c.texteMuted, fontWeight: 500 }}>Inventaire début (HT €)</span>
+              <input type="number" step="0.01" value={inventaireDebut} onChange={(e) => onInventaireDebutChange(e.target.value)} placeholder="ex. 12000.00" style={input} />
+            </label>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <span style={{ fontSize: 12, color: c.texteMuted, fontWeight: 500 }}>Inventaire fin (HT €)</span>
+              <input type="number" step="0.01" value={inventaireFin} onChange={(e) => onInventaireFinChange(e.target.value)} placeholder="ex. 11500.00" style={input} />
+            </label>
+          </div>
+        </div>
+
+        {/* ── Ajustements ──────────────────────────────────────────────── */}
+        <div style={card}>
+          <h3 style={{ margin: '0 0 4px', fontSize: 15, fontWeight: 600, color: c.texte }}>
+            Ajustements
+          </h3>
+          <p style={{ margin: '0 0 14px', fontSize: 12, color: c.texteMuted }}>
+            Montant signé : <strong>positif</strong> = ajout au coût (ex. transferts entrants), <strong>négatif</strong> = déduction (ex. repas staff, casse, cadeaux clients).
+          </p>
+
+          {ajustements.length > 0 && (
+            <div style={{ overflowX: 'auto', marginBottom: 14, border: `1px solid ${c.bordure}`, borderRadius: 8 }}>
+              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                <thead>
+                  <tr style={{ background: c.fond }}>
+                    <th style={th(c)}>Libellé</th>
+                    <th style={{ ...th(c), textAlign: 'right' }}>Montant</th>
+                    <th style={th(c)}>Commentaire</th>
+                    <th style={{ ...th(c), width: 60 }}></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {ajustements.map((a) => (
+                    <tr key={a.id}>
+                      <td style={td(c)}>{a.libelle}</td>
+                      <td style={{ ...td(c), textAlign: 'right', fontVariantNumeric: 'tabular-nums', color: Number(a.montant) < 0 ? '#15803D' : '#B91C1C' }}>
+                        {Number(a.montant) > 0 ? '+' : ''}{formatEuro(a.montant)}
+                      </td>
+                      <td style={{ ...td(c), color: c.texteMuted, fontSize: 12 }}>{a.commentaire || '—'}</td>
+                      <td style={td(c)}>
+                        <button onClick={() => deleteAjustement(a.id)} style={{ background: 'none', border: 'none', color: '#B91C1C', cursor: 'pointer', fontSize: 12 }}>Suppr.</button>
+                      </td>
+                    </tr>
+                  ))}
+                  <tr style={{ background: c.fond, fontWeight: 600 }}>
+                    <td style={td(c)}>Total ajustements</td>
+                    <td style={{ ...td(c), textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+                      {totaux.sumAjust > 0 ? '+' : ''}{formatEuro(totaux.sumAjust)}
+                    </td>
+                    <td style={td(c)} colSpan={2} />
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* Form d'ajout */}
+          <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '2fr 1fr 3fr auto', gap: 8, alignItems: 'end' }}>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span style={{ fontSize: 11, color: c.texteMuted, fontWeight: 500 }}>Libellé</span>
+              <input value={newLibelle} onChange={(e) => setNewLibelle(e.target.value)} placeholder="ex. Repas staff" style={input} />
+            </label>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span style={{ fontSize: 11, color: c.texteMuted, fontWeight: 500 }}>Montant (signé)</span>
+              <input type="number" step="0.01" value={newMontant} onChange={(e) => setNewMontant(e.target.value)} placeholder="-350.00" style={input} />
+            </label>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span style={{ fontSize: 11, color: c.texteMuted, fontWeight: 500 }}>Commentaire (optionnel)</span>
+              <input value={newCommentaire} onChange={(e) => setNewCommentaire(e.target.value)} placeholder="précision" style={input} />
+            </label>
+            <button onClick={addAjustement} disabled={addingAjustement || !newLibelle.trim() || !newMontant} style={{ ...btnPrimary, opacity: (addingAjustement || !newLibelle.trim() || !newMontant) ? 0.6 : 1 }}>
+              {addingAjustement ? '…' : '+ Ajouter'}
+            </button>
+          </div>
+        </div>
+
+        {/* ── Notes libres ─────────────────────────────────────────────── */}
+        <div style={card}>
+          <h3 style={{ margin: '0 0 8px', fontSize: 15, fontWeight: 600, color: c.texte }}>Notes</h3>
+          <textarea
+            value={notes}
+            onChange={(e) => onNotesChange(e.target.value)}
+            placeholder="Commentaire libre sur ce rapport food cost"
+            rows={3}
+            style={{ ...input, fontFamily: 'inherit', resize: 'vertical' }}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Sous-composants ────────────────────────────────────────────────────────
+
+function KpiCard({ label, value, valueColor, sub, c }) {
+  return (
+    <div style={{ background: c.blanc, borderRadius: 12, border: `0.5px solid ${c.bordure}`, padding: '14px 16px' }}>
+      <div style={{ fontSize: 11, color: c.texteMuted, textTransform: 'uppercase', fontWeight: 600, marginBottom: 4 }}>{label}</div>
+      <div style={{ fontSize: 22, fontWeight: 600, color: valueColor || c.texte, fontVariantNumeric: 'tabular-nums' }}>{value}</div>
+      {sub && <div style={{ marginTop: 4 }}>{sub}</div>}
+    </div>
+  )
+}
+
+const th = (c) => ({
+  padding: '10px 12px', textAlign: 'left', fontWeight: 600, fontSize: 11,
+  color: c.texteMuted, textTransform: 'uppercase',
+  borderBottom: `1px solid ${c.bordure}`, whiteSpace: 'nowrap',
+})
+const td = (c) => ({
+  padding: '10px 12px', fontSize: 13, color: c.texte,
+  borderBottom: `1px solid ${c.bordure}`,
+})

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -202,6 +202,7 @@ export default function Navbar({ section = 'cuisine' }) {
             { label: 'Achats',        path: '/controle-gestion/achats' },
             { label: 'Fournisseurs',  path: '/controle-gestion/fournisseurs' },
             { label: 'Mercuriale',    path: '/controle-gestion/mercuriale' },
+            ...(role === 'admin' || role === 'directeur' ? [{ label: 'Food cost',     path: '/controle-gestion/food-cost' }] : []),
             ...(role === 'admin' || role === 'directeur' ? [{ label: 'Analyses',      path: '/controle-gestion/analyses' }] : []),
             { label: 'Suivi CA',      path: '/controle-gestion/ventes' },
             ...(role === 'admin' || role === 'directeur' ? [{ label: 'Rapport hebdo',  path: '/controle-gestion/ventes/rapport-hebdo' }] : []),

--- a/lib/services/foodCost.service.ts
+++ b/lib/services/foodCost.service.ts
@@ -1,0 +1,216 @@
+/**
+ * Service layer for Food Cost Ratio domain.
+ *
+ * Un rapport = (client, periode_debut, periode_fin) avec :
+ *   - inventaires début/fin (saisis, HT, optionnels)
+ *   - liste d'ajustements libres (libellé + montant signé + commentaire)
+ *
+ * Le CA Food HT et la somme des achats sur la période sont *calculés à la
+ * volée* depuis ca_journalier et achats_factures. On ne les persiste pas.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type {
+  UpsertRapportInput,
+  PatchRapportInput,
+  DeleteRapportInput,
+  GetRapportInput,
+  CreateAjustementInput,
+  PatchAjustementInput,
+  DeleteAjustementInput,
+} from '../validators/foodCost.schema'
+
+// TVA Food 10% (cohérent avec lib/caAnalyses.js / TVA_FOOD)
+const TVA_FOOD = 1.10
+
+// ── Helpers de calcul ──────────────────────────────────────────────────────
+
+export async function computeCaFoodHt(
+  db: SupabaseClient,
+  clientId: string,
+  debut: string,
+  fin: string,
+): Promise<number> {
+  const { data, error } = await db
+    .from('ca_journalier')
+    .select('ca_food')
+    .eq('client_id', clientId)
+    .gte('jour', debut)
+    .lte('jour', fin)
+  if (error) throw new Error(error.message)
+  const totalFoodTtc = (data ?? []).reduce((s, r) => s + (Number((r as { ca_food: number | null }).ca_food) || 0), 0)
+  return totalFoodTtc / TVA_FOOD
+}
+
+export async function computeAchatsHt(
+  db: SupabaseClient,
+  clientId: string,
+  debut: string,
+  fin: string,
+): Promise<number> {
+  const { data, error } = await db
+    .from('achats_factures')
+    .select('total_ht')
+    .eq('client_id', clientId)
+    .gte('date_facture', debut)
+    .lte('date_facture', fin)
+    .is('deleted_at', null)
+  if (error) throw new Error(error.message)
+  return (data ?? []).reduce((s, r) => s + (Number((r as { total_ht: number | null }).total_ht) || 0), 0)
+}
+
+// ── Rapport CRUD ───────────────────────────────────────────────────────────
+
+export async function upsertRapport(
+  db: SupabaseClient,
+  input: UpsertRapportInput,
+  userId: string,
+) {
+  const { clientId, periodeDebut, periodeFin } = input
+
+  // 1. Rapport existant pour cette période ?
+  const { data: existing } = await db
+    .from('food_cost_rapports')
+    .select('id')
+    .eq('client_id', clientId)
+    .eq('periode_debut', periodeDebut)
+    .eq('periode_fin', periodeFin)
+    .is('deleted_at', null)
+    .maybeSingle()
+
+  if (existing) return { rapport_id: existing.id, created: false }
+
+  // 2. Création
+  const { data: created, error } = await db
+    .from('food_cost_rapports')
+    .insert({
+      client_id: clientId,
+      periode_debut: periodeDebut,
+      periode_fin: periodeFin,
+      created_by: userId,
+    })
+    .select('id')
+    .single()
+  if (error) throw new Error(error.message)
+  return { rapport_id: created.id, created: true }
+}
+
+export async function getRapport(db: SupabaseClient, input: GetRapportInput) {
+  const { rapportId, clientId } = input
+
+  const { data: rapport, error } = await db
+    .from('food_cost_rapports')
+    .select('id, client_id, periode_debut, periode_fin, inventaire_debut_ht, inventaire_fin_ht, notes, created_at, updated_at')
+    .eq('id', rapportId)
+    .eq('client_id', clientId)
+    .is('deleted_at', null)
+    .maybeSingle()
+  if (error) throw new Error(error.message)
+  if (!rapport) return null
+
+  const { data: ajustements } = await db
+    .from('food_cost_ajustements')
+    .select('id, libelle, montant, commentaire, created_at')
+    .eq('rapport_id', rapportId)
+    .eq('client_id', clientId)
+    .order('created_at', { ascending: true })
+
+  // Calculs live
+  const [caFoodHt, achatsHt] = await Promise.all([
+    computeCaFoodHt(db, clientId, rapport.periode_debut, rapport.periode_fin),
+    computeAchatsHt(db, clientId, rapport.periode_debut, rapport.periode_fin),
+  ])
+
+  return {
+    rapport,
+    ajustements: ajustements ?? [],
+    totaux: {
+      ca_food_ht: caFoodHt,
+      achats_ht: achatsHt,
+    },
+  }
+}
+
+export async function patchRapport(db: SupabaseClient, input: PatchRapportInput) {
+  const { rapportId, clientId, inventaireDebutHt, inventaireFinHt, notes } = input
+
+  const updates: Record<string, unknown> = {}
+  if (inventaireDebutHt !== undefined) updates.inventaire_debut_ht = inventaireDebutHt
+  if (inventaireFinHt !== undefined) updates.inventaire_fin_ht = inventaireFinHt
+  if (notes !== undefined) updates.notes = notes
+
+  if (Object.keys(updates).length === 0) return { updated: false }
+
+  const { error } = await db
+    .from('food_cost_rapports')
+    .update(updates)
+    .eq('id', rapportId)
+    .eq('client_id', clientId)
+    .is('deleted_at', null)
+  if (error) throw new Error(error.message)
+  return { updated: true }
+}
+
+export async function deleteRapport(db: SupabaseClient, input: DeleteRapportInput) {
+  const { rapportId, clientId } = input
+  const { error } = await db
+    .from('food_cost_rapports')
+    .update({ deleted_at: new Date().toISOString() })
+    .eq('id', rapportId)
+    .eq('client_id', clientId)
+    .is('deleted_at', null)
+  if (error) throw new Error(error.message)
+  return { deleted: true }
+}
+
+// ── Ajustements CRUD ───────────────────────────────────────────────────────
+
+export async function createAjustement(
+  db: SupabaseClient,
+  input: CreateAjustementInput,
+  userId: string,
+) {
+  const { clientId, rapportId, libelle, montant, commentaire } = input
+  const { data, error } = await db
+    .from('food_cost_ajustements')
+    .insert({
+      client_id: clientId,
+      rapport_id: rapportId,
+      libelle,
+      montant,
+      commentaire: commentaire ?? '',
+      created_by: userId,
+    })
+    .select('id, libelle, montant, commentaire, created_at')
+    .single()
+  if (error) throw new Error(error.message)
+  return data
+}
+
+export async function patchAjustement(db: SupabaseClient, input: PatchAjustementInput) {
+  const { clientId, ajustementId, libelle, montant, commentaire } = input
+  const updates: Record<string, unknown> = {}
+  if (libelle !== undefined) updates.libelle = libelle
+  if (montant !== undefined) updates.montant = montant
+  if (commentaire !== undefined) updates.commentaire = commentaire
+  if (Object.keys(updates).length === 0) return { updated: false }
+
+  const { error } = await db
+    .from('food_cost_ajustements')
+    .update(updates)
+    .eq('id', ajustementId)
+    .eq('client_id', clientId)
+  if (error) throw new Error(error.message)
+  return { updated: true }
+}
+
+export async function deleteAjustement(db: SupabaseClient, input: DeleteAjustementInput) {
+  const { clientId, ajustementId } = input
+  const { error } = await db
+    .from('food_cost_ajustements')
+    .delete()
+    .eq('id', ajustementId)
+    .eq('client_id', clientId)
+  if (error) throw new Error(error.message)
+  return { deleted: true }
+}

--- a/lib/validators/foodCost.schema.ts
+++ b/lib/validators/foodCost.schema.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod'
+import { clientIdSchema, uuidSchema } from './achats.schema'
+
+// Période ISO YYYY-MM-DD
+const dateIso = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date attendue au format YYYY-MM-DD')
+
+// ── Upsert d'un rapport food cost pour une période donnée ─────────────────
+// Crée si absent, retourne l'existant si déjà présent (idempotent sur
+// le couple client_id + periode_debut + periode_fin).
+export const upsertRapportSchema = z.object({
+  clientId:           clientIdSchema,
+  periodeDebut:       dateIso,
+  periodeFin:         dateIso,
+}).refine(d => d.periodeFin >= d.periodeDebut, {
+  message: 'periodeFin doit être >= periodeDebut',
+  path: ['periodeFin'],
+})
+
+// ── Patch d'un rapport (inventaires + notes) ───────────────────────────────
+export const patchRapportSchema = z.object({
+  rapportId:           uuidSchema,
+  clientId:            clientIdSchema,
+  inventaireDebutHt:   z.coerce.number().nullable().optional(),
+  inventaireFinHt:     z.coerce.number().nullable().optional(),
+  notes:               z.string().max(2000).optional(),
+})
+
+// ── Delete (soft) d'un rapport ─────────────────────────────────────────────
+export const deleteRapportSchema = z.object({
+  rapportId: uuidSchema,
+  clientId:  clientIdSchema,
+})
+
+// ── Get rapport + computed totals ──────────────────────────────────────────
+export const getRapportSchema = z.object({
+  rapportId: uuidSchema,
+  clientId:  clientIdSchema,
+})
+
+// ── Ajustements ─────────────────────────────────────────────────────────────
+export const createAjustementSchema = z.object({
+  clientId:    clientIdSchema,
+  rapportId:   uuidSchema,
+  libelle:     z.string().min(1, 'Libellé requis').max(255),
+  montant:     z.coerce.number(),  // signé
+  commentaire: z.string().max(2000).optional().default(''),
+})
+
+export const patchAjustementSchema = z.object({
+  clientId:    clientIdSchema,
+  ajustementId: uuidSchema,
+  libelle:     z.string().min(1).max(255).optional(),
+  montant:     z.coerce.number().optional(),
+  commentaire: z.string().max(2000).optional(),
+})
+
+export const deleteAjustementSchema = z.object({
+  clientId:     clientIdSchema,
+  ajustementId: uuidSchema,
+})
+
+export type UpsertRapportInput   = z.infer<typeof upsertRapportSchema>
+export type PatchRapportInput    = z.infer<typeof patchRapportSchema>
+export type DeleteRapportInput   = z.infer<typeof deleteRapportSchema>
+export type GetRapportInput      = z.infer<typeof getRapportSchema>
+export type CreateAjustementInput = z.infer<typeof createAjustementSchema>
+export type PatchAjustementInput  = z.infer<typeof patchAjustementSchema>
+export type DeleteAjustementInput = z.infer<typeof deleteAjustementSchema>

--- a/supabase/migrations/20260513000000_food_cost_rapports.sql
+++ b/supabase/migrations/20260513000000_food_cost_rapports.sql
@@ -1,0 +1,94 @@
+-- ============================================================================
+-- food_cost_rapports : rapports de food cost ratio sauvegardés.
+--
+-- Un rapport = un couple (période début, période fin) sur un client donné.
+-- Le CA Food et les achats sont recalculés live depuis ca_journalier et
+-- achats_factures ; seuls sont persistés ici l'inventaire de début/fin
+-- (saisis manuellement, HT) et les ajustements (table fille).
+--
+-- Ratio food cost = (inv_debut + achats - inv_fin + Σ ajustements) / CA_food_ht
+--                   × 100
+--
+-- Inventaires optionnels : si NULL, traités comme 0 dans le calcul et un
+-- avertissement est affiché côté UI ("ratio approximatif").
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.food_cost_rapports (
+  id                    uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id             uuid        NOT NULL REFERENCES public.clients (id) ON DELETE CASCADE,
+  periode_debut         date        NOT NULL,
+  periode_fin           date        NOT NULL,
+  inventaire_debut_ht   numeric(12,2),
+  inventaire_fin_ht     numeric(12,2),
+  notes                 text        NOT NULL DEFAULT '',
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  updated_at            timestamptz NOT NULL DEFAULT now(),
+  created_by            uuid        REFERENCES auth.users (id) ON DELETE SET NULL,
+  deleted_at            timestamptz,
+  CONSTRAINT food_cost_rapports_dates_check CHECK (periode_fin >= periode_debut)
+);
+
+-- Une seule période active par client (soft-delete permet de recréer un
+-- rapport sur la même fenêtre si l'ancien est archivé).
+CREATE UNIQUE INDEX IF NOT EXISTS food_cost_rapports_periode_uniq
+  ON public.food_cost_rapports (client_id, periode_debut, periode_fin)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS food_cost_rapports_client_debut_idx
+  ON public.food_cost_rapports (client_id, periode_debut DESC)
+  WHERE deleted_at IS NULL;
+
+COMMENT ON TABLE public.food_cost_rapports IS
+  'Rapports food cost ratio : inventaires début/fin (optionnels) et ajustements (table fille). CA et achats recalculés live.';
+
+DROP TRIGGER IF EXISTS trg_food_cost_rapports_updated_at ON public.food_cost_rapports;
+CREATE TRIGGER trg_food_cost_rapports_updated_at
+  BEFORE UPDATE ON public.food_cost_rapports
+  FOR EACH ROW EXECUTE FUNCTION public.ca_set_updated_at();
+
+ALTER TABLE public.food_cost_rapports ENABLE ROW LEVEL SECURITY;
+CREATE POLICY food_cost_rapports_select ON public.food_cost_rapports FOR SELECT TO authenticated
+  USING (public.user_has_client_access(client_id));
+CREATE POLICY food_cost_rapports_insert ON public.food_cost_rapports FOR INSERT TO authenticated
+  WITH CHECK (public.user_has_client_access(client_id));
+CREATE POLICY food_cost_rapports_update ON public.food_cost_rapports FOR UPDATE TO authenticated
+  USING (public.user_has_client_access(client_id))
+  WITH CHECK (public.user_has_client_access(client_id));
+CREATE POLICY food_cost_rapports_delete ON public.food_cost_rapports FOR DELETE TO authenticated
+  USING (public.user_has_client_access(client_id));
+
+
+-- ============================================================================
+-- food_cost_ajustements : entrées libres ajoutées/retranchées au coût matière.
+--
+-- Ex. "Repas staff : -350", "Casse cave : +120", "Cadeau client : -80".
+-- montant signé : valeur positive = ajout au coût ; valeur négative = déduction.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.food_cost_ajustements (
+  id           uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  rapport_id   uuid        NOT NULL REFERENCES public.food_cost_rapports (id) ON DELETE CASCADE,
+  client_id    uuid        NOT NULL REFERENCES public.clients (id) ON DELETE CASCADE,
+  libelle      text        NOT NULL,
+  montant      numeric(12,2) NOT NULL,
+  commentaire  text        NOT NULL DEFAULT '',
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  created_by   uuid        REFERENCES auth.users (id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS food_cost_ajustements_rapport_idx
+  ON public.food_cost_ajustements (rapport_id);
+
+COMMENT ON TABLE public.food_cost_ajustements IS
+  'Lignes d''ajustement libres rattachées à un rapport food cost (repas staff, casse, cadeaux, etc.). Montant signé.';
+
+ALTER TABLE public.food_cost_ajustements ENABLE ROW LEVEL SECURITY;
+CREATE POLICY food_cost_ajustements_select ON public.food_cost_ajustements FOR SELECT TO authenticated
+  USING (public.user_has_client_access(client_id));
+CREATE POLICY food_cost_ajustements_insert ON public.food_cost_ajustements FOR INSERT TO authenticated
+  WITH CHECK (public.user_has_client_access(client_id));
+CREATE POLICY food_cost_ajustements_update ON public.food_cost_ajustements FOR UPDATE TO authenticated
+  USING (public.user_has_client_access(client_id))
+  WITH CHECK (public.user_has_client_access(client_id));
+CREATE POLICY food_cost_ajustements_delete ON public.food_cost_ajustements FOR DELETE TO authenticated
+  USING (public.user_has_client_access(client_id));


### PR DESCRIPTION
## Summary

- Nouvelle page **/controle-gestion/food-cost** (menu Gestion → Food cost, admin/directeur).
- Le ratio se calcule live : `(inv_debut + achats - inv_fin + Σ ajustements) / CA_food_ht × 100`.
- CA Food et achats sont recalculés depuis `ca_journalier` / `achats_factures` à chaque visite ; seuls les inventaires + ajustements + notes sont persistés.
- Avertissement UI si inventaires manquants (« ratio approximatif »).
- Code couleur du ratio : < 30 % vert · < 35 % jaune · < 40 % orange · ≥ 40 % rouge.

## Persistance

Migration `20260513000000_food_cost_rapports.sql` (**déjà appliquée en prod** via Supabase MCP avant ouverture de la PR pour permettre les tests locaux) :
- `food_cost_rapports` : 1 ligne par couple `(client_id, periode_debut, periode_fin)` unique parmi les non-supprimés.
- `food_cost_ajustements` : N lignes par rapport (libellé, montant signé, commentaire).
- RLS via `user_has_client_access`.

## UX

- Sélecteur de période avec presets (Ce mois, Mois préc., 30 j, Trimestre, Année).
- 4 KPI : CA Food HT · Achats HT · Coût matière · Ratio %.
- Inputs inventaires + textarea notes : autosave debounced 500 ms.
- Liste d'ajustements éditable inline + form d'ajout (libellé / montant signé / commentaire).
- À la première visite d'une période, le rapport est créé automatiquement (idempotent — repasser sur la même fenêtre récupère l'existant).

## Test plan

- [ ] Page accessible depuis le menu Gestion → Food cost
- [ ] Sélection d'une période préset → KPI mis à jour
- [ ] Saisie d'un inventaire début → s'enregistre sans recharger
- [ ] Ajout d'un ajustement « Repas staff » à -350 → ratio baisse
- [ ] Suppression d'un ajustement → ratio remonte
- [ ] Retour sur la même période 5 min après → tout est repersisté
- [ ] Sans inventaires → bandeau d'avertissement visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)