### PR TITLE
fix(analyses): respecte les overrides nb_jours (fermetures) dans le calcul budget

### DIFF
--- a/app/controle-gestion/analyses/page.js
+++ b/app/controle-gestion/analyses/page.js
@@ -103,6 +103,9 @@ export default function AnalysesPage() {
   // budgetByYear : { 2026: rows, 2025: rows } pour gérer périodes à cheval.
   const [budgetByYear, setBudgetByYear] = useState({})
   const [budgetByYearCompare, setBudgetByYearCompare] = useState({})
+  // Overrides nb_jours (fermetures exceptionnelles) configurés sur /budgets.
+  // Stockés en Map<`${annee}_${mois}_${jds}`, nb_jours> pour lookup O(1).
+  const [overridesNbJours, setOverridesNbJours] = useState(new Map())
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
@@ -217,23 +220,42 @@ export default function AnalysesPage() {
             .in('annee', compareYears)
         : Promise.resolve({ data: [], error: null })
 
-      const [caRes, compareCaRes, budgetRes, compareBudgetRes] = await Promise.all([
-        caQuery, compareCaQuery, budgetQuery, compareBudgetQuery,
+      // Overrides nb_jours (fermetures exceptionnelles) sur toutes les années
+      // couvertes par la plage et la comparaison. Une seule query suffit, le
+      // volume est petit (≤ 84 lignes/an = 12 mois × 7 jours).
+      const overridesYears = Array.from(new Set([...years, ...compareYears]))
+      const overridesQuery = overridesYears.length > 0
+        ? supabase
+            .from('ca_budget_jours_override')
+            .select('annee, mois, jour_semaine, nb_jours')
+            .eq('client_id', clientId)
+            .in('annee', overridesYears)
+        : Promise.resolve({ data: [], error: null })
+
+      const [caRes, compareCaRes, budgetRes, compareBudgetRes, overridesRes] = await Promise.all([
+        caQuery, compareCaQuery, budgetQuery, compareBudgetQuery, overridesQuery,
       ])
       if (caRes.error) throw caRes.error
       if (compareCaRes.error) throw compareCaRes.error
       if (budgetRes.error) throw budgetRes.error
       if (compareBudgetRes.error) throw compareBudgetRes.error
+      if (overridesRes.error) throw overridesRes.error
 
       const groupByYear = (rows) => rows.reduce((acc, r) => {
         ;(acc[r.annee] ||= []).push(r)
         return acc
       }, {})
 
+      const overridesMap = new Map()
+      for (const o of overridesRes.data || []) {
+        overridesMap.set(`${o.annee}_${o.mois}_${o.jour_semaine}`, Number(o.nb_jours))
+      }
+
       setRawCa(caRes.data || [])
       setRawCaCompare(compareCaRes.data || [])
       setBudgetByYear(groupByYear(budgetRes.data || []))
       setBudgetByYearCompare(groupByYear(compareBudgetRes.data || []))
+      setOverridesNbJours(overridesMap)
     } catch (e) {
       setError(e.message || 'Erreur de chargement')
     } finally {
@@ -390,8 +412,8 @@ export default function AnalysesPage() {
   }, [filteredRows, dateDebut, dateFin, filterJoursActive, joursSet])
 
   const periodBudget = useMemo(
-    () => periodBudgetTotal(filteredBudgetByYear, dateDebut, dateFin, filterJoursActive ? joursSet : null),
-    [filteredBudgetByYear, dateDebut, dateFin, filterJoursActive, joursSet]
+    () => periodBudgetTotal(filteredBudgetByYear, dateDebut, dateFin, filterJoursActive ? joursSet : null, overridesNbJours),
+    [filteredBudgetByYear, dateDebut, dateFin, filterJoursActive, joursSet, overridesNbJours]
   )
 
   const compareBudgetRange = useMemo(
@@ -401,8 +423,8 @@ export default function AnalysesPage() {
 
   const periodBudgetCompare = useMemo(() => {
     if (!compareBudgetRange) return 0
-    return periodBudgetTotal(filteredCompareBudgetByYear, compareBudgetRange.debut, compareBudgetRange.fin, filterJoursActive ? joursSet : null)
-  }, [filteredCompareBudgetByYear, compareBudgetRange, filterJoursActive, joursSet])
+    return periodBudgetTotal(filteredCompareBudgetByYear, compareBudgetRange.debut, compareBudgetRange.fin, filterJoursActive ? joursSet : null, overridesNbJours)
+  }, [filteredCompareBudgetByYear, compareBudgetRange, filterJoursActive, joursSet, overridesNbJours])
 
   // ── Comparison props injectés dans les KPIs ──────────────────────────────
   // - 'aucune' → pas de comparaison
@@ -428,10 +450,10 @@ export default function AnalysesPage() {
   // passer joursSet ici : on est déjà filtré au niveau de `days`.
   const daysWithBudget = useMemo(() => {
     return days.map((d) => {
-      const budget = periodBudgetTotal(filteredBudgetByYear, d.iso, d.iso)
+      const budget = periodBudgetTotal(filteredBudgetByYear, d.iso, d.iso, null, overridesNbJours)
       return { ...d, budget }
     })
-  }, [days, filteredBudgetByYear])
+  }, [days, filteredBudgetByYear, overridesNbJours])
 
   const tableauTotals = useMemo(() => {
     let lunchCouverts = 0, dinnerCouverts = 0, budget = 0

--- a/lib/__tests__/caAnalyses.test.ts
+++ b/lib/__tests__/caAnalyses.test.ts
@@ -178,6 +178,43 @@ describe('periodBudgetTotal', () => {
     const total = periodBudgetTotal({ 2026: rows }, '2026-05-04', '2026-05-05', new Set([1]))
     expect(total).toBe(100)
   })
+
+  it('applique le ratio override nb_jours sur le mois entier', () => {
+    // Mai 2026 contient 4 lundis (4, 11, 18, 25). Override dit "3 lundis"
+    // (ex : un lundi férié). Budget lundi = 100. Sans override : 4 × 100 = 400.
+    // Avec override : 3 × 100 = 300 (ratio 3/4 appliqué aux 4 lundis comptés).
+    const rows = [
+      { jour_semaine: 1, lieu_service_id: 'L1', service: 'lunch', mois: null, ca_food_cible: 100, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+    ]
+    const overrides = new Map([['2026_5_1', 3]])
+    const total = periodBudgetTotal({ 2026: rows }, '2026-05-01', '2026-05-31', null, overrides)
+    expect(total).toBe(300)
+  })
+
+  it('ratio override scale proportionnellement quand la plage ne couvre qu\'une partie du mois', () => {
+    // Plage 2026-05-01 → 2026-05-15 : couvre 2 lundis (4, 11) sur 4 du mois.
+    // Override dit "3 lundis sur le mois" → ratio 3/4 = 0.75.
+    // Résultat attendu : 2 × 100 × 0.75 = 150.
+    const rows = [
+      { jour_semaine: 1, lieu_service_id: 'L1', service: 'lunch', mois: null, ca_food_cible: 100, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+    ]
+    const overrides = new Map([['2026_5_1', 3]])
+    const total = periodBudgetTotal({ 2026: rows }, '2026-05-01', '2026-05-15', null, overrides)
+    expect(total).toBe(150)
+  })
+
+  it('aucun override fourni → comportement identique à l\'ancien', () => {
+    // Mai 2026 : 4 lundis × 100 = 400.
+    const rows = [
+      { jour_semaine: 1, lieu_service_id: 'L1', service: 'lunch', mois: null, ca_food_cible: 100, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+    ]
+    const sansArg = periodBudgetTotal({ 2026: rows }, '2026-05-01', '2026-05-31')
+    const avecArgNull = periodBudgetTotal({ 2026: rows }, '2026-05-01', '2026-05-31', null, null)
+    const avecMapVide = periodBudgetTotal({ 2026: rows }, '2026-05-01', '2026-05-31', null, new Map())
+    expect(sansArg).toBe(400)
+    expect(avecArgNull).toBe(400)
+    expect(avecMapVide).toBe(400)
+  })
 })
 
 describe('pickGranularity', () => {

--- a/lib/caAnalyses.js
+++ b/lib/caAnalyses.js
@@ -467,11 +467,32 @@ export function budgetByIsoJdsForMonth(budgetRows, monthNum) {
   return out
 }
 
+// Compte le nombre d'occurrences naturel d'un jour-de-semaine (isoJds 1..7)
+// dans un mois calendaire entier. Utilisé pour calculer le ratio d'override.
+export function countIsoJdsInMonth(annee, mois, isoJds) {
+  const daysInMonth = new Date(annee, mois, 0).getDate() // dernier jour
+  let count = 0
+  for (let d = 1; d <= daysInMonth; d++) {
+    const dow = new Date(annee, mois - 1, d).getDay() // 0=dim..6=sam
+    const iso = dow === 0 ? 7 : dow
+    if (iso === isoJds) count++
+  }
+  return count
+}
+
 // Somme des budgets journaliers sur la période [debut, fin].
 // budgetRowsByYear : map { [annee]: rows[] } pour gérer les périodes
 // chevauchant deux années (ex: décembre → janvier).
 // `isoJdsFilter` (optionnel) : Set<number 1..7> — ne sommer que ces jours-de-semaine.
-export function periodBudgetTotal(budgetRowsByYear, debut, fin, isoJdsFilter = null) {
+// `overridesByYearMonth` (optionnel) : Map<`${annee}_${mois}_${jds}`, nb_jours>
+//   pour appliquer les fermetures exceptionnelles configurées dans /budgets.
+//   Si fourni, scale le budget de chaque (mois, jds) par
+//   (override_nb_jours / nb_jours_naturel_du_mois). Quand la plage ne couvre
+//   pas le mois entier, le ratio s'applique proportionnellement au nombre de
+//   jours du jds présents dans la plage (approximation : on ignore quelle
+//   occurrence précise est fermée — pour ça il faudrait un calendrier de
+//   fermetures à la date, chantier séparé).
+export function periodBudgetTotal(budgetRowsByYear, debut, fin, isoJdsFilter = null, overridesByYearMonth = null) {
   // Cache du Map par (annee, mois) pour éviter de recalculer à chaque jour
   const cache = new Map()
   const getMap = (annee, mois) => {
@@ -481,6 +502,21 @@ export function periodBudgetTotal(budgetRowsByYear, debut, fin, isoJdsFilter = n
     }
     return cache.get(key)
   }
+
+  // Cache du ratio override par (annee, mois, jds). 1 si pas d'override.
+  const ratioCache = new Map()
+  const getRatio = (annee, mois, jds) => {
+    if (!overridesByYearMonth) return 1
+    const key = `${annee}_${mois}_${jds}`
+    if (ratioCache.has(key)) return ratioCache.get(key)
+    const override = overridesByYearMonth.get(key)
+    if (override == null) { ratioCache.set(key, 1); return 1 }
+    const naturel = countIsoJdsInMonth(annee, mois, jds)
+    const r = naturel > 0 ? override / naturel : 1
+    ratioCache.set(key, r)
+    return r
+  }
+
   let total = 0
   for (const d of eachDayIso(debut, fin)) {
     if (isoJdsFilter && !isoJdsFilter.has(d.isoJds)) continue
@@ -488,7 +524,8 @@ export function periodBudgetTotal(budgetRowsByYear, debut, fin, isoJdsFilter = n
     const annee = date.getFullYear()
     const mois = date.getMonth() + 1
     const map = getMap(annee, mois)
-    total += map.get(d.isoJds) || 0
+    const budgetParJour = map.get(d.isoJds) || 0
+    total += budgetParJour * getRatio(annee, mois, d.isoJds)
   }
   return total
 }


### PR DESCRIPTION
## Summary

**Bug** : sur `/controle-gestion/analyses`, le budget projeté sur une plage était calculé en itérant sur **chaque jour calendaire** de la période, en ignorant les **fermetures exceptionnelles** configurées dans `/controle-gestion/ventes/budgets` (table `ca_budget_jours_override`).

**Conséquence concrète** : sur Marsan, budget annuel ~5,6 M€ configuré (avec ses fermetures), mais `/analyses` affichait **3,1 M€ sur 01/01 → 14/05** (au lieu de ~2 M€ attendu au prorata avec fermetures). L'écart vs budget paraissait catastrophique alors qu'il était mécanique.

C'était documenté comme un "chantier séparé" dans la migration `20260510000001` mais on est en train de buter dessus.

## Fix

- `periodBudgetTotal` accepte un nouveau param optionnel `overridesByYearMonth` (Map). Rétrocompatible : 5e arg, défaut `null` = ancien comportement.
- Pour chaque `(mois, jour-de-semaine)`, applique le ratio `override / nb_naturel_du_mois` au budget de chaque jour de cette catégorie présent dans la plage.
- Quand la plage couvre **tout** le mois → le ratio donne exactement le nb_jours overrided.
- Quand la plage ne couvre qu'**une partie** du mois → le ratio s'applique proportionnellement (approximation, puisqu'on n'a pas le calendrier précis des fermetures à la date).
- `/analyses` charge maintenant `ca_budget_jours_override` en parallèle des autres queries et le passe aux 3 appels existants (KPI budget, comparaison, tableau jour-jour).

## Tests

3 nouveaux cas dans `lib/__tests__/caAnalyses.test.ts` :
- ratio override sur un mois entier (4 lundis → 3)
- ratio scalé sur une plage partielle
- absence d'override = comportement strictement identique à avant

→ **45/45 tests passent**.

## Test plan UX

- [ ] `/analyses` sur Marsan, période "01/01 → 14/05" : le budget affiché doit baisser (et donc l'écart vs budget devient plus réaliste, plus proche de zéro)
- [ ] Le widget "budget annuel" total sur la même période doit maintenant être cohérent avec ce qu'affiche `/controle-gestion/ventes/budgets`
- [ ] Pour un client sans aucun override configuré : aucun changement de comportement (vérifié par test)
- [ ] Filtre "uniquement Dimanche" : si tu as overridé des dimanches fermés, le budget des dimanches doit aussi être réduit en conséquence

🤖 Generated with [Claude Code](https://claude.com/claude-code)