### PR TITLE
fix(analyses): isole les overrides mensuels — un budget mars ne contamine plus avril

### DIFF
--- a/lib/__tests__/caAnalyses.test.ts
+++ b/lib/__tests__/caAnalyses.test.ts
@@ -141,6 +141,32 @@ describe('budgetByIsoJdsForMonth', () => {
     ]
     expect(budgetByIsoJdsForMonth(rows, 5).get(1)).toBe(130)
   })
+
+  it('n\'utilise PAS une row d\'un autre mois comme fallback (cas Joia)', () => {
+    // Cas réel : Joia a un budget Dimanche en JANVIER (mois=1, 15400). On
+    // demande le budget pour MAI (monthNum=5). L'ancienne version pouvait
+    // accidentellement prendre la row janvier comme "défaut" pour mai.
+    // Nouvelle version : ignore les rows mois ≠ 5 et ≠ null.
+    const rows = [
+      { jour_semaine: 7, lieu_service_id: 'L1', service: 'lunch', mois: 1, ca_food_cible: 15400, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+    ]
+    expect(budgetByIsoJdsForMonth(rows, 5).get(7)).toBeUndefined()
+    expect(budgetByIsoJdsForMonth(rows, 1).get(7)).toBe(15400)
+  })
+
+  it('override d\'un autre mois ne contamine pas le mois demandé même si listé en premier', () => {
+    // Garantit l'indépendance par rapport à l'ordre de la query Supabase.
+    const rows = [
+      // Override février (en premier dans l'array)
+      { jour_semaine: 7, lieu_service_id: 'L1', service: 'lunch', mois: 2, ca_food_cible: 20000, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+      // Défaut annuel
+      { jour_semaine: 7, lieu_service_id: 'L1', service: 'lunch', mois: null, ca_food_cible: 10000, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+    ]
+    // Pour janvier (pas d'override) → on doit prendre le défaut 10 000, pas l'override février
+    expect(budgetByIsoJdsForMonth(rows, 1).get(7)).toBe(10000)
+    // Pour février → override 20 000
+    expect(budgetByIsoJdsForMonth(rows, 2).get(7)).toBe(20000)
+  })
 })
 
 describe('periodBudgetTotal', () => {

--- a/lib/caAnalyses.js
+++ b/lib/caAnalyses.js
@@ -441,20 +441,30 @@ export function topBottomDays(days, n = 5) {
 // ── Budget ──────────────────────────────────────────────────────────────────
 
 // budgetRows : ca_budgets sur l'année concernée, filtrés (par lieu/service
-// côté SQL ou JS), avec mois NULL (défaut) ou mois = monthNum (override).
+// côté SQL ou JS). Chaque row a soit `mois = null` (défaut annuel) soit
+// `mois ∈ 1..12` (override pour ce mois précis).
 //
 // Renvoie un Map<isoJds (1..7), totalBudgetCible> calculé pour `monthNum`.
-// Override prioritaire sur défaut au niveau (jds, lieu, service).
+// Override mensuel prioritaire sur défaut annuel au niveau (jds, lieu, service).
+// Les rows avec un mois différent de monthNum sont ignorées (elles ne
+// concernent pas le mois demandé, pas même comme défaut — la version d'avant
+// pouvait les attraper accidentellement selon l'ordre d'itération).
 export function budgetByIsoJdsForMonth(budgetRows, monthNum) {
-  const cellMap = new Map() // key = `${jds}_${lieu}_${svc}`
+  const cellMap = new Map() // key = `${jds}_${lieu}_${svc}` → row choisie
+
+  // Pass 1 : défauts annuels (mois = null). Sert de base.
   for (const b of budgetRows) {
+    if (b.mois != null) continue
     const key = `${b.jour_semaine}_${b.lieu_service_id}_${b.service}`
-    if (b.mois === monthNum) {
-      cellMap.set(key, b)
-    } else if (!cellMap.has(key)) {
-      cellMap.set(key, b)
-    }
+    cellMap.set(key, b)
   }
+  // Pass 2 : override pour `monthNum`. Écrase le défaut sur la même clé.
+  for (const b of budgetRows) {
+    if (b.mois !== monthNum) continue
+    const key = `${b.jour_semaine}_${b.lieu_service_id}_${b.service}`
+    cellMap.set(key, b)
+  }
+
   const out = new Map()
   for (const cell of cellMap.values()) {
     const total =
@@ -486,20 +496,25 @@ export function dailyBudgetForCell(
   const isoJds = dow === 0 ? 7 : dow
   const yearRows = budgetRowsByYear[annee] || []
 
-  // 1. Filtre par jds + lieu (optionnel) + service (optionnel).
-  // 2. Pour chaque (lieu, service) restant, applique la priorité override
-  //    mensuel > défaut au niveau de la cellule.
+  // Filtre par jds + lieu (optionnel) + service (optionnel).
+  // Comme budgetByIsoJdsForMonth, on fait 2 passes pour qu'une row override
+  // d'un autre mois ne pollue pas la cellule par accident.
   const cellMap = new Map() // key = `${lieu}_${service}` → row choisie
+  // Pass 1 : défauts annuels
   for (const b of yearRows) {
     if (b.jour_semaine !== isoJds) continue
     if (lieuServiceId != null && b.lieu_service_id !== lieuServiceId) continue
     if (service != null && b.service !== service) continue
-    const key = `${b.lieu_service_id}_${b.service}`
-    if (b.mois === mois) {
-      cellMap.set(key, b)
-    } else if (!cellMap.has(key)) {
-      cellMap.set(key, b)
-    }
+    if (b.mois != null) continue
+    cellMap.set(`${b.lieu_service_id}_${b.service}`, b)
+  }
+  // Pass 2 : override pour ce mois précis
+  for (const b of yearRows) {
+    if (b.jour_semaine !== isoJds) continue
+    if (lieuServiceId != null && b.lieu_service_id !== lieuServiceId) continue
+    if (service != null && b.service !== service) continue
+    if (b.mois !== mois) continue
+    cellMap.set(`${b.lieu_service_id}_${b.service}`, b)
   }
 
   // 3. Somme des cellules sélectionnées


### PR DESCRIPTION
## Summary

Suite à ton retour "j'ai bien du budget sur les dimanches" sur Joia, j'ai creusé. Le budget existait bien en base, mais le calcul l'oubliait dans certains cas.

## Cause

Dans `budgetByIsoJdsForMonth` (et son cousin `dailyBudgetForCell` ajouté hier), la logique de priorité `override mensuel > défaut annuel` était subtilement sensible à l'ordre d'itération :

\`\`\`js
for (const b of budgetRows) {
  if (b.mois === monthNum) cellMap.set(key, b)
  else if (!cellMap.has(key)) cellMap.set(key, b)  // ← piège
}
\`\`\`

Le `else if` mettait dans la cellMap **n'importe quelle row dont `mois ≠ monthNum`**, à condition qu'elle arrive avant l'override exact. Donc une row "mois = 1" (override janvier) pouvait :
- être prise comme défaut pour mai (si elle arrivait en premier)
- empêcher la "vraie" row défaut (mois=null) de prendre sa place

Vu que Supabase ne garantit pas l'ordre sans `ORDER BY`, le bug se manifestait de façon imprévisible — c'est probablement ce qui faisait disparaître ton budget dimanche sur certaines périodes.

## Fix

Deux passes explicites :
1. **Pass 1** : seed la cellMap avec les défauts annuels (`mois IS NULL`)
2. **Pass 2** : écrase avec l'override mensuel exact (`mois = monthNum`)

Les rows `mois ≠ monthNum ET mois ≠ null` sont strictement ignorées (elles concernent d'autres mois — pas leur problème).

Même fix sur `dailyBudgetForCell` (qui faisait pareil pour les cellules en mode split).

## Tests

2 nouveaux cas dans `lib/__tests__/caAnalyses.test.ts` :
- une row janvier ne doit pas servir de défaut pour mai
- une row override mois X en premier ne doit pas écraser le défaut quand on demande un mois Y différent

→ **47/47 tests passent**.

## Test plan UX

- [ ] Joia / `/analyses` / janvier → le dimanche 04/01 affiche maintenant son Δ Budget (vs le 15 400 € que tu as configuré, divisé par le nb réel de dimanches)
- [ ] Si tu as configuré des budgets mois-par-mois sur Marsan aussi, vérifier que chaque mois lit bien le sien (pas un mois voisin)
- [ ] Sans config (Joia avec dimanche vide) → le delta gris neutre s'affiche toujours, avec le tooltip "Aucun budget configuré"

🤖 Generated with [Claude Code](https://claude.com/claude-code)