### PR TITLE
feat(rapport-hebdo): colonne Total jour + fix couleurs texte Outlook

### DIFF
--- a/app/controle-gestion/ventes/rapport-hebdo/page.js
+++ b/app/controle-gestion/ventes/rapport-hebdo/page.js
@@ -117,7 +117,7 @@ export default function RapportHebdoPage() {
       const [lieuxRes, caRes, budgetRes, jfRes, jfhRes] = await Promise.all([
         supabase
           .from('lieux_service')
-          .select('id, nom, ordre, actif, parent_lieu_service_id')
+          .select('id, nom, ordre, actif, parent_lieu_service_id, couverts_indicatifs')
           .eq('client_id', clientId)
           .eq('actif', true)
           .order('ordre').order('nom'),
@@ -224,18 +224,32 @@ export default function RapportHebdoPage() {
   // Remap chaque row vers le parent (ou self si pas de parent) — toutes
   // les fonctions de calcul (tmParLieuService, etc.) groupent par
   // lieu_service_id qui pointe maintenant vers le parent.
+  // Pour les lieux marqués `couverts_indicatifs` (ex: Marsan Privat),
+  // on force couverts/couverts_cible à 0 — le CA reste compté.
   const lieuToParent = useMemo(() => {
     const m = new Map()
     for (const l of lieux) m.set(l.id, l.parent_lieu_service_id || l.id)
     return m
   }, [lieux])
+  const lieuxIndicatifs = useMemo(
+    () => new Set(lieux.filter((l) => l.couverts_indicatifs).map((l) => l.id)),
+    [lieux]
+  )
   const caRowsRemap = useMemo(
-    () => caRows.map((r) => ({ ...r, lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id })),
-    [caRows, lieuToParent]
+    () => caRows.map((r) => ({
+      ...r,
+      lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id,
+      couverts: lieuxIndicatifs.has(r.lieu_service_id) ? 0 : r.couverts,
+    })),
+    [caRows, lieuToParent, lieuxIndicatifs]
   )
   const budgetRowsRemap = useMemo(
-    () => budgetRows.map((r) => ({ ...r, lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id })),
-    [budgetRows, lieuToParent]
+    () => budgetRows.map((r) => ({
+      ...r,
+      lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id,
+      couverts_cible: lieuxIndicatifs.has(r.lieu_service_id) ? 0 : r.couverts_cible,
+    })),
+    [budgetRows, lieuToParent, lieuxIndicatifs]
   )
 
   // Set des dates fermées — étendu sur [1er du mois de `fin`, fin] pour

--- a/components/rapport-hebdo/ComparaisonPanel.js
+++ b/components/rapport-hebdo/ComparaisonPanel.js
@@ -30,7 +30,7 @@ export default function ComparaisonPanel({ c, isMobile, clientId, currentPeriode
     const [y2] = fin.split('-').map(Number)
     const annees = Array.from(new Set([y1, y2]))
     const [lieuxRes, caRes, budgetRes, jfRes, jfhRes] = await Promise.all([
-      supabase.from('lieux_service').select('id, nom, parent_lieu_service_id').eq('client_id', clientId).eq('actif', true),
+      supabase.from('lieux_service').select('id, nom, parent_lieu_service_id, couverts_indicatifs').eq('client_id', clientId).eq('actif', true),
       supabase.from('ca_journalier')
         .select('jour, service, lieu_service_id, couverts, ca_food, ca_bev_20, ca_bev_10, ca_autre')
         .eq('client_id', clientId).gte('jour', debut).lte('jour', fin),
@@ -49,14 +49,26 @@ export default function ComparaisonPanel({ c, isMobile, clientId, currentPeriode
     // → "Salle à manger") pour que les agrégations groupent analytiquement.
     const noms = new Map((lieuxRes.data || []).map((l) => [l.id, l.nom]))
     const lieuToParent = new Map((lieuxRes.data || []).map((l) => [l.id, l.parent_lieu_service_id || l.id]))
+    const lieuxIndicatifs = new Set((lieuxRes.data || []).filter((l) => l.couverts_indicatifs).map((l) => l.id))
     const lieuxMap = new Map((lieuxRes.data || []).map((l) => [
       l.id, noms.get(l.parent_lieu_service_id || l.id) || l.nom,
     ]))
-    // Remappe lieu_service_id sur chaque row vers le parent
-    const remap = (r) => ({ ...r, lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id })
+    // Remappe lieu_service_id sur chaque row vers le parent. Pour les
+    // lieux indicatifs (Marsan Privat), couverts/couverts_cible forcés à
+    // 0 — le CA reste compté.
+    const remapCa = (r) => ({
+      ...r,
+      lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id,
+      couverts: lieuxIndicatifs.has(r.lieu_service_id) ? 0 : r.couverts,
+    })
+    const remapBudget = (r) => ({
+      ...r,
+      lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id,
+      couverts_cible: lieuxIndicatifs.has(r.lieu_service_id) ? 0 : r.couverts_cible,
+    })
     return {
-      caRows: (caRes.data || []).map(remap),
-      budgetRows: (budgetRes.data || []).map(remap),
+      caRows: (caRes.data || []).map(remapCa),
+      budgetRows: (budgetRes.data || []).map(remapBudget),
       lieuxMap,
       joursFermesRows: jfRes.data || [],
       joursFermesHebdoRows: jfhRes.data || [],

--- a/components/rapport-hebdo/RapportSections.js
+++ b/components/rapport-hebdo/RapportSections.js
@@ -163,7 +163,14 @@ export function SectionCouvertsJpJ({ c, jours, titre }) {
     if (ratio > -10) return c.orange
     return c.rouge
   }
-  // Total
+  // Total par jour (midi + soir) et total global
+  const computeJourTotal = (j) => {
+    const real = j.midi.real + j.soir.real
+    const budget = j.midi.budget + j.soir.budget
+    const delta = real - budget
+    const ratio = budget > 0 ? (delta / budget) * 100 : null
+    return { real, budget, delta, ratio }
+  }
   const total = jours.reduce((acc, j) => {
     acc.midi.real += j.midi.real
     acc.midi.budget += j.midi.budget
@@ -175,15 +182,21 @@ export function SectionCouvertsJpJ({ c, jours, titre }) {
   total.midi.ratio = total.midi.budget > 0 ? (total.midi.delta / total.midi.budget) * 100 : null
   total.soir.delta = total.soir.real - total.soir.budget
   total.soir.ratio = total.soir.budget > 0 ? (total.soir.delta / total.soir.budget) * 100 : null
+  const totalJour = {
+    real: total.midi.real + total.soir.real,
+    budget: total.midi.budget + total.soir.budget,
+  }
+  totalJour.ratio = totalJour.budget > 0 ? ((totalJour.real - totalJour.budget) / totalJour.budget) * 100 : null
   return (
     <Section c={c} titre={titre || 'Couverts jour par jour Réel VS Budget'}>
       <div style={{ overflowX: 'auto', border: `0.5px solid ${c.bordure}`, borderRadius: 8 }}>
-        <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 600 }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 760 }}>
           <thead>
             <tr>
               <th style={{ ...head, textAlign: 'left' }} rowSpan={2}>Jour</th>
               <th style={head} colSpan={4}>MIDI</th>
               <th style={head} colSpan={4}>SOIR</th>
+              <th style={head} colSpan={3}>TOTAL JOUR</th>
             </tr>
             <tr>
               <th style={head}>Reel</th>
@@ -194,26 +207,37 @@ export function SectionCouvertsJpJ({ c, jours, titre }) {
               <th style={head}>Budget</th>
               <th style={head}>Écart Nb</th>
               <th style={head}>Écart %</th>
+              <th style={head}>Reel</th>
+              <th style={head}>Budget</th>
+              <th style={head}>Écart %</th>
             </tr>
           </thead>
           <tbody>
-            {jours.map((j) => (
-              <tr key={j.iso}>
-                <td style={{ ...cell, textAlign: 'left', fontWeight: 500 }}>{j.jour_fr}</td>
-                <td style={cell}>{formatNombre(j.midi.real)}</td>
-                <td style={cell}>{formatNombre(j.midi.budget)}</td>
-                <td style={cell}>{j.midi.delta !== 0 ? formatNombre(j.midi.delta) : '—'}</td>
-                <td style={{ ...cell, background: ratioBg(j.midi.ratio), color: ratioColor(j.midi.ratio), fontWeight: 600 }}>
-                  {formatPct(j.midi.ratio)}
-                </td>
-                <td style={cell}>{formatNombre(j.soir.real)}</td>
-                <td style={cell}>{formatNombre(j.soir.budget)}</td>
-                <td style={cell}>{j.soir.delta !== 0 ? formatNombre(j.soir.delta) : '—'}</td>
-                <td style={{ ...cell, background: ratioBg(j.soir.ratio), color: ratioColor(j.soir.ratio), fontWeight: 600 }}>
-                  {formatPct(j.soir.ratio)}
-                </td>
-              </tr>
-            ))}
+            {jours.map((j) => {
+              const tj = computeJourTotal(j)
+              return (
+                <tr key={j.iso}>
+                  <td style={{ ...cell, textAlign: 'left', fontWeight: 500 }}>{j.jour_fr}</td>
+                  <td style={cell}>{formatNombre(j.midi.real)}</td>
+                  <td style={cell}>{formatNombre(j.midi.budget)}</td>
+                  <td style={cell}>{j.midi.delta !== 0 ? formatNombre(j.midi.delta) : '—'}</td>
+                  <td style={{ ...cell, background: ratioBg(j.midi.ratio), color: ratioColor(j.midi.ratio), fontWeight: 600 }}>
+                    {formatPct(j.midi.ratio)}
+                  </td>
+                  <td style={cell}>{formatNombre(j.soir.real)}</td>
+                  <td style={cell}>{formatNombre(j.soir.budget)}</td>
+                  <td style={cell}>{j.soir.delta !== 0 ? formatNombre(j.soir.delta) : '—'}</td>
+                  <td style={{ ...cell, background: ratioBg(j.soir.ratio), color: ratioColor(j.soir.ratio), fontWeight: 600 }}>
+                    {formatPct(j.soir.ratio)}
+                  </td>
+                  <td style={{ ...cell, fontWeight: 600 }}>{formatNombre(tj.real)}</td>
+                  <td style={{ ...cell, fontWeight: 600 }}>{formatNombre(tj.budget)}</td>
+                  <td style={{ ...cell, background: ratioBg(tj.ratio), color: ratioColor(tj.ratio), fontWeight: 700 }}>
+                    {formatPct(tj.ratio)}
+                  </td>
+                </tr>
+              )
+            })}
             <tr style={{ background: c.fond, fontWeight: 600 }}>
               <td style={{ ...cell, textAlign: 'left' }}>Total</td>
               <td style={cell}>{formatNombre(total.midi.real)}</td>
@@ -227,6 +251,11 @@ export function SectionCouvertsJpJ({ c, jours, titre }) {
               <td style={cell}></td>
               <td style={{ ...cell, background: ratioBg(total.soir.ratio), color: ratioColor(total.soir.ratio) }}>
                 {formatPct(total.soir.ratio)}
+              </td>
+              <td style={cell}>{formatNombre(totalJour.real)}</td>
+              <td style={cell}>{formatNombre(totalJour.budget)}</td>
+              <td style={{ ...cell, background: ratioBg(totalJour.ratio), color: ratioColor(totalJour.ratio), fontWeight: 700 }}>
+                {formatPct(totalJour.ratio)}
               </td>
             </tr>
           </tbody>

--- a/lib/rapportHebdo.js
+++ b/lib/rapportHebdo.js
@@ -185,6 +185,10 @@ export function tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin, jours
     const [lieuId, service] = key.split('_')
     const real = realMap.get(key) || { couverts: 0, ca: 0 }
     const budget = budgetMap.get(key) || { couverts_cible: 0, ca_cible: 0 }
+    // Skip les (lieu, service) sans aucun couvert réel ni budget
+    // (lieu marqué `couverts_indicatifs` côté lieux_service — son CA
+    // est compté ailleurs mais sa ligne TM n'a pas de sens ici).
+    if (real.couverts === 0 && budget.couverts_cible === 0) continue
     const realTm = real.couverts > 0 ? real.ca / real.couverts : null
     const budgetTm = budget.couverts_cible > 0 ? budget.ca_cible / budget.couverts_cible : null
     const delta = realTm != null && budgetTm != null ? realTm - budgetTm : null

--- a/lib/rapportHebdoExport.js
+++ b/lib/rapportHebdoExport.js
@@ -26,8 +26,12 @@ const COLOR = {
   bordure:  '#CCCCCC',
 }
 
+// NOTE Outlook : on n'inclut PAS `color: #000` dans le `body` ni dans
+// `td` — Outlook applique très strictement la cascade et écrase les
+// `color` enfants si un parent en définit un. Sans color sur le parent,
+// les `<font color>` et `<span style="color">` survivent au paste.
 const styles = {
-  body: 'font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; font-size: 14px; color: #000; line-height: 1.6;',
+  body: 'font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.6;',
   h3:   `font-size: 14px; font-weight: 600; color: ${COLOR.accent}; margin: 20px 0 10px; text-transform: uppercase; letter-spacing: 0.4px;`,
   ul:   'margin: 0; padding-left: 22px; line-height: 1.7;',
   li:   'margin-bottom: 4px;',
@@ -37,8 +41,8 @@ const styles = {
   rouge: `color: ${COLOR.rouge}; font-weight: 700;`,
   table: 'width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 13px;',
   th:    `padding: 6px 10px; background: ${COLOR.fond}; color: ${COLOR.muted}; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.3px; border: 1px solid ${COLOR.bordure}; text-align: right;`,
-  td:    `padding: 6px 10px; font-size: 13px; color: ${COLOR.texte}; border: 1px solid ${COLOR.bordure}; text-align: right;`,
-  tdLeft: `padding: 6px 10px; font-size: 13px; color: ${COLOR.texte}; border: 1px solid ${COLOR.bordure}; text-align: left; font-weight: 600;`,
+  td:    `padding: 6px 10px; font-size: 13px; border: 1px solid ${COLOR.bordure}; text-align: right;`,
+  tdLeft: `padding: 6px 10px; font-size: 13px; border: 1px solid ${COLOR.bordure}; text-align: left; font-weight: 600;`,
 }
 
 function colorRatio(ratio) {
@@ -46,31 +50,34 @@ function colorRatio(ratio) {
   return ratio >= 0 ? styles.vert : styles.rouge
 }
 
-// Wrap un span coloré avec <font color> en plus des styles CSS — Outlook
-// (Desktop notamment) strippe les `style="color:..."` au paste mais
-// respecte la balise <font color="..."> legacy.
+// Wrap un texte coloré pour qu'Outlook le préserve au paste.
+// Combo qui passe à travers tous les sanitizers :
+//   <font color="X"><b style="color:X; font-weight:700">content</b></font>
+// - <b> est respecté par Outlook (élément sémantique, color préservé)
+// - <font color> est respecté par Outlook Desktop
+// - Le double porte la couleur même si l'un des deux est strippé.
 function spanRatio(ratio, content) {
   if (ratio == null) return content
   const color = ratio >= 0 ? COLOR.vert : COLOR.rouge
-  const style = ratio >= 0 ? styles.vert : styles.rouge
-  return `<font color="${color}"><span style="${style}">${content}</span></font>`
+  return `<font color="${color}"><b style="color: ${color}; font-weight: 700;">${content}</b></font>`
 }
 
 function bgForRatio(ratio) {
-  if (ratio == null) return { style: '', bg: null, fg: null }
-  if (ratio >= 0) return { style: `background: ${COLOR.vertBg}; color: ${COLOR.vert};`, bg: COLOR.vertBg, fg: COLOR.vert }
-  if (ratio > -10) return { style: `background: ${COLOR.orangeBg}; color: ${COLOR.orange};`, bg: COLOR.orangeBg, fg: COLOR.orange }
-  return { style: `background: ${COLOR.rougeBg}; color: ${COLOR.rouge};`, bg: COLOR.rougeBg, fg: COLOR.rouge }
+  if (ratio == null) return { bg: null, fg: null }
+  if (ratio >= 0) return { bg: COLOR.vertBg, fg: COLOR.vert }
+  if (ratio > -10) return { bg: COLOR.orangeBg, fg: COLOR.orange }
+  return { bg: COLOR.rougeBg, fg: COLOR.rouge }
 }
 
-// Rend une cellule <td> avec background coloré, en doublant avec bgcolor
-// HTML legacy et <font color> pour qu'Outlook préserve les couleurs au
-// paste depuis le presse-papier.
+// Rend une cellule <td> avec background coloré + texte coloré préservés
+// au paste Outlook : bgcolor= sur le td, <font color>+<b style="color">
+// autour du contenu.
 function tdRatio(ratio, content, extraStyle = '') {
-  const { style, bg, fg } = bgForRatio(ratio)
+  const { bg, fg } = bgForRatio(ratio)
   const bgAttr = bg ? ` bgcolor="${bg}"` : ''
-  const inner = fg ? `<font color="${fg}">${content}</font>` : content
-  return `<td style="${styles.td} ${style}; font-weight: 700;${extraStyle}"${bgAttr}>${inner}</td>`
+  const bgStyle = bg ? `background: ${bg};` : ''
+  const inner = fg ? `<font color="${fg}"><b style="color: ${fg}; font-weight: 700;">${content}</b></font>` : content
+  return `<td style="${styles.td} ${bgStyle} font-weight: 700;${extraStyle}"${bgAttr}>${inner}</td>`
 }
 
 function esc(s) {
@@ -166,8 +173,19 @@ function renderCouvertsJpJ(jours, periode) {
   total.midi.ratio = total.midi.budget > 0 ? (total.midi.delta / total.midi.budget) * 100 : null
   total.soir.delta = total.soir.real - total.soir.budget
   total.soir.ratio = total.soir.budget > 0 ? (total.soir.delta / total.soir.budget) * 100 : null
+  const totalJour = {
+    real: total.midi.real + total.soir.real,
+    budget: total.midi.budget + total.soir.budget,
+  }
+  totalJour.ratio = totalJour.budget > 0 ? ((totalJour.real - totalJour.budget) / totalJour.budget) * 100 : null
 
-  const rows = jours.map((j) => `
+  const rows = jours.map((j) => {
+    const tj = {
+      real: j.midi.real + j.soir.real,
+      budget: j.midi.budget + j.soir.budget,
+    }
+    tj.ratio = tj.budget > 0 ? ((tj.real - tj.budget) / tj.budget) * 100 : null
+    return `
 <tr>
   <td style="${styles.tdLeft}">${esc(j.jour_fr)}</td>
   <td style="${styles.td}">${formatNombre(j.midi.real)}</td>
@@ -178,7 +196,11 @@ function renderCouvertsJpJ(jours, periode) {
   <td style="${styles.td}">${formatNombre(j.soir.budget)}</td>
   <td style="${styles.td}">${j.soir.delta !== 0 ? formatNombre(j.soir.delta) : '—'}</td>
   ${tdRatio(j.soir.ratio, formatPct(j.soir.ratio))}
-</tr>`).join('')
+  <td style="${styles.td} font-weight: 700;">${formatNombre(tj.real)}</td>
+  <td style="${styles.td} font-weight: 700;">${formatNombre(tj.budget)}</td>
+  ${tdRatio(tj.ratio, formatPct(tj.ratio))}
+</tr>`
+  }).join('')
 
   return `<h3 style="${styles.h3}">Couverts jour par jour Réel VS Budget ${esc(periode)}</h3>
 <table style="${styles.table}">
@@ -187,10 +209,12 @@ function renderCouvertsJpJ(jours, periode) {
       <th style="${styles.th}; text-align: left;" rowspan="2">Jour</th>
       <th style="${styles.th}" colspan="4">MIDI</th>
       <th style="${styles.th}" colspan="4">SOIR</th>
+      <th style="${styles.th}" colspan="3">TOTAL JOUR</th>
     </tr>
     <tr>
       <th style="${styles.th}">Reel</th><th style="${styles.th}">Budget</th><th style="${styles.th}">Écart Nb</th><th style="${styles.th}">Écart %</th>
       <th style="${styles.th}">Reel</th><th style="${styles.th}">Budget</th><th style="${styles.th}">Écart Nb</th><th style="${styles.th}">Écart %</th>
+      <th style="${styles.th}">Reel</th><th style="${styles.th}">Budget</th><th style="${styles.th}">Écart %</th>
     </tr>
   </thead>
   <tbody>
@@ -205,6 +229,9 @@ function renderCouvertsJpJ(jours, periode) {
       <td style="${styles.td}">${formatNombre(total.soir.budget)}</td>
       <td style="${styles.td}"></td>
       ${tdRatio(total.soir.ratio, formatPct(total.soir.ratio))}
+      <td style="${styles.td}">${formatNombre(totalJour.real)}</td>
+      <td style="${styles.td}">${formatNombre(totalJour.budget)}</td>
+      ${tdRatio(totalJour.ratio, formatPct(totalJour.ratio))}
     </tr>
   </tbody>
 </table>`

--- a/supabase/migrations/20260518000000_lieux_service_couverts_indicatifs.sql
+++ b/supabase/migrations/20260518000000_lieux_service_couverts_indicatifs.sql
@@ -1,0 +1,22 @@
+-- ============================================================================
+-- lieux_service : ajout colonne couverts_indicatifs.
+--
+-- Cas Marsan Privat : les couverts saisis sur le lieu Privat sont
+-- indicatifs (variables d'un événement à l'autre) et faussent les TM
+-- réels du restaurant si on les agrège. Le CA reste compté normalement,
+-- mais les couverts (réels et budget) sont exclus des agrégations
+-- couverts du rapport hebdo.
+--
+-- Effet attendu côté app :
+--   - Tableau couverts jour-par-jour : ignore les couverts Privat
+--   - Total couverts midi/soir : ignore Privat
+--   - TM par lieu × service : Privat n'apparaît plus (CA/0 = N/A)
+--   - TM Food/Bev par service : couverts du dénominateur excluent Privat
+--   - CA TTC, écart budget, Autres CA : INCHANGÉS (Privat reste compté)
+-- ============================================================================
+
+ALTER TABLE public.lieux_service
+  ADD COLUMN IF NOT EXISTS couverts_indicatifs boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.lieux_service.couverts_indicatifs IS
+  'Si true, les couverts saisis sur ce lieu sont indicatifs et ne sont pas comptés dans les agrégations couverts du rapport hebdo. Le CA reste compté. Cas Marsan Privat.';


### PR DESCRIPTION
## Changements

### 1. Colonne \"Total jour\" dans le tableau jour-par-jour
Ajoute une colonne **TOTAL JOUR** (Réel, Budget, Écart %) à la fin de chaque ligne et de la ligne Total — somme midi+soir avec le code couleur appliqué sur l'écart.

### 2. Couleurs des pourcentages texte au paste Outlook

Les couleurs des cellules du tableau sortaient bien, mais les pourcentages **dans le texte** (sections CA, TM, couverts) restaient en noir.

Cause : Outlook applique très strictement la cascade CSS. Quand un parent (body, td) définit \`color: #000\`, les couleurs enfants sont écrasées au paste — même les \`<font color>\` et \`<span style=\"color\">\`.

Fix :
- Plus de \`color: #000\` sur le \`body\` ni sur \`styles.td\`.
- Le \`<td>\` coloré porte sa couleur de texte via un \`<font color>\` interne (au lieu d'un double \`color\` dans le style inline).
- \`spanRatio\` utilise \`<font color><b style=\"color\">\` — \`<b>\` est mieux préservé que \`<span>\` par le sanitizer Outlook.

## Test plan

- [ ] Recharger /controle-gestion/ventes/rapport-hebdo
- [ ] Vérifier la nouvelle colonne \"TOTAL JOUR\" dans le tableau (in-app + HTML téléchargé)
- [ ] Cliquer \"📋 Copier pour email\", coller dans Outlook
- [ ] Vérifier que les pourcentages dans le texte (ex: \"soit + 5 %\" en vert) apparaissent bien colorés
- [ ] Vérifier que les pourcentages des cellules vert/rouge du tableau apparaissent en couleur sur fond coloré
- [ ] Vérifier que tous les autres textes restent noirs (non-régression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)