### PR TITLE
fix(dashboard): KpiCaMtd lit ca_journalier au lieu de ventes_journalieres

### DIFF
--- a/components/dashboard/widgets/KpiCaMtd.js
+++ b/components/dashboard/widgets/KpiCaMtd.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { supabase, getClientId } from '../../../lib/supabase'
+import { aggregateTotals } from '../../../lib/caAnalyses'
 
 function firstDayOfMonthIso(d = new Date()) {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`
@@ -15,17 +16,20 @@ export default function KpiCaMtd({ c, isMobile }) {
       const clientId = await getClientId()
       if (!clientId) { setLoading(false); return }
       const debut = firstDayOfMonthIso()
+      // Source = ca_journalier (saisie CA agrégé par jour × lieu × service),
+      // alignée avec /controle-gestion/ventes et /controle-gestion/analyses.
+      // L'ancien widget lisait ventes_journalieres (saisie fiche-par-fiche)
+      // → restituait 0 € pour les clients qui ne saisissent pas ticket par
+      // ticket. aggregateTotals applique le TTC → HT par catégorie (food/soft
+      // 10 %, alcool 20 %) cohéremment avec les autres pages.
       const { data } = await supabase
-        .from('ventes_journalieres')
-        .select('quantite_vendue, prix_vente_net')
+        .from('ca_journalier')
+        .select('couverts, ca_food, ca_bev_20, ca_bev_10, ca_autre')
         .eq('client_id', clientId)
         .gte('jour', debut)
       if (cancelled) return
-      const total = (data || []).reduce(
-        (sum, row) => sum + (Number(row.quantite_vendue) || 0) * (Number(row.prix_vente_net) || 0),
-        0,
-      )
-      setCa(total)
+      const totals = aggregateTotals(data || [])
+      setCa(totals.caHt)
       setLoading(false)
     })()
     return () => { cancelled = true }


### PR DESCRIPTION
## Bug

Le widget **"CA cumulé mois en cours"** du dashboard lisait \`ventes_journalieres\` (saisie ticket par ticket). Or les clients qui saisissent leur CA agrégé via \`/controle-gestion/ventes/saisie\` (Joia, Marsan, etc.) n'utilisent pas cette table → widget bloqué à **0 €** alors que \`/analyses\` affiche ~50 k€ pour la même période.

## Fix

- Source passée à \`ca_journalier\` (la même table que \`/analyses\` et \`/ventes\`)
- Réutilise \`aggregateTotals\` de \`lib/caAnalyses\` pour la conversion TTC → HT par catégorie (food/soft 10 %, alcool 20 %, autre 10 %)
- Cohérent à la centime près avec le KPI "CA HT" de \`/analyses\`

## Validation DB directe

Joia mai 2026 → \`SUM(food/1.10 + bev20/1.20 + bev10/1.10 + autre/1.10)\` = **44 544.54 €** → matche **44 545 €** affiché sur \`/analyses\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)