### PR TITLE
feat(achats): OCR multi-factures + tri colonnes + UX import

### DIFF
--- a/app/api/achats/parse-facture/route.ts
+++ b/app/api/achats/parse-facture/route.ts
@@ -23,30 +23,43 @@ const schema = z.object({
   clientId: z.string().uuid(),
 })
 
-const PROMPT_EXTRACTION = `Tu analyses une photo ou scan d'une facture fournisseur de restauration française.
-La facture peut faire PLUSIEURS PAGES : les lignes sont sur les premières pages,
-les TOTAUX (HT, TVA, TTC) sont en bas de la DERNIÈRE PAGE. Lis tout le document.
+const PROMPT_EXTRACTION = `Tu analyses un PDF/scan qui peut contenir UNE OU PLUSIEURS factures fournisseur
+de restauration française, à la suite dans le même document.
 
-Extrais les informations suivantes et retourne UNIQUEMENT du JSON valide,
-sans markdown, sans texte avant ou après.
+Comment distinguer plusieurs factures :
+- Une nouvelle facture commence à chaque fois que tu vois un en-tête "FACTURE N°",
+  "FACTURE D'AVOIR", "FACTURE", "AVOIR" suivi d'un nouveau numéro distinct.
+- Plusieurs pages qui partagent le MÊME numéro de facture = UNE SEULE facture
+  (typiquement les lignes débordent sur une 2ème page, et les totaux HT/TVA/TTC
+  sont en bas de la dernière page de cette facture).
+- Si tu vois un nouveau numéro de facture / d'avoir, démarre une nouvelle entrée
+  dans le tableau "factures".
 
