### PR TITLE
fix(analyses): override nb_jours respecte service et lieu (cas Joia dim soir)

### DIFF
--- a/app/controle-gestion/analyses/page.js
+++ b/app/controle-gestion/analyses/page.js
@@ -221,13 +221,15 @@ export default function AnalysesPage() {
         : Promise.resolve({ data: [], error: null })
 
       // Overrides nb_jours (fermetures exceptionnelles) sur toutes les années
-      // couvertes par la plage et la comparaison. Une seule query suffit, le
-      // volume est petit (≤ 84 lignes/an = 12 mois × 7 jours).
+      // couvertes par la plage et la comparaison. Une override peut être
+      // global (service=null, lieu=null) ou ciblé sur un service précis
+      // (lunch/dinner) et/ou un lieu précis. Lookup côté code avec priorité
+      // (lieu_specifique, svc) > (NULL, svc_specifique) > (NULL, NULL).
       const overridesYears = Array.from(new Set([...years, ...compareYears]))
       const overridesQuery = overridesYears.length > 0
         ? supabase
             .from('ca_budget_jours_override')
-            .select('annee, mois, jour_semaine, nb_jours')
+            .select('annee, mois, jour_semaine, service, lieu_service_id, nb_jours')
             .eq('client_id', clientId)
             .in('annee', overridesYears)
         : Promise.resolve({ data: [], error: null })
@@ -246,9 +248,16 @@ export default function AnalysesPage() {
         return acc
       }, {})
 
+      // Indexation par clé fully-qualified (annee, mois, jds, service, lieu).
+      // Le lookup côté caAnalyses.js fait la priorité (lieu, svc) > (NULL, svc) > (NULL, NULL).
       const overridesMap = new Map()
       for (const o of overridesRes.data || []) {
-        overridesMap.set(`${o.annee}_${o.mois}_${o.jour_semaine}`, Number(o.nb_jours))
+        const svcKey = o.service ?? '__all__'
+        const lieuKey = o.lieu_service_id ?? '__all__'
+        overridesMap.set(
+          `${o.annee}_${o.mois}_${o.jour_semaine}_${svcKey}_${lieuKey}`,
+          Number(o.nb_jours)
+        )
       }
 
       setRawCa(caRes.data || [])

