### PR TITLE
feat(rapport-hebdo): flag couverts_indicatifs sur lieux (cas Marsan Privat)

### DIFF
--- a/app/controle-gestion/ventes/rapport-hebdo/page.js
+++ b/app/controle-gestion/ventes/rapport-hebdo/page.js
@@ -117,7 +117,7 @@ export default function RapportHebdoPage() {
       const [lieuxRes, caRes, budgetRes, jfRes, jfhRes] = await Promise.all([
         supabase
           .from('lieux_service')
-          .select('id, nom, ordre, actif, parent_lieu_service_id')
+          .select('id, nom, ordre, actif, parent_lieu_service_id, couverts_indicatifs')
           .eq('client_id', clientId)
           .eq('actif', true)
           .order('ordre').order('nom'),
@@ -224,18 +224,32 @@ export default function RapportHebdoPage() {
   // Remap chaque row vers le parent (ou self si pas de parent) — toutes
   // les fonctions de calcul (tmParLieuService, etc.) groupent par
   // lieu_service_id qui pointe maintenant vers le parent.
+  // Pour les lieux marqués `couverts_indicatifs` (ex: Marsan Privat),
+  // on force couverts/couverts_cible à 0 — le CA reste compté.
   const lieuToParent = useMemo(() => {
     const m = new Map()
     for (const l of lieux) m.set(l.id, l.parent_lieu_service_id || l.id)
     return m
   }, [lieux])
+  const lieuxIndicatifs = useMemo(
+    () => new Set(lieux.filter((l) => l.couverts_indicatifs).map((l) => l.id)),
+    [lieux]
+  )
   const caRowsRemap = useMemo(
-    () => caRows.map((r) => ({ ...r, lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id })),
-    [caRows, lieuToParent]
+    () => caRows.map((r) => ({
+      ...r,
+      lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id,
+      couverts: lieuxIndicatifs.has(r.lieu_service_id) ? 0 : r.couverts,
+    })),
+    [caRows, lieuToParent, lieuxIndicatifs]
   )
   const budgetRowsRemap = useMemo(
-    () => budgetRows.map((r) => ({ ...r, lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id })),
-    [budgetRows, lieuToParent]
+    () => budgetRows.map((r) => ({
+      ...r,
+      lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id,
+      couverts_cible: lieuxIndicatifs.has(r.lieu_service_id) ? 0 : r.couverts_cible,
+    })),
+    [budgetRows, lieuToParent, lieuxIndicatifs]
   )
 
   // Set des dates fermées — étendu sur [1er du mois de `fin`, fin] pour

--- a/components/rapport-hebdo/ComparaisonPanel.js
+++ b/components/rapport-hebdo/ComparaisonPanel.js
@@ -30,7 +30,7 @@ export default function ComparaisonPanel({ c, isMobile, clientId, currentPeriode
     const [y2] = fin.split('-').map(Number)
     const annees = Array.from(new Set([y1, y2]))
     const [lieuxRes, caRes, budgetRes, jfRes, jfhRes] = await Promise.all([
-      supabase.from('lieux_service').select('id, nom, parent_lieu_service_id').eq('client_id', clientId).eq('actif', true),
+      supabase.from('lieux_service').select('id, nom, parent_lieu_service_id, couverts_indicatifs').eq('client_id', clientId).eq('actif', true),
       supabase.from('ca_journalier')
         .select('jour, service, lieu_service_id, couverts, ca_food, ca_bev_20, ca_bev_10, ca_autre')
         .eq('client_id', clientId).gte('jour', debut).lte('jour', fin),
@@ -49,14 +49,26 @@ export default function ComparaisonPanel({ c, isMobile, clientId, currentPeriode
     // → "Salle à manger") pour que les agrégations groupent analytiquement.
     const noms = new Map((lieuxRes.data || []).map((l) => [l.id, l.nom]))
     const lieuToParent = new Map((lieuxRes.data || []).map((l) => [l.id, l.parent_lieu_service_id || l.id]))
+    const lieuxIndicatifs = new Set((lieuxRes.data || []).filter((l) => l.couverts_indicatifs).map((l) => l.id))
     const lieuxMap = new Map((lieuxRes.data || []).map((l) => [
       l.id, noms.get(l.parent_lieu_service_id || l.id) || l.nom,
     ]))
-    // Remappe lieu_service_id sur chaque row vers le parent
-    const remap = (r) => ({ ...r, lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id })
+    // Remappe lieu_service_id sur chaque row vers le parent. Pour les
+    // lieux indicatifs (Marsan Privat), couverts/couverts_cible forcés à
+    // 0 — le CA reste compté.
+    const remapCa = (r) => ({
+      ...r,
+      lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id,
+      couverts: lieuxIndicatifs.has(r.lieu_service_id) ? 0 : r.couverts,
+    })
+    const remapBudget = (r) => ({
+      ...r,
+      lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id,
+      couverts_cible: lieuxIndicatifs.has(r.lieu_service_id) ? 0 : r.couverts_cible,
+    })
     return {
-      caRows: (caRes.data || []).map(remap),
-      budgetRows: (budgetRes.data || []).map(remap),
+      caRows: (caRes.data || []).map(remapCa),
+      budgetRows: (budgetRes.data || []).map(remapBudget),
       lieuxMap,
       joursFermesRows: jfRes.data || [],
       joursFermesHebdoRows: jfhRes.data || [],

--- a/lib/rapportHebdo.js
+++ b/lib/rapportHebdo.js
@@ -185,6 +185,10 @@ export function tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin, jours
     const [lieuId, service] = key.split('_')
     const real = realMap.get(key) || { couverts: 0, ca: 0 }
     const budget = budgetMap.get(key) || { couverts_cible: 0, ca_cible: 0 }
+    // Skip les (lieu, service) sans aucun couvert réel ni budget
+    // (lieu marqué `couverts_indicatifs` côté lieux_service — son CA
+    // est compté ailleurs mais sa ligne TM n'a pas de sens ici).
+    if (real.couverts === 0 && budget.couverts_cible === 0) continue
     const realTm = real.couverts > 0 ? real.ca / real.couverts : null
     const budgetTm = budget.couverts_cible > 0 ? budget.ca_cible / budget.couverts_cible : null
     const delta = realTm != null && budgetTm != null ? realTm - budgetTm : null

--- a/supabase/migrations/20260518000000_lieux_service_couverts_indicatifs.sql
+++ b/supabase/migrations/20260518000000_lieux_service_couverts_indicatifs.sql
@@ -1,0 +1,22 @@
+-- ============================================================================
+-- lieux_service : ajout colonne couverts_indicatifs.
+--
+-- Cas Marsan Privat : les couverts saisis sur le lieu Privat sont
+-- indicatifs (variables d'un événement à l'autre) et faussent les TM
+-- réels du restaurant si on les agrège. Le CA reste compté normalement,
+-- mais les couverts (réels et budget) sont exclus des agrégations
+-- couverts du rapport hebdo.
+--
+-- Effet attendu côté app :
+--   - Tableau couverts jour-par-jour : ignore les couverts Privat
+--   - Total couverts midi/soir : ignore Privat
+--   - TM par lieu × service : Privat n'apparaît plus (CA/0 = N/A)
+--   - TM Food/Bev par service : couverts du dénominateur excluent Privat
+--   - CA TTC, écart budget, Autres CA : INCHANGÉS (Privat reste compté)
+-- ============================================================================
+
+ALTER TABLE public.lieux_service
+  ADD COLUMN IF NOT EXISTS couverts_indicatifs boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.lieux_service.couverts_indicatifs IS
+  'Si true, les couverts saisis sur ce lieu sont indicatifs et ne sont pas comptés dans les agrégations couverts du rapport hebdo. Le CA reste compté. Cas Marsan Privat.';


### PR DESCRIPTION
## Contexte

Sur Marsan, le lieu **Privat** sert aux privatisations. Les couverts y sont saisis à titre indicatif (très variables d'un événement à l'autre) et faussent les agrégations couverts du rapport hebdo. Le CA en revanche doit continuer à être compté.

## Solution

Nouveau flag \`lieux_service.couverts_indicatifs\` (boolean, default false). Quand activé sur un lieu, les couverts (réel + budget) sont mis à 0 en amont du calcul — le CA reste intact.

Migration appliquée. Privat Marsan marqué à \`true\`.

⚠️ Pas d'UI dédiée pour l'instant — pour activer le flag sur d'autres lieux, passe par SQL direct (même approche que \`parent_lieu_service_id\`).

## Effets sur le rapport hebdo

| KPI | Impact |
|---|---|
| CA TTC réel & budget | ✅ inchangé (CA Privat compté) |
| Autres CA (privatisations) | ✅ inchangé |
| Tableau couverts jour-par-jour | 🔄 ignore Privat |
| Total couverts midi/soir | 🔄 ignore Privat |
| Ticket moyen par lieu × service | 🔄 ligne Privat disparaît |
| TM Food/Bev par service | 🔄 dénominateur sans Privat → TM remonte |

## Vérification Marsan semaine 11-17 mai 2026

Couverts budget Privat sur la semaine (jeu+ven dinner = 30, sam lunch = 15) → 45 couverts en moins dans les totaux du tableau jour-par-jour.

## Test plan

- [ ] Recharger /controle-gestion/ventes/rapport-hebdo Marsan
- [ ] Vérifier que le tableau jour-par-jour n'inclut plus les 45 couverts Privat budget de la semaine
- [ ] Vérifier que le CA semaine reste identique (276 760 € cumul mois)
- [ ] Vérifier que la liste \"Ticket moyen par lieu\" ne contient plus de ligne Privat
- [ ] Vérifier que les TM Food/Bev midi/soir sont cohérents (un peu plus élevés qu'avant)
- [ ] Vérifier que JOIA est inchangé (aucun lieu marqué indicatif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)