-Format attendu :
+Extrais les informations et retourne UNIQUEMENT du JSON valide, sans markdown,
+sans texte avant ou après.
+
+Format attendu (toujours un array "factures", même s'il n'y en a qu'une) :
 {
-  "fournisseur": "Nom du fournisseur (string ou null)",
-  "date_facture": "YYYY-MM-DD (string ou null)",
-  "numero_facture": "Numéro ou référence de la facture (string ou null)",
-  "total_ht_facture": 726.74,
-  "total_ttc_facture": 784.15,
-  "montant_tva_total": 42.88,
-  "montant_taxes_hors_tva": 14.53,
-  "lignes": [
+  "factures": [
     {
-      "designation": "Nom du produit tel qu'il apparaît sur la facture",
-      "quantite": 5.0,
-      "unite": "kg",
-      "prix_unitaire_ht": 2.50,
-      "montant_ht": 12.50,
-      "taux_tva": 5.5
+      "fournisseur": "Nom du fournisseur (string ou null)",
+      "date_facture": "YYYY-MM-DD (string ou null)",
+      "numero_facture": "Numéro ou référence de la facture (string ou null)",
+      "type": "facture" | "avoir",
+      "total_ht_facture": 726.74,
+      "total_ttc_facture": 784.15,
+      "montant_tva_total": 42.88,
+      "montant_taxes_hors_tva": 14.53,
+      "lignes": [
+        {
+          "designation": "Nom du produit tel qu'il apparaît sur la facture",
+          "quantite": 5.0,
+          "unite": "kg",
+          "prix_unitaire_ht": 2.50,
+          "montant_ht": 12.50,
+          "taux_tva": 5.5
+        }
+      ]
     }
   ]
 }
@@ -59,15 +72,21 @@ Règles CRITIQUES :
    Le séparateur de milliers est l'espace ou rien (ex: "1 234,56" → 1234.56).
    Ne confonds JAMAIS "1,610" (= 1.61) avec 1610.
 
-2. TOTAUX FACTURE (en bas de la dernière page, sous le tableau des lignes) :
+2. TYPE DE DOCUMENT :
+   - "avoir" si l'en-tête mentionne "FACTURE D'AVOIR" / "AVOIR" / "NOTE DE CRÉDIT",
+     ou si les montants/quantités sont négatifs.
+   - "facture" sinon.
+
+3. TOTAUX FACTURE (en bas de la dernière page de chaque facture) :
    - total_ht_facture : "Total HT" ou "Montant HT" du pied de facture (avant TVA).
    - total_ttc_facture : "Total TTC" ou "Net à payer" ou "A payer" du pied.
    - montant_tva_total : "Total TVA" ou "Montant TVA" en euros (pas en %).
    - montant_taxes_hors_tva : "Total taxes hors TVA" / éco-contributions /
      consigne / contributions diverses si présent. Sinon null.
    Si plusieurs taux de TVA sont récapitulés, montant_tva_total est leur SOMME.
+   Pour un avoir, ces montants peuvent être négatifs : renvoie-les tels quels.
 
-3. LIGNES DE FACTURE (cherche dans tout le tableau, sur toutes les pages) :
+4. LIGNES DE FACTURE (cherche dans le tableau de CHAQUE facture) :
    - designation : nom du produit comme écrit (ex: "MARJOLAINE EN BOTTE (FRANCE)").
    - quantite : nombre dans la colonne "Qté" / "Quantité".
    - unite : "kg", "g", "L", "mL", "pièce", "carton", etc. Si "U"/"Un"/"Unité" → "pièce".
@@ -77,9 +96,11 @@ Règles CRITIQUES :
      quand même montant_ht. Le serveur dérivera le P.U. = montant_ht / quantite.
    - taux_tva : 5.5 / 10 / 20. Cherche colonnes "Code TVA", "Taux", "TVA" ou
      codes G1/G2/G3 renvoyant à un récap en pied. Sinon null.
+   N'inclus PAS de ligne dont la quantité ET le montant sont 0 (lignes vides
+   parfois imprimées par les ERP).
 
-4. Si une valeur est absente ou illisible, utilise null.
-5. Ne retourne QUE le JSON, rien d'autre. Pas de markdown, pas d'explication.`
+5. Si une valeur est absente ou illisible, utilise null.
+6. Ne retourne QUE le JSON, rien d'autre. Pas de markdown, pas d'explication.`
 
 export const POST = apiHandler({
   schema,
@@ -94,7 +115,8 @@ export const POST = apiHandler({
 
     const message = await getAnthropic().messages.create({
       model: 'claude-opus-4-7',
-      max_tokens: 4096,
+      // 8192 : marge pour un PDF multi-factures (1 facture ~ 500-1500 tokens en sortie).
+      max_tokens: 8192,
       messages: [
         {
           role: 'user',
@@ -134,70 +156,99 @@ export const POST = apiHandler({
     //   3. Si on n'a que le PU IA → on l'utilise tel quel.
     //   4. Si on n'a rien → 0.
     const resolvePrixUnitaire = (puIA: number | null, montantHt: number | null, qte: number) => {
-      const puVerite = montantHt != null && qte > 0 ? montantHt / qte : null
-      if (puIA != null && puVerite != null) {
-        const ecart = Math.abs(puIA - puVerite) / Math.max(puVerite, 0.01)
-        return ecart < 0.05 ? puIA : puVerite
+      // On raisonne en valeur absolue pour gérer les avoirs (montants négatifs)
+      // sans rejeter les lignes valides.
+      const puVerite = montantHt != null && qte !== 0 ? montantHt / qte : null
+      const puIAAbs = puIA != null ? Math.abs(puIA) : null
+      const puVeriteAbs = puVerite != null ? Math.abs(puVerite) : null
+      if (puIAAbs != null && puVeriteAbs != null) {
+        const ecart = Math.abs(puIAAbs - puVeriteAbs) / Math.max(puVeriteAbs, 0.01)
+        return ecart < 0.05 ? puIAAbs : puVeriteAbs
       }
-      return puIA ?? puVerite ?? 0
+      return puIAAbs ?? puVeriteAbs ?? 0
     }
-
-    const lignes = ((parsed.lignes as Array<Record<string, unknown>>) || [])
-      .filter((l) => l && l.designation)
-      .map((l) => {
-        const tauxRaw = l.taux_tva
-        const taux = tauxRaw == null ? null : Number(tauxRaw)
-        const quantite = Number(l.quantite) || 1
-        const puRaw = Number(l.prix_unitaire_ht)
-        const montantHtRaw = Number(l.montant_ht)
-        const puIA = Number.isFinite(puRaw) && puRaw > 0 ? puRaw : null
-        const montantHt = Number.isFinite(montantHtRaw) && montantHtRaw > 0 ? montantHtRaw : null
-        const prixUnitaire = resolvePrixUnitaire(puIA, montantHt, quantite)
-        return {
-          designation: String(l.designation ?? '').trim(),
-          quantite,
-          unite: String(l.unite ?? '').trim() || null,
-          prix_unitaire_ht: prixUnitaire,
-          taux_tva: taux != null && Number.isFinite(taux) && taux >= 0 && taux <= 100 ? taux : null,
-        }
-      })
-
-    // Diagnostic : aide à comprendre les régressions OCR (lignes sans prix).
-    const sansPrix = lignes.filter((l) => !l.prix_unitaire_ht).length
-    if (sansPrix > 0) {
-      console.warn(
-        `[parse-facture] ${sansPrix}/${lignes.length} lignes sans prix.`,
-        'Échantillon brut:',
-        JSON.stringify(((parsed.lignes as unknown[]) || []).slice(0, 3))
-      )
-    }
-
-    // Filtre date_facture : on n'accepte que YYYY-MM-DD valide, sinon null
-    // (évite que Claude renvoie "hier" ou "2024-13-45" et fasse péter l'insert)
-    const rawDate = (parsed.date_facture as string) ?? null
-    const dateFactureValide = rawDate && /^\d{4}-\d{2}-\d{2}$/.test(rawDate) && !Number.isNaN(Date.parse(rawDate))
-      ? rawDate
-      : null
 
     const sanitizeMontant = (v: unknown): number | null => {
       if (v == null) return null
       const n = Number(v)
-      return Number.isFinite(n) && n >= 0 ? n : null
+      // On accepte les négatifs pour les avoirs ; le signe est porté par "type".
+      return Number.isFinite(n) ? n : null
     }
-    const montantTvaTotal = sanitizeMontant(parsed.montant_tva_total)
-    const totalHtFacture = sanitizeMontant(parsed.total_ht_facture)
-    const totalTtcFacture = sanitizeMontant(parsed.total_ttc_facture)
-    const montantTaxesHorsTva = sanitizeMontant(parsed.montant_taxes_hors_tva)
 
-    return Response.json({
-      fournisseur: (parsed.fournisseur as string) ?? null,
-      date_facture: dateFactureValide,
-      numero_facture: (parsed.numero_facture as string) ?? null,
-      montant_tva_total: montantTvaTotal,
-      total_ht_facture: totalHtFacture,
-      total_ttc_facture: totalTtcFacture,
-      montant_taxes_hors_tva: montantTaxesHorsTva,
-      lignes,
-    })
+    type FactureRaw = Record<string, unknown>
+    const processFacture = (raw: FactureRaw) => {
+      const lignes = ((raw.lignes as Array<Record<string, unknown>>) || [])
+        .filter((l) => l && l.designation)
+        .map((l) => {
+          const tauxRaw = l.taux_tva
+          const taux = tauxRaw == null ? null : Number(tauxRaw)
+          const quantite = Math.abs(Number(l.quantite) || 1)
+          const puRaw = Number(l.prix_unitaire_ht)
+          const montantHtRaw = Number(l.montant_ht)
+          const puIA = Number.isFinite(puRaw) && puRaw !== 0 ? puRaw : null
+          const montantHt = Number.isFinite(montantHtRaw) && montantHtRaw !== 0 ? montantHtRaw : null
+          const prixUnitaire = resolvePrixUnitaire(puIA, montantHt, quantite)
+          return {
+            designation: String(l.designation ?? '').trim(),
+            quantite,
+            unite: String(l.unite ?? '').trim() || null,
+            prix_unitaire_ht: prixUnitaire,
+            taux_tva: taux != null && Number.isFinite(taux) && taux >= 0 && taux <= 100 ? taux : null,
+          }
+        })
+
+      // Filtre date_facture : on n'accepte que YYYY-MM-DD valide, sinon null
+      // (évite que Claude renvoie "hier" ou "2024-13-45" et fasse péter l'insert)
+      const rawDate = (raw.date_facture as string) ?? null
+      const dateFactureValide = rawDate && /^\d{4}-\d{2}-\d{2}$/.test(rawDate) && !Number.isNaN(Date.parse(rawDate))
+        ? rawDate
+        : null
+
+      // statut métier côté UI : 'avoir' si Claude a marqué le doc comme avoir,
+      // ou si tous les totaux sont négatifs. Sinon 'facture'.
+      const typeRaw = String(raw.type ?? '').toLowerCase()
+      const totalHtRaw = sanitizeMontant(raw.total_ht_facture)
+      const isAvoir = typeRaw === 'avoir' || (totalHtRaw != null && totalHtRaw < 0)
+
+      return {
+        fournisseur: (raw.fournisseur as string) ?? null,
+        date_facture: dateFactureValide,
+        numero_facture: (raw.numero_facture as string) ?? null,
+        statut: (isAvoir ? 'avoir' : 'facture') as 'avoir' | 'facture',
+        // Les montants sont retournés en valeur absolue : le statut 'avoir'
+        // suffit côté save-facture pour appliquer le signe négatif.
+        montant_tva_total: totalHtRaw != null ? Math.abs(sanitizeMontant(raw.montant_tva_total) ?? 0) || null : sanitizeMontant(raw.montant_tva_total),
+        total_ht_facture: totalHtRaw != null ? Math.abs(totalHtRaw) : null,
+        total_ttc_facture: (() => {
+          const v = sanitizeMontant(raw.total_ttc_facture)
+          return v != null ? Math.abs(v) : null
+        })(),
+        montant_taxes_hors_tva: (() => {
+          const v = sanitizeMontant(raw.montant_taxes_hors_tva)
+          return v != null ? Math.abs(v) : null
+        })(),
+        lignes,
+      }
+    }
+
+    // L'IA peut renvoyer soit { factures: [...] } (nouveau format multi-factures),
+    // soit l'ancien format à plat { fournisseur, lignes, ... }. On normalise vers
+    // un array dans tous les cas pour que le client n'ait qu'un code à gérer.
+    const rawFactures: FactureRaw[] = Array.isArray(parsed.factures)
+      ? (parsed.factures as FactureRaw[])
+      : [parsed as FactureRaw]
+
+    const factures = rawFactures.map(processFacture)
+
+    // Diagnostic : aide à comprendre les régressions OCR (lignes sans prix).
+    const totalLignes = factures.reduce((s, f) => s + f.lignes.length, 0)
+    const sansPrix = factures.reduce((s, f) => s + f.lignes.filter((l) => !l.prix_unitaire_ht).length, 0)
+    if (sansPrix > 0) {
+      console.warn(
+        `[parse-facture] ${sansPrix}/${totalLignes} lignes sans prix sur ${factures.length} facture(s).`
+      )
+    }
+
+    return Response.json({ factures })
   },
 })

--- a/app/controle-gestion/achats/import/page.js
+++ b/app/controle-gestion/achats/import/page.js
@@ -115,6 +115,17 @@ export default function AchatsImportPage() {
   const [linkingIngFor, setLinkingIngFor] = useState(null)
   const [linkSearch, setLinkSearch] = useState('')
 
+  // ── Multi-factures (un PDF peut contenir plusieurs factures à la suite) ──
+  // extractedFactures = null si pas encore extrait ou si extraction vide.
+  // Sinon array brut tel que renvoyé par /api/achats/parse-facture, qu'on
+  // navigue via currentFactureIdx. Les modifs utilisateur sur la facture
+  // courante sont re-snapshotées dans ce tableau quand on change d'index.
+  const [extractedFactures, setExtractedFactures] = useState(null)
+  const [currentFactureIdx, setCurrentFactureIdx] = useState(0)
+  const [savedFactureIdxs, setSavedFactureIdxs] = useState(() => new Set())
+  // Flash de succès affiché après chaque save en multi-factures (s'estompe).
+  const [lastSavedFlash, setLastSavedFlash] = useState(null)
+
   // ── Refs ──────────────────────────────────────────────────────────────────
   const fileInputRef = useRef(null)
 
@@ -190,6 +201,98 @@ export default function AchatsImportPage() {
     })])
   }, [isManuelMode, authReady, enrichLigneLocal])
 
+  // ─── Multi-factures : helpers de chargement / snapshot / navigation ───────
+
+  // Pousse une facture brute (telle que renvoyée par l'OCR ou snapshotée) dans
+  // le state d'édition courant. Reset aussi les warnings/erreurs liés au save.
+  const loadFactureIntoState = useCallback((facture) => {
+    setFournisseur(facture.fournisseur || '')
+    setDateFacture(facture.date_facture || yesterdayIso())
+    setNumeroFacture(facture.numero_facture || '')
+    setStatut(facture.statut || 'facture')
+    setTotalHtSaisi(facture.total_ht_facture != null ? Number(facture.total_ht_facture) : null)
+    setMontantTvaSaisi(facture.montant_tva_total != null ? Number(facture.montant_tva_total) : null)
+    setTotalTtcSaisi(facture.total_ttc_facture != null ? Number(facture.total_ttc_facture) : null)
+    const enriched = (facture.lignes || []).map(l =>
+      enrichLigneLocal({
+        _id:              makeLigneId(),
+        designation:      l.designation || '',
+        quantite:         Number(l.quantite) || 1,
+        unite:            l.unite || '',
+        prix_unitaire_ht: Number(l.prix_unitaire_ht) || 0,
+        taux_tva:         l.taux_tva != null ? Number(l.taux_tva) : null,
+      })
+    )
+    setLignes(enriched)
+    setError('')
+    setDuplicateWarning(null)
+  }, [enrichLigneLocal])
+
+  // Vérification doublon par numéro de facture (réutilisé après extraction
+  // et après chaque navigation entre factures d'un même PDF).
+  const checkDuplicate = useCallback(async (numeroFact) => {
+    setDuplicateWarning(null)
+    if (!numeroFact?.trim() || !clientId) return
+    try {
+      const { data: { session } } = await supabase.auth.getSession()
+      const dupRes = await fetch(
+        `/api/achats/check-duplicate?clientId=${clientId}&numeroFacture=${encodeURIComponent(numeroFact.trim())}`,
+        { headers: { 'Authorization': `Bearer ${session.access_token}` } }
+      )
+      if (dupRes.ok || dupRes.status === 409) {
+        const payload = await dupRes.json().catch(() => null)
+        if (payload?.existing) setDuplicateWarning(payload.existing)
+      }
+    } catch {
+      // Pas bloquant : le check sera refait côté serveur au save.
+    }
+  }, [clientId])
+
+  // Capture le state d'édition courant pour le re-stocker dans extractedFactures
+  // (utilisé avant de basculer sur une autre facture, pour ne pas perdre les
+  // modifs si l'utilisateur revient dessus).
+  const snapshotCurrent = useCallback(() => ({
+    fournisseur,
+    date_facture: dateFacture,
+    numero_facture: numeroFacture,
+    statut,
+    total_ht_facture: totalHtSaisi != null && totalHtSaisi !== '' ? Number(totalHtSaisi) : null,
+    montant_tva_total: montantTvaSaisi != null && montantTvaSaisi !== '' ? Number(montantTvaSaisi) : null,
+    total_ttc_facture: totalTtcSaisi != null && totalTtcSaisi !== '' ? Number(totalTtcSaisi) : null,
+    lignes: lignes.map(l => ({
+      designation:      l.designation,
+      quantite:         l.quantite,
+      unite:            l.unite,
+      prix_unitaire_ht: l.prix_unitaire_ht,
+      taux_tva:         l.taux_tva,
+    })),
+  }), [fournisseur, dateFacture, numeroFacture, statut, totalHtSaisi, montantTvaSaisi, totalTtcSaisi, lignes])
+
+  const goToFacture = useCallback((idx) => {
+    if (!extractedFactures) return
+    if (idx < 0 || idx >= extractedFactures.length || idx === currentFactureIdx) return
+    // Persiste les éditions sur la facture courante avant de basculer.
+    const snapshot = snapshotCurrent()
+    setExtractedFactures(prev => {
+      if (!prev) return prev
+      const next = [...prev]
+      next[currentFactureIdx] = snapshot
+      return next
+    })
+    setCurrentFactureIdx(idx)
+    loadFactureIntoState(extractedFactures[idx])
+    checkDuplicate(extractedFactures[idx].numero_facture)
+    setLastSavedFlash(null)
+  }, [extractedFactures, currentFactureIdx, snapshotCurrent, loadFactureIntoState, checkDuplicate])
+
+  // Le flash de succès s'estompe au bout de 4 secondes pour ne pas rester
+  // collé en permanence sur la facture en cours.
+  useEffect(() => {
+    if (!lastSavedFlash) return
+    const t = setTimeout(() => setLastSavedFlash(null), 4000)
+    return () => clearTimeout(t)
+  }, [lastSavedFlash])
+
   // ─── Extraction IA ────────────────────────────────────────────────────────
 
   const extractFromImage = useCallback(async (file) => {
@@ -209,47 +312,32 @@ export default function AchatsImportPage() {
       const result = await res.json()
       if (!res.ok) throw new Error(result.error || 'Erreur extraction')
 
-      setFournisseur(result.fournisseur || '')
-      setDateFacture(result.date_facture || yesterdayIso())
-      setNumeroFacture(result.numero_facture || '')
-      // Pré-remplit les totaux extraits du pied de facture (override des
-      // totaux calculés depuis les lignes ; l'utilisateur peut modifier).
-      if (result.total_ht_facture != null) setTotalHtSaisi(Number(result.total_ht_facture))
-      if (result.montant_tva_total != null) setMontantTvaSaisi(Number(result.montant_tva_total))
-      if (result.total_ttc_facture != null) setTotalTtcSaisi(Number(result.total_ttc_facture))
-      const enriched = (result.lignes || []).map(l =>
-        enrichLigneLocal({
-          _id:              makeLigneId(),
-          designation:      l.designation || '',
-          quantite:         Number(l.quantite) || 1,
-          unite:            l.unite || '',
-          prix_unitaire_ht: Number(l.prix_unitaire_ht) || 0,
-          taux_tva:         l.taux_tva != null ? Number(l.taux_tva) : null,
-        })
-      )
-      setLignes(enriched)
+      const factures = Array.isArray(result.factures) ? result.factures : []
+      setSavedFactureIdxs(new Set())
 
-      // Vérification doublon dès l'extraction, avant que l'utilisateur clique sur Enregistrer
-      if (result.numero_facture?.trim()) {
-        const dupRes = await fetch(
-          `/api/achats/check-duplicate?clientId=${clientId}&numeroFacture=${encodeURIComponent(result.numero_facture.trim())}`,
-          { headers: { 'Authorization': `Bearer ${session.access_token}` } }
-        )
-        // 200 = pas de doublon, 409 = doublon trouvé (avec body { duplicate, existing })
-        if (dupRes.ok || dupRes.status === 409) {
-          const payload = await dupRes.json().catch(() => null)
-          if (payload?.existing) setDuplicateWarning(payload.existing)
-        }
+      if (factures.length === 0) {
+        // OCR n'a rien retourné : on bascule en review avec un formulaire vide.
+        setExtractedFactures(null)
+        setCurrentFactureIdx(0)
+        setLignes([])
+        setStep('review')
+        return
       }
+
+      setExtractedFactures(factures)
+      setCurrentFactureIdx(0)
+      loadFactureIntoState(factures[0])
+      await checkDuplicate(factures[0].numero_facture)
 
       setStep('review')
     } catch (err) {
       console.error('Extraction IA échouée :', err)
       setExtractError(err.message || 'Extraction échouée')
+      setExtractedFactures(null)
       setLignes([])
       setStep('review')
     }
-  }, [clientId, enrichLigneLocal])
+  }, [clientId, loadFactureIntoState, checkDuplicate])
 
   // ─── Sélection de fichier (mobile input + desktop drop partagé) ───────────
 
@@ -333,6 +421,14 @@ export default function AchatsImportPage() {
     setError('')
     setExtractError('')
     setPrixMajCount(0)
+    setExtractedFactures(null)
+    setCurrentFactureIdx(0)
+    setSavedFactureIdxs(new Set())
+    setLastSavedFlash(null)
+    setDuplicateWarning(null)
+    setTotalHtSaisi(null)
+    setMontantTvaSaisi(null)
+    setTotalTtcSaisi(null)
   }, [])
 
   // ─── Sauvegarde ───────────────────────────────────────────────────────────
@@ -436,8 +532,33 @@ export default function AchatsImportPage() {
       setError('Ajoutez au moins une ligne avec une désignation avant d\'enregistrer.')
       return
     }
+    // Doublon déjà signalé : empêche l'aller-retour inutile au serveur. L'utilisateur
+    // doit explicitement cliquer "Importer quand même" (qui appelle handleSave(true)).
+    if (duplicateWarning && !forceInsert) {
+      setError(`Cette facture (n° ${numeroFacture}) est déjà en base. Utilisez le bandeau d'avertissement en haut pour annuler ou forcer l'import.`)
+      window.scrollTo({ top: 0, behavior: 'smooth' })
+      return
+    }
+
     setError('')
-    setDuplicateWarning(null)
+    if (forceInsert) setDuplicateWarning(null)
+
+    // Multi-factures : si c'est la dernière restante à enregistrer, demande
+    // une confirmation explicite avant le save final.
+    if (extractedFactures && extractedFactures.length > 1) {
+      const seraToutSave =
+        savedFactureIdxs.size + (savedFactureIdxs.has(currentFactureIdx) ? 0 : 1) >= extractedFactures.length
+      if (seraToutSave) {
+        const total = extractedFactures.length
+        const ok = window.confirm(
+          `Vous êtes sur le point d'enregistrer la dernière facture restante.\n\n` +
+          `Au total, ${total} facture${total > 1 ? 's' : ''} auront été enregistrées depuis ce PDF.\n\n` +
+          `Confirmer ?`
+        )
+        if (!ok) return
+      }
+    }
+
     setStep('saving')
 
     try {
@@ -480,13 +601,43 @@ export default function AchatsImportPage() {
       if (result.file_uploaded === false) {
         window.alert('Facture enregistrée, mais le fichier source n\'a pas pu être stocké. Vous pourrez la consulter sans aperçu PDF/image.')
       }
+
+      // Mode multi-factures : on marque la courante comme enregistrée et on
+      // cherche la prochaine non-enregistrée pour la charger automatiquement.
+      // S'il n'y en a plus → redirect vers la liste des achats comme avant.
+      if (extractedFactures && extractedFactures.length > 1) {
+        const newSaved = new Set(savedFactureIdxs)
+        newSaved.add(currentFactureIdx)
+        setSavedFactureIdxs(newSaved)
+
+        // Mémorise le numéro de la facture qu'on vient d'enregistrer pour le
+        // flash de succès qui s'affichera sur la facture suivante.
+        const savedNumero = extractedFactures[currentFactureIdx]?.numero_facture || `Facture ${currentFactureIdx + 1}`
+
+        // Cherche la prochaine facture non-save (cyclique : on commence à idx+1)
+        let nextIdx = null
+        for (let i = 1; i <= extractedFactures.length; i++) {
+          const candidate = (currentFactureIdx + i) % extractedFactures.length
+          if (!newSaved.has(candidate)) { nextIdx = candidate; break }
+        }
+
+        if (nextIdx != null) {
+          setCurrentFactureIdx(nextIdx)
+          loadFactureIntoState(extractedFactures[nextIdx])
+          await checkDuplicate(extractedFactures[nextIdx].numero_facture)
+          setLastSavedFlash(`✓ ${savedNumero} enregistrée — ${newSaved.size} / ${extractedFactures.length} factures sauvegardées`)
+          setStep('review')
+          return
+        }
+      }
+
       router.push('/controle-gestion/achats')
     } catch (err) {
       console.error('handleSave error:', err)
       setError(err.message || 'Erreur lors de l\'enregistrement.')
       setStep('review')
     }
-  }, [clientId, fournisseur, numeroFacture, dateFacture, statut, lignes, fileBase64, fileMime, autoCreateMissing, router, tauxTva, montantTvaSaisi])
+  }, [clientId, fournisseur, numeroFacture, dateFacture, statut, lignes, fileBase64, fileMime, autoCreateMissing, router, tauxTva, montantTvaSaisi, extractedFactures, currentFactureIdx, savedFactureIdxs, loadFactureIntoState, checkDuplicate, duplicateWarning])
 
   // ─── Styles partagés ─────────────────────────────────────────────────────
 