--- a/lib/__tests__/caAnalyses.test.ts
+++ b/lib/__tests__/caAnalyses.test.ts
@@ -212,7 +212,8 @@ describe('periodBudgetTotal', () => {
     const rows = [
       { jour_semaine: 1, lieu_service_id: 'L1', service: 'lunch', mois: null, ca_food_cible: 100, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
     ]
-    const overrides = new Map([['2026_5_1', 3]])
+    // Clé override "global" (service=null, lieu=null) → s'applique à toutes les cellules
+    const overrides = new Map([['2026_5_1___all_____all__', 3]])
     const total = periodBudgetTotal({ 2026: rows }, '2026-05-01', '2026-05-31', null, overrides)
     expect(total).toBe(300)
   })
@@ -224,9 +225,25 @@ describe('periodBudgetTotal', () => {
     const rows = [
       { jour_semaine: 1, lieu_service_id: 'L1', service: 'lunch', mois: null, ca_food_cible: 100, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
     ]
-    const overrides = new Map([['2026_5_1', 3]])
+    const overrides = new Map([['2026_5_1___all_____all__', 3]])
     const total = periodBudgetTotal({ 2026: rows }, '2026-05-01', '2026-05-15', null, overrides)
     expect(total).toBe(150)
+  })
+
+  it('cas Joia : un override service=dinner ne zéroter pas le service=lunch du même jds', () => {
+    // Joia : pas de service dimanche soir → override dim/dinner = 0.
+    // Le dim midi (lunch) doit garder son budget normal (4 lundis × 100 = 400).
+    const rows = [
+      { jour_semaine: 7, lieu_service_id: 'L1', service: 'lunch',  mois: null, ca_food_cible: 100, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+      { jour_semaine: 7, lieu_service_id: 'L1', service: 'dinner', mois: null, ca_food_cible: 50,  ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+    ]
+    // 4 dimanches en mai 2026 (3, 10, 17, 24, 31 = 5 dim en réalité). Vérif :
+    // Mai 2026 commence par ven → 3, 10, 17, 24, 31 = 5 dimanches.
+    // Override dim/dinner = 0 → ratio dinner = 0/5 = 0 → dinner total = 0
+    // Lunch : pas d'override → ratio = 1 → 5 dim × 100 = 500.
+    const overrides = new Map([['2026_5_7_dinner___all__', 0]])
+    const total = periodBudgetTotal({ 2026: rows }, '2026-05-01', '2026-05-31', null, overrides)
+    expect(total).toBe(500)
   })
 
   it('aucun override fourni → comportement identique à l\'ancien', () => {

--- a/lib/caAnalyses.js
+++ b/lib/caAnalyses.js
@@ -440,16 +440,43 @@ export function topBottomDays(days, n = 5) {
 
 // ── Budget ──────────────────────────────────────────────────────────────────
 
+// Lookup ratio d'override nb_jours pour une cellule (jds, lieu, svc) d'un
+// mois donné. Priorité décroissante :
+//   1. override spécifique au lieu + service
+//   2. override service-only (lieu = null)
+//   3. override jds-only (service = null, lieu = null)
+//   4. 1 (pas d'override)
+// L'override stocke `nb_jours` (nb d'occurrences réellement ouvertes du jds
+// dans le mois). Le ratio retourné = `nb_jours / nb_naturel_du_mois`.
+function ratioOverrideForCell(overridesMap, annee, mois, jds, lieu, service) {
+  if (!overridesMap) return 1
+  const prefix = `${annee}_${mois}_${jds}_`
+  const lieuKey = lieu ?? '__all__'
+  const keys = [
+    `${prefix}${service}_${lieuKey}`,
+    `${prefix}${service}_${'__all__'}`,
+    `${prefix}${'__all__'}_${'__all__'}`,
+  ]
+  let nbJours = null
+  for (const k of keys) {
+    if (overridesMap.has(k)) { nbJours = overridesMap.get(k); break }
+  }
+  if (nbJours == null) return 1
+  const naturel = countIsoJdsInMonth(annee, mois, jds)
+  return naturel > 0 ? nbJours / naturel : 1
+}
+
 // budgetRows : ca_budgets sur l'année concernée, filtrés (par lieu/service
 // côté SQL ou JS). Chaque row a soit `mois = null` (défaut annuel) soit
 // `mois ∈ 1..12` (override pour ce mois précis).
 //
 // Renvoie un Map<isoJds (1..7), totalBudgetCible> calculé pour `monthNum`.
 // Override mensuel prioritaire sur défaut annuel au niveau (jds, lieu, service).
-// Les rows avec un mois différent de monthNum sont ignorées (elles ne
-// concernent pas le mois demandé, pas même comme défaut — la version d'avant
-// pouvait les attraper accidentellement selon l'ordre d'itération).
-export function budgetByIsoJdsForMonth(budgetRows, monthNum) {
+//
+// `annee` et `overridesMap` (optionnels) servent à appliquer le ratio des
+// fermetures exceptionnelles AU NIVEAU CELLULE — un override "service=dinner
+// nb_jours=0" ne doit pas zéroter le budget du même jds en lunch.
+export function budgetByIsoJdsForMonth(budgetRows, monthNum, annee = null, overridesMap = null) {
   const cellMap = new Map() // key = `${jds}_${lieu}_${svc}` → row choisie
 
   // Pass 1 : défauts annuels (mois = null). Sert de base.
@@ -472,7 +499,10 @@ export function budgetByIsoJdsForMonth(budgetRows, monthNum) {
       Number(cell.ca_bev_20_cible || 0) +
       Number(cell.ca_bev_10_cible || 0) +
       Number(cell.ca_autre_cible || 0)
-    out.set(cell.jour_semaine, (out.get(cell.jour_semaine) || 0) + total)
+    const ratio = annee != null
+      ? ratioOverrideForCell(overridesMap, annee, monthNum, cell.jour_semaine, cell.lieu_service_id, cell.service)
+      : 1
+    out.set(cell.jour_semaine, (out.get(cell.jour_semaine) || 0) + total * ratio)
   }
   return out
 }
@@ -517,23 +547,22 @@ export function dailyBudgetForCell(
     cellMap.set(`${b.lieu_service_id}_${b.service}`, b)
   }
 
-  // 3. Somme des cellules sélectionnées
+  // 3. Somme des cellules sélectionnées, avec ratio override par cellule.
+  // Le ratio est appliqué cellule par cellule (et non globalement) pour
+  // qu'un override "dim dinner = 0" ne zéroter pas aussi le dim lunch.
   let budgetParJour = 0
   for (const cell of cellMap.values()) {
-    budgetParJour +=
+    const total =
       Number(cell.ca_food_cible || 0) +
       Number(cell.ca_bev_20_cible || 0) +
       Number(cell.ca_bev_10_cible || 0) +
       Number(cell.ca_autre_cible || 0)
-  }
-
-  // 4. Ratio override nb_jours si présent
-  if (overridesByYearMonth) {
-    const override = overridesByYearMonth.get(`${annee}_${mois}_${isoJds}`)
-    if (override != null) {
-      const naturel = countIsoJdsInMonth(annee, mois, isoJds)
-      if (naturel > 0) return budgetParJour * (override / naturel)
-    }
+    const ratio = ratioOverrideForCell(
+      overridesByYearMonth,
+      annee, mois, isoJds,
+      cell.lieu_service_id, cell.service,
+    )
+    budgetParJour += total * ratio
   }
   return budgetParJour
 }
@@ -555,48 +584,26 @@ export function countIsoJdsInMonth(annee, mois, isoJds) {
 // budgetRowsByYear : map { [annee]: rows[] } pour gérer les périodes
 // chevauchant deux années (ex: décembre → janvier).
 // `isoJdsFilter` (optionnel) : Set<number 1..7> — ne sommer que ces jours-de-semaine.
-// `overridesByYearMonth` (optionnel) : Map<`${annee}_${mois}_${jds}`, nb_jours>
-//   pour appliquer les fermetures exceptionnelles configurées dans /budgets.
-//   Si fourni, scale le budget de chaque (mois, jds) par
-//   (override_nb_jours / nb_jours_naturel_du_mois). Quand la plage ne couvre
-//   pas le mois entier, le ratio s'applique proportionnellement au nombre de
-//   jours du jds présents dans la plage (approximation : on ignore quelle
-//   occurrence précise est fermée — pour ça il faudrait un calendrier de
-//   fermetures à la date, chantier séparé).
+// `overridesByYearMonth` (optionnel) : Map<`${annee}_${mois}_${jds}_${service}_${lieu}`, nb_jours>
+//   pour appliquer les fermetures exceptionnelles. Le ratio est appliqué AU
+//   NIVEAU CELLULE (jds × lieu × service) dans budgetByIsoJdsForMonth, avec
+//   priorité (lieu, svc) > (NULL, svc) > (NULL, NULL). Ça permet de fermer
+//   un service précis (ex: dimanche soir) sans impacter l'autre service du
+//   même jds.
 export function periodBudgetTotal(budgetRowsByYear, debut, fin, isoJdsFilter = null, overridesByYearMonth = null) {
-  // Cache du Map par (annee, mois) pour éviter de recalculer à chaque jour
   const cache = new Map()
   const getMap = (annee, mois) => {
     const key = `${annee}_${mois}`
     if (!cache.has(key)) {
-      cache.set(key, budgetByIsoJdsForMonth(budgetRowsByYear[annee] || [], mois))
+      cache.set(key, budgetByIsoJdsForMonth(budgetRowsByYear[annee] || [], mois, annee, overridesByYearMonth))
     }
     return cache.get(key)
   }
-
-  // Cache du ratio override par (annee, mois, jds). 1 si pas d'override.
-  const ratioCache = new Map()
-  const getRatio = (annee, mois, jds) => {
-    if (!overridesByYearMonth) return 1
-    const key = `${annee}_${mois}_${jds}`
-    if (ratioCache.has(key)) return ratioCache.get(key)
-    const override = overridesByYearMonth.get(key)
-    if (override == null) { ratioCache.set(key, 1); return 1 }
-    const naturel = countIsoJdsInMonth(annee, mois, jds)
-    const r = naturel > 0 ? override / naturel : 1
-    ratioCache.set(key, r)
-    return r
-  }
-
   let total = 0
   for (const d of eachDayIso(debut, fin)) {
     if (isoJdsFilter && !isoJdsFilter.has(d.isoJds)) continue
     const date = fromIsoDate(d.iso)
-    const annee = date.getFullYear()
-    const mois = date.getMonth() + 1
-    const map = getMap(annee, mois)
-    const budgetParJour = map.get(d.isoJds) || 0
-    total += budgetParJour * getRatio(annee, mois, d.isoJds)
+    total += getMap(date.getFullYear(), date.getMonth() + 1).get(d.isoJds) || 0
   }
   return total
 }


### PR DESCRIPTION
## Le VRAI bug enfin trouvé

Pour Joia, la table `ca_budget_jours_override` contient une row par mois pour signifier "pas de service dimanche soir" :

\`\`\`
(annee=2026, mois=1, jds=7, service='dinner', lieu_service_id=NULL, nb_jours=0)
\`\`\`

Légitime — dim soir = 0 occurrences ouvertes.

**Mais** le code `/analyses` indexait ces overrides avec la clé `${annee}_${mois}_${jds}` **sans tenir compte du service ni du lieu**. Conséquence : l'override "dim/**dinner** = 0" était appliqué aussi au **dim/lunch** → ratio 0/4 = 0 → budget dim midi = 0 → Δ = +CA total (gris).

D'où ce que tu voyais : tous les autres jours OK (rouge négatif), seul le dim affichait gris.

## Le fix

1. **Query** : `select` ajoute maintenant `service` et `lieu_service_id` depuis `ca_budget_jours_override`
2. **Indexation** : clé fully-qualified `${annee}_${mois}_${jds}_${svc}_${lieu}` avec `'__all__'` pour les wildcards (service=null, lieu=null)
3. **Lookup ratio** au niveau cellule (jds × lieu × service) avec priorité :
   - `(lieu_specifique, svc_specifique)` → override précis pour cette cellule
   - `(NULL, svc_specifique)` → override global pour ce service (cas Joia)
   - `(NULL, NULL)` → override global pour ce jds tous services
4. Le ratio est désormais appliqué dans `budgetByIsoJdsForMonth` au niveau de chaque cellule (au lieu du total agrégé), de sorte qu'un override service-spécifique ne contamine plus les autres services

## Tests

Nouveau cas "Joia dim/dinner = 0" qui vérifie qu'un override service-only ne zéroter pas l'autre service du même jds. **48/48 passent**.

## Test plan

- [ ] Joia / `/analyses` / janvier → le 04/01 dim doit maintenant afficher Δ = caTot - 3850 = **-1093 €** (rouge)
- [ ] Mêmes vérifs sur 11/01, 18/01, 25/01 dim (tous les dim de janvier)
- [ ] Pareil sur février, mars, ... (puisque tu as l'override dim/dinner=0 sur tous les mois)
- [ ] Marsan : vérifier qu'aucun chiffre n'a régressé (si Marsan n'a pas d'override service-only, comportement strictement identique)

🤖 Generated with [Claude Code](https://claude.com/claude-code)