### PR TITLE
fix(ingredients): scope la contrainte unique sur (client_id, nom)

### DIFF
--- a/app/ingredients/page.js
+++ b/app/ingredients/page.js
@@ -257,10 +257,11 @@ export default function IngredientsPage() {
         categorie_id: editionCategorie || null
       }).eq('id', id).eq('client_id', clientId)
       if (error) {
-        // Contrainte UNIQUE globale sur le nom : un autre établissement a déjà
-        // réservé ce nom. On remonte un message clair plutôt qu'un échec silencieux.
+        // Contrainte UNIQUE (client_id, nom) depuis 2026-05-15 : un autre
+        // ingrédient de cet établissement a déjà ce nom (ex: même renommage en
+        // boucle, ou race condition entre 2 onglets).
         if (error.code === '23505' || /duplicate key/i.test(error.message)) {
-          window.alert(`Le nom "${nomTrim}" est déjà utilisé par un autre établissement. Modifie légèrement le nom (ex : ajoute une marque ou une précision).`)
+          window.alert(`Le nom "${nomTrim}" est déjà utilisé par un autre ingrédient de votre établissement.`)
           return
         }
         throw error

--- a/lib/services/achats.service.ts
+++ b/lib/services/achats.service.ts
@@ -557,9 +557,9 @@ export async function deleteFacture(
 
 /**
  * Cherche un ingrédient existant pour ce client (par nom case-insensitive),
- * sinon le crée. Si la création échoue à cause de l'unique global sur `nom`
- * (la contrainte est sur `nom` seul, pas par client_id), c'est qu'un autre
- * établissement utilise déjà ce nom — on remonte une ConflictError exploitable.
+ * sinon le crée. Depuis la migration 2026-05-15, la contrainte unique est
+ * scopée par client (`UNIQUE (client_id, nom)`), donc le seul cas de conflit
+ * possible est une race condition au sein du même client.
  */
 export async function findOrCreateIngredient(
   db: SupabaseClient,
@@ -595,9 +595,11 @@ export async function findOrCreateIngredient(
     .single()
 
   if (error) {
-    // Conflit unique global → un autre établissement a réservé ce nom
+    // Conflit (client_id, nom) — l'ingrédient existe déjà dans cet établissement.
+    // En pratique le lookup `ilike` ci-dessus l'aurait trouvé sauf si une autre
+    // transaction l'a inséré entre les deux requêtes (race condition).
     if (error.code === '23505' || /duplicate key/i.test(error.message)) {
-      throw new ConflictError(`L'ingrédient "${nomTrim}" est déjà utilisé par un autre établissement. Modifie légèrement le nom.`)
+      throw new ConflictError(`L'ingrédient "${nomTrim}" existe déjà dans votre établissement.`)
     }
     throw new Error(error.message)
   }

--- a/supabase/migrations/20260515135143_ingredients_unique_per_client.sql
+++ b/supabase/migrations/20260515135143_ingredients_unique_per_client.sql
@@ -1,0 +1,27 @@
+-- ============================================================================
+-- ingredients : remplace l'UNIQUE global sur `nom` par un UNIQUE (client_id, nom)
+--
+-- Bug historique : la contrainte `ingredients_nom_unique UNIQUE (nom)` était
+-- globale, donc deux clients distincts (ex : Joia et Marsan) ne pouvaient pas
+-- créer un ingrédient portant le même nom (ex : "TRANSPORT"). L'UI remontait
+-- "L'ingrédient X est déjà utilisé par un autre établissement" — mais en
+-- réalité les data des établissements doivent être strictement isolées.
+--
+-- Cette migration scope la contrainte au tenant en remplaçant `(nom)` par
+-- `(client_id, nom)`. Aucun doublon par (client_id, nom) en base avant
+-- migration (vérifié en amont).
+--
+-- Le code applicatif (`findOrCreateIngredient`) normalise déjà le nom en
+-- UPPERCASE et fait son lookup par `ilike`, donc la contrainte sensible à la
+-- casse au niveau SQL est suffisante en pratique.
+-- ============================================================================
+
+ALTER TABLE public.ingredients
+  DROP CONSTRAINT IF EXISTS ingredients_nom_unique;
+
+ALTER TABLE public.ingredients
+  ADD CONSTRAINT ingredients_client_nom_unique
+  UNIQUE (client_id, nom);
+
+COMMENT ON CONSTRAINT ingredients_client_nom_unique ON public.ingredients IS
+  'Chaque client a son propre namespace de noms d''ingrédients. Avant 2026-05-15, la contrainte était UNIQUE (nom) global, ce qui faisait collisionner deux établissements distincts sur le même nom.';


### PR DESCRIPTION
## Bug d'isolation tenant

La contrainte \`ingredients_nom_unique UNIQUE (nom)\` était **globale**, pas scopée par client. Conséquence : deux établissements distincts (Joia + Marsan) ne pouvaient pas créer un ingrédient portant le même nom (ex: \"TRANSPORT\"). L'UI remontait *\"déjà utilisé par un autre établissement\"* — alors qu'en pratique les data devraient être strictement isolées par tenant.

## Migration

**Appliquée directement en prod via MCP Supabase** (DDL safe, 0 doublon par (client_id, nom) vérifié en amont) :

\`\`\`sql
ALTER TABLE ingredients DROP CONSTRAINT ingredients_nom_unique;
ALTER TABLE ingredients ADD CONSTRAINT ingredients_client_nom_unique UNIQUE (client_id, nom);
\`\`\`

Fichier de migration committé à \`supabase/migrations/20260515135143_ingredients_unique_per_client.sql\` pour le tracking.

## Code

- \`findOrCreateIngredient\` (lib/services/achats.service.ts) : commentaire et message ConflictError mis à jour. Le seul cas de conflit restant = race condition entre 2 requêtes simultanées dans le même client.
- \`/ingredients\` page : message alert mis à jour.

## Test plan

- [ ] Joia : OCR facture → créer ingrédient \"TRANSPORT\" → succès (avant : bloqué par contrainte globale)
- [ ] Marsan : créer aussi un \"TRANSPORT\" séparément → succès, les 2 cohabitent en base
- [ ] Tenter de créer 2× \"TRANSPORT\" dans le MÊME client → bloqué proprement avec message clair
- [ ] Édition d'un ingrédient pour lui mettre un nom déjà existant dans son propre client → alert bloquant

🤖 Generated with [Claude Code](https://claude.com/claude-code)