@@ -603,16 +754,38 @@ export default function AchatsImportPage() {
                 Importée le {new Date(duplicateWarning.created_at).toLocaleDateString('fr-FR')}
               </span>
             </div>
-            <div style={{ display: 'flex', gap: 8 }}>
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
               <button
                 onClick={() => setDuplicateWarning(null)}
                 style={{ padding: '6px 14px', borderRadius: 6, border: '1px solid #D97706', background: 'transparent', color: '#92400E', cursor: 'pointer', fontSize: 13 }}
               >
                 Annuler
               </button>
+              {/* En multi-factures : permet de sauter cette facture pour passer à la suivante non-save */}
+              {extractedFactures && extractedFactures.length > 1 && (
+                <button
+                  onClick={() => {
+                    // Cherche la prochaine facture non-save (peu importe l'ordre)
+                    let nextIdx = null
+                    for (let i = 1; i <= extractedFactures.length; i++) {
+                      const candidate = (currentFactureIdx + i) % extractedFactures.length
+                      if (!savedFactureIdxs.has(candidate) && candidate !== currentFactureIdx) {
+                        nextIdx = candidate
+                        break
+                      }
+                    }
+                    if (nextIdx != null) goToFacture(nextIdx)
+                    else setDuplicateWarning(null)
+                  }}
+                  style={{ padding: '6px 14px', borderRadius: 6, border: '1px solid #D97706', background: c.blanc, color: '#92400E', cursor: 'pointer', fontSize: 13, fontWeight: 600 }}
+                >
+                  ⏭ Passer cette facture
+                </button>
+              )}
               <button
                 onClick={() => handleSave(true)}
                 style={{ padding: '6px 14px', borderRadius: 6, border: 'none', background: '#D97706', color: '#fff', cursor: 'pointer', fontSize: 13, fontWeight: 600 }}
+                title="Tentera de forcer l'import. Échouera si une facture avec le même numéro existe déjà en base."
               >
                 Importer quand même
               </button>
@@ -759,6 +932,69 @@ export default function AchatsImportPage() {
               {extractError && (
                 <div style={{ background: c.orangeClair, border: `1px solid ${c.orange}`, borderRadius: 8, padding: '10px 14px', fontSize: 13, color: '#92400E' }}>
                   ⚠️ Extraction IA échouée ({extractError}). Saisissez les lignes manuellement.
+                </div>
+              )}
+
+              {/* Multi-factures : sélecteur de facture courante */}
+              {extractedFactures && extractedFactures.length > 1 && (
+                <div style={{ background: c.accentClair || c.fond, border: `1px solid ${c.accent}`, borderRadius: 10, padding: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
+                    <div style={{ fontSize: 14, fontWeight: 600, color: c.texte }}>
+                      📑 {extractedFactures.length} factures détectées dans le PDF
+                    </div>
+                    <div style={{ fontSize: 12, color: c.texteMuted }}>
+                      {savedFactureIdxs.size} / {extractedFactures.length} enregistrée{savedFactureIdxs.size > 1 ? 's' : ''}
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                    <button
+                      onClick={() => goToFacture(currentFactureIdx - 1)}
+                      disabled={currentFactureIdx === 0 || step === 'saving'}
+                      style={{ ...btnSecondary, padding: '6px 12px', width: 'auto', opacity: currentFactureIdx === 0 ? 0.4 : 1 }}
+                    >
+                      ← Précédente
+                    </button>
+                    <select
+                      value={currentFactureIdx}
+                      onChange={e => goToFacture(Number(e.target.value))}
+                      disabled={step === 'saving'}
+                      style={{ ...inputS, flex: 1, minWidth: 180 }}
+                    >
+                      {extractedFactures.map((f, idx) => (
+                        <option key={idx} value={idx}>
+                          {savedFactureIdxs.has(idx) ? '✓ ' : ''}
+                          Facture {idx + 1}/{extractedFactures.length}
+                          {f.numero_facture ? ` — ${f.numero_facture}` : ' — (sans numéro)'}
+                          {f.statut === 'avoir' ? ' · Avoir' : ''}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      onClick={() => goToFacture(currentFactureIdx + 1)}
+                      disabled={currentFactureIdx === extractedFactures.length - 1 || step === 'saving'}
+                      style={{ ...btnSecondary, padding: '6px 12px', width: 'auto', opacity: currentFactureIdx === extractedFactures.length - 1 ? 0.4 : 1 }}
+                    >
+                      Suivante →
+                    </button>
+                  </div>
+                  {savedFactureIdxs.has(currentFactureIdx) && (
+                    <div style={{ fontSize: 12, color: c.vert, fontWeight: 600 }}>
+                      ✓ Cette facture a déjà été enregistrée. Vous pouvez la modifier et l&apos;enregistrer à nouveau, ou passer à la suivante.
+                    </div>
+                  )}
+                  {!savedFactureIdxs.has(currentFactureIdx)
+                    && savedFactureIdxs.size === extractedFactures.length - 1 && (
+                    <div style={{ fontSize: 12, color: c.accent, fontWeight: 600 }}>
+                      🏁 Dernière facture restante. Après l&apos;enregistrement, vous serez redirigé vers la liste des achats.
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Flash de succès après chaque enregistrement en multi-factures */}
+              {lastSavedFlash && (
+                <div style={{ background: c.vertClair, border: `1px solid ${c.vert}`, borderRadius: 8, padding: '10px 14px', fontSize: 13, color: c.vert, fontWeight: 600 }}>
+                  {lastSavedFlash}
                 </div>
               )}
 
@@ -984,7 +1220,10 @@ export default function AchatsImportPage() {
                                   <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
                                     <span style={badgeVert}>✓ Reconnu</span>
                                     {l.ingredient_nom && <span style={{ fontSize: 10, color: c.texteMuted }}>{l.ingredient_nom}</span>}
-                                    <button onClick={() => { setLinkingIngFor(l._id); setLinkSearch(''); setCreatingIngFor(null) }} style={{ fontSize: 10, padding: '1px 5px', background: 'transparent', border: `1px solid ${c.bordure}`, color: c.texteMuted, borderRadius: 4, cursor: 'pointer', marginTop: 2 }}>Changer</button>
+                                    <div style={{ display: 'flex', gap: 4, marginTop: 2 }}>
+                                      <button onClick={() => { setLinkingIngFor(l._id); setLinkSearch(''); setCreatingIngFor(null) }} style={{ fontSize: 10, padding: '1px 5px', background: 'transparent', border: `1px solid ${c.bordure}`, color: c.texteMuted, borderRadius: 4, cursor: 'pointer' }}>Changer</button>
+                                      <button onClick={() => { setCreatingIngFor(l._id); setNewIngNom(l.designation); setLinkingIngFor(null) }} style={{ fontSize: 10, padding: '1px 5px', background: 'transparent', border: `1px solid ${c.accent}`, color: c.accent, borderRadius: 4, cursor: 'pointer' }} title="Créer un nouvel ingrédient au lieu de relier à un existant">＋ Nouveau</button>
+                                    </div>
                                   </div>
                                 ) : (
                                   <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
@@ -1108,10 +1347,17 @@ export default function AchatsImportPage() {
                               >＋ Créer</button>
                             </div>
                           ) : (
-                            <button
-                              onClick={() => { setLinkingIngFor(l._id); setLinkSearch(''); setCreatingIngFor(null) }}
-                              style={{ fontSize: 11, padding: '3px 8px', background: 'transparent', border: `1px solid ${c.bordure}`, color: c.texteMuted, borderRadius: 6, cursor: 'pointer', marginBottom: 6 }}
-                            >Changer l&rsquo;ingrédient lié</button>
+                            <div style={{ display: 'flex', gap: 6, marginBottom: 6, flexWrap: 'wrap' }}>
+                              <button
+                                onClick={() => { setLinkingIngFor(l._id); setLinkSearch(''); setCreatingIngFor(null) }}
+                                style={{ fontSize: 11, padding: '3px 8px', background: 'transparent', border: `1px solid ${c.bordure}`, color: c.texteMuted, borderRadius: 6, cursor: 'pointer' }}
+                              >Changer l&rsquo;ingrédient lié</button>
+                              <button
+                                onClick={() => { setCreatingIngFor(l._id); setNewIngNom(l.designation); setLinkingIngFor(null) }}
+                                style={{ fontSize: 11, padding: '3px 8px', background: 'transparent', border: `1px solid ${c.accent}`, color: c.accent, borderRadius: 6, cursor: 'pointer' }}
+                                title="Créer un nouvel ingrédient au lieu de relier à un existant"
+                              >＋ Créer un nouveau</button>
+                            </div>
                           )}
                           {/* Ligne 2 : Qté / Unité / Prix / TVA */}
                           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 8, marginBottom: 8 }}>
@@ -1197,7 +1443,13 @@ export default function AchatsImportPage() {
                 disabled={step === 'saving'}
                 onClick={() => handleSave()}
               >
-                {step === 'saving' ? 'Enregistrement…' : '💾 Enregistrer les achats et mettre à jour les prix'}
+                {step === 'saving'
+                  ? 'Enregistrement…'
+                  : extractedFactures && extractedFactures.length > 1
+                    ? savedFactureIdxs.size + (savedFactureIdxs.has(currentFactureIdx) ? 0 : 1) < extractedFactures.length
+                      ? `💾 Enregistrer la facture ${currentFactureIdx + 1}/${extractedFactures.length} et passer à la suivante`
+                      : `🏁 Valider la dernière facture et terminer l'import`
+                    : '💾 Enregistrer les achats et mettre à jour les prix'}
               </button>
             </div>
           </div>

--- a/app/controle-gestion/achats/page.js
+++ b/app/controle-gestion/achats/page.js
@@ -20,6 +20,31 @@ function formatDate(s) {
   return new Date(s).toLocaleDateString('fr-FR')
 }
 
+// Cellule d'en-tête cliquable pour trier sur la colonne `col`. Affiche un
+// indicateur visuel (▲ asc, ▼ desc, ↕ inactif) à droite du libellé.
+function SortHeader({ col, label, baseStyle, sortBy, sortDir, onSort, c, right = false }) {
+  const active = sortBy === col
+  return (
+    <th
+      onClick={() => onSort(col)}
+      style={{
+        ...baseStyle,
+        cursor: 'pointer',
+        userSelect: 'none',
+        color: active ? c.texte : baseStyle.color,
+      }}
+      title={`Trier par ${label.toLowerCase()}`}
+    >
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, justifyContent: right ? 'flex-end' : 'flex-start', width: '100%' }}>
+        {label}
+        <span style={{ fontSize: 9, opacity: active ? 1 : 0.35 }}>
+          {active ? (sortDir === 'asc' ? '▲' : '▼') : '↕'}
+        </span>
+      </span>
+    </th>
+  )
+}
+
 
 export default function AchatsListPage() {
   const router = useRouter()
@@ -40,6 +65,10 @@ export default function AchatsListPage() {
   const [statutsActifs, setStatutsActifs] = useState(['bl', 'facture', 'avoir'])
   const [deleting, setDeleting] = useState(null)
   const [exporting, setExporting] = useState(false)
+  // Tri : colonne active + sens. Par défaut : date décroissante (= comportement
+  // du .order() côté query Supabase).
+  const [sortBy, setSortBy] = useState('date_facture')
+  const [sortDir, setSortDir] = useState('desc')
 
   useEffect(() => {
     let cancelled = false
@@ -233,8 +262,59 @@ export default function AchatsListPage() {
     setStatutsActifs((prev) => prev.includes(k) ? prev.filter(x => x !== k) : [...prev, k])
   }
 
-  const totalHT = facturesFiltrees.reduce((s, f) => s + (Number(f.total_ht) || 0), 0)
-  const totalTVA = facturesFiltrees.reduce((s, f) => s + (tvaByFacture[f.id] || 0), 0)
+  // Sens par défaut pour chaque colonne (asc pour les textes, desc pour les
+  // dates et montants, où on veut voir le plus récent / le plus gros en premier).
+  const DEFAULT_SORT_DIR = {
+    fournisseur: 'asc',
+    numero_facture: 'asc',
+    date_facture: 'desc',
+    statut: 'asc',
+    articles: 'desc',
+    ht: 'desc',
+    tva: 'desc',
+    ttc: 'desc',
+  }
+
+  const handleSort = (col) => {
+    if (sortBy === col) {
+      setSortDir(d => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortBy(col)
+      setSortDir(DEFAULT_SORT_DIR[col] || 'asc')
+    }
+  }
+
+  // Pas de useMemo / useCallback ici : on est placés après un early return
+  // conditionnel (auth), les hooks ne peuvent pas être appelés. Le tri reste
+  // peu coûteux à recalculer à chaque render (~quelques dizaines de factures).
+  const getSortValue = (f, col) => {
+    switch (col) {
+      case 'fournisseur':    return (f.fournisseur || '').toLowerCase()
+      case 'numero_facture': return (f.numero_facture || '').toLowerCase()
+      case 'date_facture':   return f.date_facture || ''
+      case 'statut':         return f.statut || 'facture'
+      case 'articles':       return nbLignesByFacture[f.id] ?? 0
+      case 'ht':             return Number(f.total_ht) || 0
+      case 'tva':            return tvaByFacture[f.id] || 0
+      case 'ttc':            return (Number(f.total_ht) || 0) + (tvaByFacture[f.id] || 0)
+      default:               return ''
+    }
+  }
+
+  const facturesAffichees = [...facturesFiltrees].sort((a, b) => {
+    const va = getSortValue(a, sortBy)
+    const vb = getSortValue(b, sortBy)
+    let cmp
+    if (typeof va === 'number' && typeof vb === 'number') {
+      cmp = va - vb
+    } else {
+      cmp = String(va).localeCompare(String(vb), 'fr', { numeric: true, sensitivity: 'base' })
+    }
+    return sortDir === 'asc' ? cmp : -cmp
+  })
+
+  const totalHT = facturesAffichees.reduce((s, f) => s + (Number(f.total_ht) || 0), 0)
+  const totalTVA = facturesAffichees.reduce((s, f) => s + (tvaByFacture[f.id] || 0), 0)
   const totalTTC = totalHT + totalTVA
 
   const th = {
@@ -425,7 +505,30 @@ export default function AchatsListPage() {
             ) : isMobile ? (
               /* ── Vue cartes mobile ── */
               <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-                {facturesFiltrees.map((f) => {
+                {/* Sélecteur de tri (équivalent mobile des en-têtes cliquables desktop) */}
+                <div style={{ display: 'flex', gap: 6, alignItems: 'center', fontSize: 12, color: c.texteMuted }}>
+                  <span>Trier par</span>
+                  <select
+                    value={sortBy}
+                    onChange={e => { setSortBy(e.target.value); setSortDir(DEFAULT_SORT_DIR[e.target.value] || 'asc') }}
+                    style={{ padding: '6px 8px', borderRadius: 6, border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte, fontSize: 12 }}
+                  >
+                    <option value="fournisseur">Fournisseur</option>
+                    <option value="numero_facture">N° de facture</option>
+                    <option value="date_facture">Date</option>
+                    <option value="statut">Statut</option>
+                    <option value="ht">Montant HT</option>
+                    <option value="ttc">Montant TTC</option>
+                  </select>
+                  <button
+                    onClick={() => setSortDir(d => d === 'asc' ? 'desc' : 'asc')}
+                    title={sortDir === 'asc' ? 'Croissant (A→Z, 0→9)' : 'Décroissant (Z→A, 9→0)'}
+                    style={{ padding: '6px 10px', borderRadius: 6, border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte, fontSize: 12, cursor: 'pointer' }}
+                  >
+                    {sortDir === 'asc' ? '▲ A-Z' : '▼ Z-A'}
+                  </button>
+                </div>
+                {facturesAffichees.map((f) => {
                   const ht = Number(f.total_ht) || 0
                   const tva = tvaByFacture[f.id] || 0
                   const ttc = ht + tva
@@ -489,19 +592,19 @@ export default function AchatsListPage() {
                   <table style={{ width: '100%', borderCollapse: 'collapse' }}>
                     <thead>
                       <tr style={{ background: c.fond }}>
-                        <th style={th}>Fournisseur</th>
-                        <th style={th}>N° Facture</th>
-                        <th style={th}>Date</th>
-                        <th style={th}>Statut</th>
-                        <th style={thR}>Articles</th>
-                        <th style={thR}>HT</th>
-                        <th style={thR}>TVA</th>
-                        <th style={thR}>TTC</th>
+                        <SortHeader col="fournisseur"    label="Fournisseur" baseStyle={th}  sortBy={sortBy} sortDir={sortDir} onSort={handleSort} c={c} />
+                        <SortHeader col="numero_facture" label="N° Facture"  baseStyle={th}  sortBy={sortBy} sortDir={sortDir} onSort={handleSort} c={c} />
+                        <SortHeader col="date_facture"   label="Date"        baseStyle={th}  sortBy={sortBy} sortDir={sortDir} onSort={handleSort} c={c} />
+                        <SortHeader col="statut"         label="Statut"      baseStyle={th}  sortBy={sortBy} sortDir={sortDir} onSort={handleSort} c={c} />
+                        <SortHeader col="articles"       label="Articles"    baseStyle={thR} sortBy={sortBy} sortDir={sortDir} onSort={handleSort} c={c} right />
+                        <SortHeader col="ht"             label="HT"          baseStyle={thR} sortBy={sortBy} sortDir={sortDir} onSort={handleSort} c={c} right />
+                        <SortHeader col="tva"            label="TVA"         baseStyle={thR} sortBy={sortBy} sortDir={sortDir} onSort={handleSort} c={c} right />
+                        <SortHeader col="ttc"            label="TTC"         baseStyle={thR} sortBy={sortBy} sortDir={sortDir} onSort={handleSort} c={c} right />
                         {role === 'admin' && <th style={th} />}
                       </tr>
                     </thead>
                     <tbody>
-                      {facturesFiltrees.map((f, i) => {
+                      {facturesAffichees.map((f, i) => {
                         const ht = Number(f.total_ht) || 0
                         const tva = tvaByFacture[f.id] || 0
                         const ttc = ht + tva

--- a/lib/services/achats.service.ts
+++ b/lib/services/achats.service.ts
@@ -206,7 +206,17 @@ export async function saveFacture(
     .select()
     .single()
 
-  if (fErr) throw new Error(fErr.message)
+  if (fErr) {
+    // La DB a une contrainte UNIQUE (client_id, numero_facture) qui rejette
+    // même les inserts forceInsert. On remonte un message clair plutôt qu'un
+    // 500 opaque pour que l'UI puisse aiguiller l'utilisateur.
+    if (fErr.code === '23505' || /duplicate key/i.test(fErr.message)) {
+      throw new ConflictError(
+        `Une facture avec le numéro "${numeroFacture}" existe déjà en base pour ce client. Modifiez le numéro de facture ou supprimez l'ancienne avant de réimporter.`
+      )
+    }
+    throw new Error(fErr.message)
+  }
 
   // 5. Insert lines
   const lignesInsert = lignes.map((l) => {


### PR DESCRIPTION
## Summary

- **OCR multi-factures** : un PDF contenant plusieurs factures à la suite (cas Vergers Saint Eustache / Rungis) est désormais splitté automatiquement par Claude — détection des entêtes `FACTURE N°` / `FACTURE D'AVOIR` avec numéros distincts. L'API `parse-facture` retourne toujours `{ factures: [...] }` (array).
- **Navigation entre factures** dans l'écran d'import : sélecteur "Facture X/N", compteur "X/N enregistrées", boutons Précédente / Suivante, sauvegarde séquentielle. State d'édition snapshoté avant chaque navigation. Flash vert après save. Confirmation finale avant la dernière.
- **Bouton "⏭ Passer cette facture"** dans le bandeau de doublon en mode multi-factures (évite de bloquer l'import des autres si une facture existe déjà en base).
- **Bouton "＋ Nouveau"** pour créer un ingrédient même quand l'OCR en a déjà reconnu un (parfois à tort, ex: "Tomate concassée" → "Tomate").
- **Tri des colonnes** sur `/controle-gestion/achats` : Fournisseur, N° Facture, Date, Statut, Articles, HT, TVA, TTC cliquables avec indicateur ▲▼. Sélecteur de tri équivalent sur mobile.
- **Message d'erreur clair** quand la contrainte SQL unique `(client_id, numero_facture)` rejette un "Importer quand même" — avant on voyait juste "Erreur serveur interne".

## Test plan

- [ ] Déposer un PDF avec plusieurs factures distinctes → vérifier le compteur "N factures détectées"
- [ ] Vérifier qu'une facture étalée sur 2 pages (même numéro) reste fusionnée
- [ ] Vérifier qu'un avoir ressort avec `statut: avoir` et montant positif côté UI
- [ ] Naviguer entre factures via Précédente/Suivante/select → modifs préservées
- [ ] Enregistrer séquentiellement → flash vert + confirm() sur la dernière → redirect vers `/controle-gestion/achats`
- [ ] Si une facture est déjà en base : bandeau jaune + bouton "Passer cette facture" → skip propre
- [ ] Sur une ligne avec un ingrédient reconnu : bouton "＋ Nouveau" disponible
- [ ] Sur `/controle-gestion/achats` : clic sur les en-têtes → tri ascendant/descendant fonctionne pour toutes les colonnes
- [ ] Mobile : sélecteur de tri "Trier par [colonne] [▲ A-Z]" fonctionne

🤖 Generated with [Claude Code](https://claude.com/claude-code)