### PR TITLE
fix(rapport-hebdo): exclut les jours fermés sur tout le cumul mois

### DIFF
--- a/app/controle-gestion/ventes/rapport-hebdo/page.js
+++ b/app/controle-gestion/ventes/rapport-hebdo/page.js
@@ -238,13 +238,17 @@ export default function RapportHebdoPage() {
     [budgetRows, lieuToParent]
   )
 
-  // Set des dates fermées sur la période — fermetures hebdo + dates
-  // spécifiques marquées sur Budgets CA. Permet d'exclure ces jours du
-  // calcul budget pour rester cohérent avec la projection mensuelle.
-  const joursFermesIso = useMemo(
-    () => buildJoursFermesIso(joursFermesRows, joursFermesHebdoRows, debut, fin),
-    [joursFermesRows, joursFermesHebdoRows, debut, fin]
-  )
+  // Set des dates fermées — étendu sur [1er du mois de `fin`, fin] pour
+  // couvrir aussi le cumul mois (caTtcCumulMois itère depuis le 1er du
+  // mois). Si on se limitait à [debut, fin], les fermetures hebdo des
+  // jours hors-semaine (ex: lundis et dimanches du début du mois) ne
+  // seraient pas exclues du cumul mois et gonfleraient le CA budget.
+  const joursFermesIso = useMemo(() => {
+    const [y2, m2] = fin.split('-').map(Number)
+    const firstOfMonth = `${y2}-${String(m2).padStart(2, '0')}-01`
+    const debutEtendu = firstOfMonth < debut ? firstOfMonth : debut
+    return buildJoursFermesIso(joursFermesRows, joursFermesHebdoRows, debutEtendu, fin)
+  }, [joursFermesRows, joursFermesHebdoRows, debut, fin])
 
   const data = useMemo(() => buildRapportData({
     caRows: caRowsRemap, budgetRows: budgetRowsRemap, lieuxMap, debut, fin, joursFermesIso,


### PR DESCRIPTION
## Le bug

Sur le rapport hebdo, le **CA budget cumul mois** était surcompté car les fermetures hebdomadaires (et fermetures spécifiques) en dehors de la semaine courante n'étaient pas exclues.

Le set `joursFermesIso` est construit sur `[debut, fin]` (la semaine sélectionnée) mais utilisé par `caTtcCumulMois` qui itère sur `[1er du mois, fin]`. Conséquence : les lundis/dimanches du début du mois (pour un client comme MARSAN fermé lun+dim), ou les jours fériés type 1er mai, étaient **comptés au tarif budget** alors qu'ils sont fermés.

## Exemple constaté

MARSAN, semaine 11→17 mai 2026, cumul mois affiché : **350 695 €** au lieu de **276 760 €**.

Décomposition de l'écart de 73 935 € :
- 4 mai (lundi) : compté à 45 950 € (override mai Privat + défaut Salle à manger) au lieu de 0 €
- 1er mai (vendredi férié, marqué fermé spécifique) : compté à 27 985 € au lieu de 0 €

## Le fix

Étendre la construction de `joursFermesIso` sur `[1er du mois de fin, fin]` au lieu de `[debut, fin]`. Les rows brutes (`joursFermesRows`) sont déjà chargées sur cette plage étendue (`debutPourCumul`), donc pas de changement côté query.

Les autres calculs (CA semaine, TM par lieu/service, TM Food/Bev, mix, couverts, jour-par-jour) restent corrects : ils sont tous sur `[debut, fin]` et n'étaient pas affectés.

## Test plan

- [ ] Ouvrir /controle-gestion/ventes/rapport-hebdo en MARSAN sur la semaine 11-17 mai 2026
- [ ] Vérifier que le CA budget cumul mois passe de 350 695 € à 276 760 €
- [ ] Vérifier que le CA budget de la semaine (122 050 €) ne change pas
- [ ] Tester aussi avec une période qui s'étale sur 2 mois pour s'assurer que la logique `firstOfMonth < debut ? firstOfMonth : debut` est correcte

🤖 Generated with [Claude Code](https://claude.com/claude-code)