### PR TITLE
feat(analyses): Δ Budget par cellule en mode split + affichage sans budget

### DIFF
--- a/app/controle-gestion/analyses/page.js
+++ b/app/controle-gestion/analyses/page.js
@@ -632,7 +632,7 @@ export default function AnalysesPage() {
       case 'section-top-bottom-jours':
         return <SectionTopBottomJours c={c} isMobile={isMobile} topBottom={topBottom} />
       case 'section-tableau-jour-jour':
-        return <SectionTableauJourJour c={c} isMobile={isMobile} days={daysWithBudget} totals={tableauTotals} isSplit={isSplit} splitByLieu={splitByLieu} splitByService={splitByService} filteredRows={filteredRows} lieuxLabels={lieuxLabels} />
+        return <SectionTableauJourJour c={c} isMobile={isMobile} days={daysWithBudget} totals={tableauTotals} isSplit={isSplit} splitByLieu={splitByLieu} splitByService={splitByService} filteredRows={filteredRows} lieuxLabels={lieuxLabels} filteredBudgetByYear={filteredBudgetByYear} overridesNbJours={overridesNbJours} />
       case 'kpi-food-cost-moyen':
         return (
           <KpiFoodCostMoyen

--- a/components/analyses/widgets/SectionTableauJourJour.js
+++ b/components/analyses/widgets/SectionTableauJourJour.js
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { useMemo } from 'react'
 import {
   formatEur, formatEur2, formatDeltaEur,
+  dailyBudgetForCell,
   rowsByDayAndSerie,
 } from '../../../lib/caAnalyses'
 
@@ -10,12 +11,12 @@ const JOURS_FR = ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi',
 // Tableau dense jour par jour pour la période sélectionnée. Deux modes :
 //   - cumulé (isSplit=false) : 1 ligne par jour avec couv midi/soir
 //   - split (isSplit=true) : 1 ligne par (jour × série) avec colonnes Lieu
-//     et/ou Service ajoutées en tête. Le Δ Budget reste calculé au niveau
-//     du jour entier (le budget par lieu × service serait techniquement
-//     possible mais sortirait du scope PR 6).
+//     et/ou Service ajoutées en tête. Le Δ Budget est calculé par cellule
+//     (jour × lieu × service) en respectant les overrides nb_jours.
 export default function SectionTableauJourJour({
   c, isMobile, days, totals,
   isSplit, splitByLieu, splitByService, filteredRows, lieuxLabels,
+  filteredBudgetByYear, overridesNbJours,
 }) {
   if (isSplit) {
     return (
@@ -23,6 +24,8 @@ export default function SectionTableauJourJour({
         c={c} isMobile={isMobile}
         filteredRows={filteredRows} lieuxLabels={lieuxLabels}
         splitByLieu={splitByLieu} splitByService={splitByService}
+        filteredBudgetByYear={filteredBudgetByYear}
+        overridesNbJours={overridesNbJours}
       />
     )
   }
@@ -122,7 +125,10 @@ function CumulatedTable({ c, isMobile, days, totals }) {
 
 // ── Vue split : 1 ligne par (jour × série) ──────────────────────────────────
 
-function SplitTable({ c, isMobile, filteredRows, lieuxLabels, splitByLieu, splitByService }) {
+function SplitTable({
+  c, isMobile, filteredRows, lieuxLabels, splitByLieu, splitByService,
+  filteredBudgetByYear, overridesNbJours,
+}) {
   const splitDims = []
   if (splitByLieu) splitDims.push('lieu')
   if (splitByService) splitDims.push('service')
@@ -138,10 +144,16 @@ function SplitTable({ c, isMobile, filteredRows, lieuxLabels, splitByLieu, split
       if (splitByLieu) parts.push(lieuLabel)
       if (splitByService) parts.push(serviceLabel)
       const serieKey = parts.join(' / ')
-      const key = `${r.jour}__${serieKey}`
+      // Clé d'agrégation : (jour, lieu, service) quand split = lieu + service.
+      // Si seulement split par lieu, agrège les 2 services. Idem inversement.
+      const lieuKey = splitByLieu ? r.lieu_service_id : 'ALL'
+      const svcKey = splitByService ? r.service : 'ALL'
+      const key = `${r.jour}__${lieuKey}__${svcKey}`
       if (!map.has(key)) {
         map.set(key, {
           iso: r.jour, lieu: lieuLabel, service: serviceLabel, serie: serieKey,
+          lieu_service_id: splitByLieu ? r.lieu_service_id : null,
+          service_key: splitByService ? r.service : null,
           couverts: 0, food: 0, bev_20: 0, bev_10: 0, autre: 0,
         })
       }
@@ -157,19 +169,24 @@ function SplitTable({ c, isMobile, filteredRows, lieuxLabels, splitByLieu, split
         const caTot = v.food + v.bev_20 + v.bev_10 + v.autre
         const tm = v.couverts > 0 ? caTot / v.couverts : null
         const date = new Date(`${v.iso}T00:00:00`)
-        return { ...v, caTot, tm, jsWeekday: date.getDay() }
+        // Budget cible pour cette cellule (jour × [lieu] × [service])
+        const budget = filteredBudgetByYear
+          ? dailyBudgetForCell(filteredBudgetByYear, v.iso, v.lieu_service_id, v.service_key, overridesNbJours)
+          : 0
+        return { ...v, caTot, tm, budget, jsWeekday: date.getDay() }
       })
       .sort((a, b) => a.iso !== b.iso ? a.iso.localeCompare(b.iso) : a.serie.localeCompare(b.serie, 'fr'))
-  }, [filteredRows, lieuxLabels, splitByLieu, splitByService])
+  }, [filteredRows, lieuxLabels, splitByLieu, splitByService, filteredBudgetByYear, overridesNbJours])
 
   const totals = useMemo(() => {
-    const t = { couverts: 0, food: 0, bev_20: 0, bev_10: 0, autre: 0 }
+    const t = { couverts: 0, food: 0, bev_20: 0, bev_10: 0, autre: 0, budget: 0 }
     for (const r of rows) {
       t.couverts += r.couverts
       t.food += r.food
       t.bev_20 += r.bev_20
       t.bev_10 += r.bev_10
       t.autre += r.autre
+      t.budget += r.budget || 0
     }
     t.caTtc = t.food + t.bev_20 + t.bev_10 + t.autre
     t.tm = t.couverts > 0 ? t.caTtc / t.couverts : null
@@ -203,27 +220,35 @@ function SplitTable({ c, isMobile, filteredRows, lieuxLabels, splitByLieu, split
               <th style={head}>CA Soft</th>
               <th style={head}>Autres</th>
               <th style={head}>CA Total</th>
+              <th style={head}>Δ Budget</th>
               <th style={head}>TM</th>
             </tr>
           </thead>
           <tbody>
-            {rows.map((r, i) => (
-              <tr key={`${r.iso}__${r.serie}__${i}`} style={{
-                background: r.jsWeekday === 0 || r.jsWeekday === 6 ? c.fond : 'transparent',
-              }}>
-                <td style={{ ...cell, textAlign: 'left', fontWeight: 500 }}>{r.iso.slice(8)}/{r.iso.slice(5, 7)}</td>
-                <td style={{ ...cell, textAlign: 'left', color: c.texteMuted }}>{JOURS_FR[r.jsWeekday].slice(0, 3)}</td>
-                {splitByLieu && <td style={{ ...cell, textAlign: 'left' }}>{r.lieu}</td>}
-                {splitByService && <td style={{ ...cell, textAlign: 'left', color: c.texteMuted }}>{r.service}</td>}
-                <td style={cell}>{r.couverts || '—'}</td>
-                <td style={cell}>{formatEur(r.food)}</td>
-                <td style={cell}>{formatEur(r.bev_20)}</td>
-                <td style={cell}>{formatEur(r.bev_10)}</td>
-                <td style={cell}>{formatEur(r.autre)}</td>
-                <td style={{ ...cell, fontWeight: 600 }}>{formatEur(r.caTot)}</td>
-                <td style={cell}>{formatEur2(r.tm)}</td>
-              </tr>
-            ))}
+            {rows.map((r, i) => {
+              const hasData = r.caTot > 0 || r.couverts > 0
+              return (
+                <tr key={`${r.iso}__${r.serie}__${i}`} style={{
+                  background: r.jsWeekday === 0 || r.jsWeekday === 6 ? c.fond : 'transparent',
+                }}>
+                  <td style={{ ...cell, textAlign: 'left', fontWeight: 500 }}>{r.iso.slice(8)}/{r.iso.slice(5, 7)}</td>
+                  <td style={{ ...cell, textAlign: 'left', color: c.texteMuted }}>{JOURS_FR[r.jsWeekday].slice(0, 3)}</td>
+                  {splitByLieu && <td style={{ ...cell, textAlign: 'left' }}>{r.lieu}</td>}
+                  {splitByService && <td style={{ ...cell, textAlign: 'left', color: c.texteMuted }}>{r.service}</td>}
+                  <td style={cell}>{r.couverts || '—'}</td>
+                  <td style={cell}>{formatEur(r.food)}</td>
+                  <td style={cell}>{formatEur(r.bev_20)}</td>
+                  <td style={cell}>{formatEur(r.bev_10)}</td>
+                  <td style={cell}>{formatEur(r.autre)}</td>
+                  <td style={{ ...cell, fontWeight: 600 }}>{formatEur(r.caTot)}</td>
+                  <td style={budgetCellStyle({ caTot: r.caTot, budget: r.budget, hasData }, cell, c)}
+                      title={budgetCellTitle({ caTot: r.caTot, budget: r.budget })}>
+                    {budgetCellLabel({ caTot: r.caTot, budget: r.budget, hasData })}
+                  </td>
+                  <td style={cell}>{formatEur2(r.tm)}</td>
+                </tr>
+              )
+            })}
           </tbody>
           <tfoot>
             <tr style={{ background: c.fond, fontWeight: 600 }}>
@@ -234,6 +259,9 @@ function SplitTable({ c, isMobile, filteredRows, lieuxLabels, splitByLieu, split
               <td style={cell}>{formatEur(totals.bev_10)}</td>
               <td style={cell}>{formatEur(totals.autre)}</td>
               <td style={{ ...cell, fontWeight: 700 }}>{formatEur(totals.caTtc)}</td>
+              <td style={totalBudgetCellStyle(totals, cell, c)} title={totalBudgetCellTitle(totals)}>
+                {totalBudgetCellLabel(totals)}
+              </td>
               <td style={cell}>{formatEur2(totals.tm)}</td>
             </tr>
           </tfoot>
@@ -266,8 +294,11 @@ function makeStyles(c, isMobile) {
 
 // ── Helpers Δ Budget (mêmes règles que /controle-gestion/ventes) ────────────
 function budgetTone(real, budget, hasData) {
-  if (!budget) return 'none'
   if (!hasData) return 'none'
+  // Pas de budget configuré mais on a du réel → on affiche le delta en gris
+  // neutre ("info"), pour que l'utilisateur voit la perf sans laisser croire
+  // qu'il a battu un objectif (puisqu'il n'y a pas d'objectif).
+  if (!budget) return 'info'
   if (real >= budget) return 'success'
   if (real < budget * 0.95) return 'danger'
   return 'warning'
@@ -277,22 +308,26 @@ function tonePalette(tone, c) {
   if (tone === 'success') return { color: c.vert, bg: c.vertClair }
   if (tone === 'danger') return { color: c.rouge, bg: c.rougeClair }
   if (tone === 'warning') return { color: c.orange, bg: c.orangeClair }
+  if (tone === 'info') return { color: c.texteMuted, bg: c.fond }
   return { color: c.texteMuted, bg: 'transparent' }
 }
 
 function budgetCellStyle(d, base, c) {
   const tone = budgetTone(d.caTot, d.budget, d.hasData)
   const { color, bg } = tonePalette(tone, c)
-  return { ...base, color, background: bg, fontWeight: tone === 'none' ? 400 : 600 }
+  return { ...base, color, background: bg, fontWeight: tone === 'none' || tone === 'info' ? 500 : 600 }
 }
 
 function budgetCellLabel(d) {
-  if (!d.budget || !d.hasData) return '—'
-  return formatDeltaEur(d.caTot - d.budget)
+  if (!d.hasData) return '—'
+  // Quand pas de budget configuré : on affiche le delta (= caTot - 0 = caTot)
+  // pour signaler la valeur réelle. Le ton "info" + le tooltip indiquent que
+  // c'est sans référence budget.
+  return formatDeltaEur(d.caTot - (d.budget || 0))
 }
 
 function budgetCellTitle(d) {
-  if (!d.budget) return 'Pas de budget cible pour ce jour de la semaine'
+  if (!d.budget) return 'Aucun budget configuré pour ce jour de la semaine — configurez-le dans Suivi CA → Budgets'
   const ratio = d.caTot > 0 ? (d.caTot / d.budget) * 100 : 0
   return `Réel ${formatEur(d.caTot)} / Budget ${formatEur(d.budget)} (${ratio.toFixed(0)} %)`
 }
@@ -300,12 +335,12 @@ function budgetCellTitle(d) {
 function totalBudgetCellStyle(totals, base, c) {
   const tone = budgetTone(totals.caTtc, totals.budget, totals.caTtc > 0)
   const { color, bg } = tonePalette(tone, c)
-  return { ...base, color, background: bg, fontWeight: tone === 'none' ? 600 : 700 }
+  return { ...base, color, background: bg, fontWeight: tone === 'none' || tone === 'info' ? 600 : 700 }
 }
 
 function totalBudgetCellLabel(totals) {
-  if (!totals.budget || totals.caTtc === 0) return '—'
-  return formatDeltaEur(totals.caTtc - totals.budget)
+  if (totals.caTtc === 0) return '—'
+  return formatDeltaEur(totals.caTtc - (totals.budget || 0))
 }
 
 function totalBudgetCellTitle(totals) {

--- a/lib/caAnalyses.js
+++ b/lib/caAnalyses.js
@@ -467,6 +467,62 @@ export function budgetByIsoJdsForMonth(budgetRows, monthNum) {
   return out
 }
 
+// Budget journalier pour un (iso, [lieu_service_id], [service]). Si une des
+// dimensions est null, somme toutes les valeurs sur cette dimension.
+// Respecte la priorité override mensuel > défaut au niveau de chaque cellule
+// (jds, lieu, service), puis applique le ratio nb_jours_override.
+// Utilisé par le tableau jour-par-jour en mode split.
+export function dailyBudgetForCell(
+  budgetRowsByYear,
+  iso,
+  lieuServiceId = null,
+  service = null,
+  overridesByYearMonth = null,
+) {
+  const date = fromIsoDate(iso)
+  const annee = date.getFullYear()
+  const mois = date.getMonth() + 1
+  const dow = date.getDay()
+  const isoJds = dow === 0 ? 7 : dow
+  const yearRows = budgetRowsByYear[annee] || []
+
+  // 1. Filtre par jds + lieu (optionnel) + service (optionnel).
+  // 2. Pour chaque (lieu, service) restant, applique la priorité override
+  //    mensuel > défaut au niveau de la cellule.
+  const cellMap = new Map() // key = `${lieu}_${service}` → row choisie
+  for (const b of yearRows) {
+    if (b.jour_semaine !== isoJds) continue
+    if (lieuServiceId != null && b.lieu_service_id !== lieuServiceId) continue
+    if (service != null && b.service !== service) continue
+    const key = `${b.lieu_service_id}_${b.service}`
+    if (b.mois === mois) {
+      cellMap.set(key, b)
+    } else if (!cellMap.has(key)) {
+      cellMap.set(key, b)
+    }
+  }
+
+  // 3. Somme des cellules sélectionnées
+  let budgetParJour = 0
+  for (const cell of cellMap.values()) {
+    budgetParJour +=
+      Number(cell.ca_food_cible || 0) +
+      Number(cell.ca_bev_20_cible || 0) +
+      Number(cell.ca_bev_10_cible || 0) +
+      Number(cell.ca_autre_cible || 0)
+  }
+
+  // 4. Ratio override nb_jours si présent
+  if (overridesByYearMonth) {
+    const override = overridesByYearMonth.get(`${annee}_${mois}_${isoJds}`)
+    if (override != null) {
+      const naturel = countIsoJdsInMonth(annee, mois, isoJds)
+      if (naturel > 0) return budgetParJour * (override / naturel)
+    }
+  }
+  return budgetParJour
+}
+
 // Compte le nombre d'occurrences naturel d'un jour-de-semaine (isoJds 1..7)
 // dans un mois calendaire entier. Utilisé pour calculer le ratio d'override.
 export function countIsoJdsInMonth(annee, mois, isoJds) {


### PR DESCRIPTION
## Summary

Deux fixes sur le tableau **"Détail jour par jour"** de `/controle-gestion/analyses`.

### 1. Marsan — Δ Budget en mode split (par lieu et/ou par service)

**Avant** : en mode split (1 ligne par jour × lieu et/ou × service), la colonne Δ Budget était volontairement absente — un commentaire dans le code disait que c'était "out of scope" d'une ancienne PR. Du coup pour Marsan qui regarde par lieu, pas moyen de voir le delta vs budget par ligne.

**Maintenant** : la colonne est implémentée, avec un calcul de budget par cellule (jour × [lieu] × [service]) qui respecte la même logique que le reste de la page (priorité override mensuel > défaut, ratio `nb_jours_override`).

Nouveau helper `lib/caAnalyses.js :: dailyBudgetForCell` :
- Filtre les budget rows par jds + (lieu si split) + (service si split)
- Si une dimension n'est pas splittée → somme toutes les valeurs sur cette dimension
- Applique override mensuel + ratio nb_jours

### 2. Joia — Δ Budget affiché même sans budget configuré (dimanches)

**Avant** : quand aucun budget n'est configuré pour un jour-de-semaine (ex: pas de budget dimanche sur Joia), la cellule affichait juste `—`. Tu pensais que c'était un bug.

**Maintenant** : la cellule affiche le delta réel (= CA total puisque le budget=0) avec un **ton neutre gris** (≠ vert "objectif battu") et un **tooltip explicite** "Aucun budget configuré pour ce jour de la semaine — configurez-le dans Suivi CA → Budgets". Tu vois la perf et le signal "tu as oublié de configurer un budget ici".

## Test plan

- [ ] Marsan / `/analyses` / split par lieu → le tableau Détail montre maintenant une colonne Δ Budget par ligne (Salle à manger, Privat, Table de partage chacun avec son écart)
- [ ] Joia / `/analyses` / vue cumulée → le dimanche affiche `+X €` en gris au lieu de `—` ; le tooltip indique "Aucun budget configuré"
- [ ] Les autres jours avec budget configuré gardent leur couleur (vert / orange / rouge) selon dépassement
- [ ] Le ratio des fermetures (override nb_jours) reste appliqué dans les deux cas — vérifier qu'un Δ Budget en mode split sur un mois avec override donne bien la même somme que le KPI Écart vs Budget global

🤖 Generated with [Claude Code](https://claude.com/claude-code)