### PR TITLE
feat(achats): fusion multi-BL en une facture consolidée

### DIFF
--- a/app/api/achats/fusionner-bl/route.ts
+++ b/app/api/achats/fusionner-bl/route.ts
@@ -1,0 +1,13 @@
+import { apiHandler } from '../../../../lib/apiHandler'
+import { fusionnerBlsSchema } from '../../../../lib/validators/achats.schema'
+import { fusionnerBls } from '../../../../lib/services/achats.service'
+
+export const POST = apiHandler({
+  schema: fusionnerBlsSchema,
+  guard: 'adminOrSuperadmin',
+  clientIdFrom: 'body.clientId',
+  handler: async ({ data, user, db }) => {
+    const result = await fusionnerBls(db, data, user!.id)
+    return Response.json(result)
+  },
+})

--- a/app/controle-gestion/achats/[id]/page.js
+++ b/app/controle-gestion/achats/[id]/page.js
@@ -33,6 +33,9 @@ export default function AchatsDetailPage() {
   const [authReady, setAuthReady] = useState(false)
   const [clientId, setClientId] = useState(null)
   const [facture, setFacture] = useState(null)
+  // Si ce BL a été fusionné, on garde un mini-récap de la facture cible
+  // pour afficher la bannière + lien.
+  const [factureConsolidee, setFactureConsolidee] = useState(null)
   const [lignes, setLignes] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -83,7 +86,7 @@ export default function AchatsDetailPage() {
 
     const { data: fac, error: fErr } = await supabase
       .from('achats_factures')
-      .select('id, fournisseur, numero_facture, date_facture, total_ht, statut, taux_tva, montant_tva, fichier_url, created_at')
+      .select('id, fournisseur, numero_facture, date_facture, total_ht, statut, taux_tva, montant_tva, fichier_url, facture_consolidee_id, created_at')
       .eq('id', id)
       .eq('client_id', clientId)
       .maybeSingle()
@@ -91,6 +94,19 @@ export default function AchatsDetailPage() {
     if (fErr) { setError(fErr.message); setLoading(false); return }
     if (!fac) { setError('Facture introuvable.'); setLoading(false); return }
     setFacture(fac)
+
+    // Si ce BL a été fusionné, charge un mini-récap de la facture cible
+    if (fac.facture_consolidee_id) {
+      const { data: parent } = await supabase
+        .from('achats_factures')
+        .select('id, numero_facture, date_facture')
+        .eq('id', fac.facture_consolidee_id)
+        .eq('client_id', clientId)
+        .maybeSingle()
+      setFactureConsolidee(parent || null)
+    } else {
+      setFactureConsolidee(null)
+    }
 
     const { data: rows, error: lErr } = await supabase
       .from('achats_lignes')
@@ -281,6 +297,7 @@ export default function AchatsDetailPage() {
 
   const ht = facture ? Number(facture.total_ht) || 0 : 0
   const isBl = facture?.statut === 'bl'
+  const estFusionne = !!facture?.facture_consolidee_id
 
   const th  = { padding: isMobile ? '10px 8px' : '11px 14px', textAlign: 'left',  fontWeight: 600, fontSize: 11, color: c.texteMuted, textTransform: 'uppercase', borderBottom: `1px solid ${c.bordure}`, whiteSpace: 'nowrap' }
   const thR = { ...th, textAlign: 'right' }
@@ -305,7 +322,7 @@ export default function AchatsDetailPage() {
           />
           {role === 'admin' && !loading && facture && (
             <div style={{ display: 'flex', gap: 8 }}>
-              {isBl && (
+              {isBl && !estFusionne && (
                 <button onClick={handleConfirmFacture} disabled={saving}
                   style={{ padding: '7px 14px', borderRadius: 8, fontSize: 13, border: 'none', background: '#059669', color: '#fff', cursor: 'pointer', fontWeight: 500 }}>
                   ✓ Confirmer comme facture
@@ -325,6 +342,36 @@ export default function AchatsDetailPage() {
 
         {error && <p style={{ color: '#B91C1C', fontSize: 14, margin: '8px 0' }}>{error}</p>}
         {loading && <p style={{ color: c.texteMuted, fontSize: 14 }}>Chargement…</p>}
+
+        {/* Bannière BL fusionné — pointe vers la facture consolidée */}
+        {estFusionne && (
+          <div style={{
+            margin: '12px 0', padding: '10px 14px', borderRadius: 8,
+            background: '#FEF3C7', border: '1px solid #F59E0B', color: '#78350F',
+            fontSize: 13, display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap',
+          }}>
+            <span>📎</span>
+            <span style={{ flex: 1, minWidth: 0 }}>
+              Ce BL a été fusionné dans la facture
+              {factureConsolidee?.numero_facture ? <strong> {factureConsolidee.numero_facture}</strong> : ' consolidée'}
+              {factureConsolidee?.date_facture && (
+                <span style={{ opacity: 0.75 }}> du {new Date(factureConsolidee.date_facture).toLocaleDateString('fr-FR')}</span>
+              )}
+              . Ses lignes et totaux ont été transférés (ce BL n&apos;est plus compté pour éviter le double-comptage).
+            </span>
+            {factureConsolidee?.id && (
+              <button
+                onClick={() => router.push(`/controle-gestion/achats/${factureConsolidee.id}`)}
+                style={{
+                  padding: '5px 10px', borderRadius: 6, fontSize: 12, fontWeight: 600,
+                  border: '1px solid #F59E0B', background: '#FBBF24', color: '#78350F', cursor: 'pointer',
+                }}
+              >
+                Voir la facture →
+              </button>
+            )}
+          </div>
+        )}
 
         {!loading && facture && (
           <>

--- a/app/controle-gestion/achats/page.js
+++ b/app/controle-gestion/achats/page.js
@@ -80,6 +80,11 @@ export default function AchatsListPage() {
   })
   const [deleting, setDeleting] = useState(null)
   const [exporting, setExporting] = useState(false)
+  // Sélection multi-BL pour fusion en une facture consolidée.
+  // Set des id de BL cochés. Modal de fusion conditionnée à ≥ 2 sélectionnés.
+  const [selectedBlIds, setSelectedBlIds] = useState(() => new Set())
+  const [fusionModalOpen, setFusionModalOpen] = useState(false)
+  const [fusionning, setFusionning] = useState(false)
   // Tri : colonne active + sens. Par défaut : date décroissante (= comportement
   // du .order() côté query Supabase).
   const [sortBy, setSortBy] = useState(() => searchParams.get('tri') || 'date_facture')
@@ -134,7 +139,7 @@ export default function AchatsListPage() {
 
     const { data: rows, error: fErr } = await supabase
       .from('achats_factures')
-      .select('id, fournisseur, numero_facture, date_facture, total_ht, taux_tva, montant_tva, statut, created_at')
+      .select('id, fournisseur, numero_facture, date_facture, total_ht, taux_tva, montant_tva, statut, facture_consolidee_id, created_at')
       .eq('client_id', cid)
       .is('deleted_at', null)
       .order('date_facture', { ascending: false })
@@ -217,6 +222,60 @@ export default function AchatsListPage() {
       setError(`Export impossible : ${err.message}`)
     } finally {
       setExporting(false)
+    }
+  }
+
+  // Toggle d'une case BL. Garantit qu'on ne coche que des BL non fusionnés.
+  const toggleSelect = (id, e) => {
+    e.stopPropagation()
+    setSelectedBlIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+  const clearSelection = () => setSelectedBlIds(new Set())
+
+  // Stats sur la sélection courante : nb, fournisseurs distincts, totaux.
+  const selectedBls = factures.filter((f) => selectedBlIds.has(f.id))
+  const selectedFournisseurs = [...new Set(selectedBls.map((b) => (b.fournisseur || '').trim().toLowerCase()).filter(Boolean))]
+  const sameFournisseur = selectedFournisseurs.length <= 1
+  const selectedTotalHt = selectedBls.reduce((s, b) => s + (Number(b.total_ht) || 0), 0)
+  const selectedTotalTva = selectedBls.reduce((s, b) => s + (tvaByFacture[b.id] || 0), 0)
+
+  const handleFusion = async (numero, date, totalHt, montantTva) => {
+    if (!clientId || selectedBlIds.size < 2) return
+    setFusionning(true)
+    setError('')
+    try {
+      const { data: { session } } = await supabase.auth.getSession()
+      const res = await fetch('/api/achats/fusionner-bl', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
+        body: JSON.stringify({
+          clientId,
+          blIds: [...selectedBlIds],
+          numeroFacture: numero,
+          dateFacture: date,
+          totalHt,
+          montantTva: montantTva ?? null,
+        }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error(j.error || j.message || 'Erreur lors de la fusion')
+      }
+      const result = await res.json()
+      setFusionModalOpen(false)
+      clearSelection()
+      await loadFactures()
+      // Redirige vers la facture créée pour vérif rapide
+      if (result.facture_id) router.push(`/controle-gestion/achats/${result.facture_id}`)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setFusionning(false)
     }
   }
 
@@ -571,20 +630,35 @@ export default function AchatsListPage() {
                   const ttc = ht + tva
                   const nb = nbLignesByFacture[f.id] ?? 0
                   const badgeStyle = badgeStyleFor(f.statut)
+                  const isSelectableBl = role === 'admin' && f.statut === 'bl' && !f.facture_consolidee_id
+                  const isSelected = selectedBlIds.has(f.id)
                   return (
                     <div
                       key={f.id}
                       onClick={() => router.push(`/controle-gestion/achats/${f.id}`)}
                       style={{
-                        background: c.blanc, borderRadius: 10, border: `0.5px solid ${c.bordure}`,
+                        background: isSelected ? c.accentClair : c.blanc, borderRadius: 10,
+                        border: `${isSelected ? '1.5px' : '0.5px'} solid ${isSelected ? c.accent : c.bordure}`,
                         padding: '14px 16px', cursor: 'pointer',
                       }}
                     >
-                      {/* Ligne 1 : fournisseur + badge */}
-                      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
-                        <span style={{ fontSize: 15, fontWeight: 600, color: c.texte }}>
-                          {f.fournisseur || <span style={{ color: c.texteMuted, fontWeight: 400 }}>—</span>}
-                        </span>
+                      {/* Ligne 1 : checkbox (BL seul) + fournisseur + badge */}
+                      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6, gap: 8 }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0, flex: 1 }}>
+                          {isSelectableBl && (
+                            <input
+                              type="checkbox"
+                              checked={isSelected}
+                              onChange={(e) => toggleSelect(f.id, e)}
+                              onClick={(e) => e.stopPropagation()}
+                              style={{ cursor: 'pointer', width: 18, height: 18 }}
+                              aria-label={`Sélectionner BL ${f.numero_facture || ''}`}
+                            />
+                          )}
+                          <span style={{ fontSize: 15, fontWeight: 600, color: c.texte, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                            {f.fournisseur || <span style={{ color: c.texteMuted, fontWeight: 400 }}>—</span>}
+                          </span>
+                        </div>
                         <span style={badgeStyle}>{statutLabel(f.statut)}</span>
                       </div>
                       {/* Ligne 2 : n° facture · date */}
@@ -629,6 +703,7 @@ export default function AchatsListPage() {
                   <table style={{ width: '100%', borderCollapse: 'collapse' }}>
                     <thead>
                       <tr style={{ background: c.fond }}>
+                        {role === 'admin' && <th style={{ ...th, width: 32, padding: '11px 8px' }} aria-label="Sélection" />}
                         <SortHeader col="fournisseur"    label="Fournisseur" baseStyle={th}  sortBy={sortBy} sortDir={sortDir} onSort={handleSort} c={c} />
                         <SortHeader col="numero_facture" label="N° Facture"  baseStyle={th}  sortBy={sortBy} sortDir={sortDir} onSort={handleSort} c={c} />
                         <SortHeader col="date_facture"   label="Date"        baseStyle={th}  sortBy={sortBy} sortDir={sortDir} onSort={handleSort} c={c} />
@@ -646,18 +721,33 @@ export default function AchatsListPage() {
                         const tva = tvaByFacture[f.id] || 0
                         const ttc = ht + tva
                         const nb = nbLignesByFacture[f.id] ?? 0
+                        const isSelectableBl = role === 'admin' && f.statut === 'bl' && !f.facture_consolidee_id
+                        const isSelected = selectedBlIds.has(f.id)
                         return (
                           <tr
                             key={f.id}
                             onClick={() => router.push(`/controle-gestion/achats/${f.id}`)}
                             style={{
                               cursor: 'pointer',
-                              background: i % 2 === 0 ? c.blanc : c.fond,
+                              background: isSelected ? c.accentClair : (i % 2 === 0 ? c.blanc : c.fond),
                               transition: 'background 0.12s',
                             }}
-                            onMouseEnter={(e) => e.currentTarget.style.background = c.accentClair}
-                            onMouseLeave={(e) => e.currentTarget.style.background = i % 2 === 0 ? c.blanc : c.fond}
+                            onMouseEnter={(e) => { if (!isSelected) e.currentTarget.style.background = c.accentClair }}
+                            onMouseLeave={(e) => { if (!isSelected) e.currentTarget.style.background = i % 2 === 0 ? c.blanc : c.fond }}
                           >
+                            {role === 'admin' && (
+                              <td style={{ ...td, padding: '11px 8px', textAlign: 'center' }} onClick={(e) => e.stopPropagation()}>
+                                {isSelectableBl ? (
+                                  <input
+                                    type="checkbox"
+                                    checked={isSelected}
+                                    onChange={(e) => toggleSelect(f.id, e)}
+                                    style={{ cursor: 'pointer', width: 16, height: 16 }}
+                                    aria-label={`Sélectionner BL ${f.numero_facture || ''}`}
+                                  />
+                                ) : null}
+                              </td>
+                            )}
                             <td style={{ ...td, fontWeight: 500 }}>
                               {f.fournisseur || <span style={{ color: c.texteMuted }}>—</span>}
                             </td>
@@ -687,6 +777,7 @@ export default function AchatsListPage() {
                     </tbody>
                     <tfoot>
                       <tr style={{ fontWeight: 600, background: c.fond }}>
+                        {role === 'admin' && <td style={td} />}
                         <td style={{ ...td, color: c.texte }}>
                           {facturesFiltrees.length} facture{facturesFiltrees.length !== 1 ? 's' : ''}
                         </td>
@@ -704,6 +795,190 @@ export default function AchatsListPage() {
           </>
         )}
       </div>
+
+      {/* Barre flottante de fusion (visible dès qu'au moins 1 BL est coché) */}
+      {selectedBlIds.size > 0 && (
+        <div style={{
+          position: 'fixed', left: 16, right: 16, bottom: 16,
+          maxWidth: 720, margin: '0 auto',
+          background: c.blanc, borderRadius: 12,
+          border: `1px solid ${c.bordure}`,
+          boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
+          padding: '12px 16px',
+          display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap',
+          zIndex: 50,
+        }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 14, fontWeight: 600, color: c.texte }}>
+              {selectedBlIds.size} BL sélectionné{selectedBlIds.size > 1 ? 's' : ''}
+              {sameFournisseur && selectedBls[0]?.fournisseur && (
+                <span style={{ fontWeight: 400, color: c.texteMuted, marginLeft: 6 }}>
+                  — {selectedBls[0].fournisseur}
+                </span>
+              )}
+            </div>
+            <div style={{ fontSize: 12, color: c.texteMuted, marginTop: 2 }}>
+              {sameFournisseur
+                ? `Total HT : ${formatEuro(selectedTotalHt)} · TVA : ${formatEuro(selectedTotalTva)}`
+                : `⚠ Fournisseurs différents (${selectedFournisseurs.length}) — fusion impossible`}
+            </div>
+          </div>
+          <button
+            onClick={clearSelection}
+            style={{
+              padding: '8px 14px', borderRadius: 8, fontSize: 13,
+              border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte, cursor: 'pointer',
+            }}
+          >
+            Annuler
+          </button>
+          <button
+            onClick={() => setFusionModalOpen(true)}
+            disabled={selectedBlIds.size < 2 || !sameFournisseur}
+            title={
+              selectedBlIds.size < 2 ? 'Sélectionne au moins 2 BL'
+              : !sameFournisseur ? 'Tous les BL doivent être du même fournisseur'
+              : 'Fusionner les BL sélectionnés en une facture'
+            }
+            style={{
+              padding: '8px 16px', borderRadius: 8, fontSize: 13,
+              border: 'none',
+              background: (selectedBlIds.size < 2 || !sameFournisseur) ? c.bordure : c.accent,
+              color: c.texte, fontWeight: 600,
+              cursor: (selectedBlIds.size < 2 || !sameFournisseur) ? 'not-allowed' : 'pointer',
+              opacity: (selectedBlIds.size < 2 || !sameFournisseur) ? 0.6 : 1,
+            }}
+          >
+            Fusionner en facture →
+          </button>
+        </div>
+      )}
+
+      {/* Modal de fusion */}
+      {fusionModalOpen && (
+        <FusionModal
+          c={c}
+          isMobile={isMobile}
+          selectedBls={selectedBls}
+          totalHt={selectedTotalHt}
+          totalTva={selectedTotalTva}
+          onClose={() => setFusionModalOpen(false)}
+          onSubmit={handleFusion}
+          submitting={fusionning}
+        />
+      )}
+    </div>
+  )
+}
+
+// ── Modal de fusion BL → facture ──────────────────────────────────────────
+// Pré-rempli avec les sommes des BL sélectionnés. L'utilisateur peut
+// ajuster numero, date, HT et TVA avant validation.
+function FusionModal({ c, isMobile, selectedBls, totalHt, totalTva, onClose, onSubmit, submitting }) {
+  const [numero, setNumero] = useState('')
+  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10))
+  const [ht, setHt] = useState(() => Number(totalHt || 0).toFixed(2))
+  const [tva, setTva] = useState(() => Number(totalTva || 0).toFixed(2))
+  const ttc = (Number(ht) || 0) + (Number(tva) || 0)
+
+  const submit = (e) => {
+    e.preventDefault()
+    if (!numero.trim() || !date) return
+    onSubmit(numero.trim(), date, Number(ht) || 0, Number(tva) || 0)
+  }
+
+  const input = {
+    width: '100%', padding: '8px 10px', borderRadius: 8,
+    border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte,
+    fontSize: 14, boxSizing: 'border-box',
+  }
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.4)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        padding: 16, zIndex: 100,
+      }}
+    >
+      <form
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={submit}
+        style={{
+          background: c.blanc, borderRadius: 12, padding: isMobile ? 16 : 24,
+          maxWidth: 480, width: '100%',
+          maxHeight: '90vh', overflowY: 'auto',
+        }}
+      >
+        <h2 style={{ margin: '0 0 4px', fontSize: 18, fontWeight: 600, color: c.texte }}>
+          Fusionner {selectedBls.length} BL en facture
+        </h2>
+        <p style={{ margin: '0 0 16px', fontSize: 13, color: c.texteMuted }}>
+          Fournisseur : <strong style={{ color: c.texte }}>{selectedBls[0]?.fournisseur || '—'}</strong><br />
+          Les lignes des BL seront déplacées vers la nouvelle facture, et les BL passeront à zéro.
+        </p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <label style={{ display: 'block' }}>
+            <div style={{ fontSize: 12, color: c.texteMuted, marginBottom: 4 }}>N° facture *</div>
+            <input
+              type="text" value={numero} onChange={(e) => setNumero(e.target.value)}
+              placeholder="ex: FA-2026-042" required style={input}
+            />
+          </label>
+          <label style={{ display: 'block' }}>
+            <div style={{ fontSize: 12, color: c.texteMuted, marginBottom: 4 }}>Date facture *</div>
+            <input type="date" value={date} onChange={(e) => setDate(e.target.value)} required style={input} />
+          </label>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 10 }}>
+            <label>
+              <div style={{ fontSize: 12, color: c.texteMuted, marginBottom: 4 }}>Total HT</div>
+              <input
+                type="number" step="0.01" value={ht}
+                onChange={(e) => setHt(e.target.value)} style={input}
+              />
+            </label>
+            <label>
+              <div style={{ fontSize: 12, color: c.texteMuted, marginBottom: 4 }}>Montant TVA</div>
+              <input
+                type="number" step="0.01" value={tva}
+                onChange={(e) => setTva(e.target.value)} style={input}
+              />
+            </label>
+            <label>
+              <div style={{ fontSize: 12, color: c.texteMuted, marginBottom: 4 }}>TTC (auto)</div>
+              <input
+                type="text" readOnly value={ttc.toFixed(2)}
+                style={{ ...input, background: c.fond, color: c.texteMuted }}
+              />
+            </label>
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 20 }}>
+          <button
+            type="button" onClick={onClose} disabled={submitting}
+            style={{
+              padding: '8px 14px', borderRadius: 8, fontSize: 13,
+              border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte, cursor: 'pointer',
+            }}
+          >
+            Annuler
+          </button>
+          <button
+            type="submit" disabled={submitting || !numero.trim() || !date}
+            style={{
+              padding: '8px 16px', borderRadius: 8, fontSize: 13,
+              border: 'none', background: c.accent, color: c.texte, fontWeight: 600,
+              cursor: submitting ? 'wait' : 'pointer',
+              opacity: (submitting || !numero.trim() || !date) ? 0.6 : 1,
+            }}
+          >
+            {submitting ? 'Création…' : 'Créer la facture'}
+          </button>
+        </div>
+      </form>
     </div>
   )
 }

--- a/lib/services/achats.service.ts
+++ b/lib/services/achats.service.ts
@@ -4,7 +4,7 @@
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { SaveFactureInput, CreateIngredientInput, BulkImportHeadersInput } from '../validators/achats.schema'
+import type { SaveFactureInput, CreateIngredientInput, BulkImportHeadersInput, FusionnerBlsInput } from '../validators/achats.schema'
 import { ConflictError, ValidationError, NotFoundError } from '../errors'
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -531,6 +531,126 @@ export async function updateFacture(
 
   if (error) throw new Error(error.message)
   return { updated: true }
+}
+
+/**
+ * Fusionne plusieurs BL en une seule facture consolidée.
+ *
+ * Comportement :
+ *   1. Vérifie : tous les BL appartiennent au client, statut='bl', non
+ *      supprimés, non déjà fusionnés, même fournisseur.
+ *   2. Crée une nouvelle facture (statut='facture') avec les valeurs
+ *      saisies (numero, date, HT, TVA).
+ *   3. Déplace toutes les lignes des BL vers la nouvelle facture.
+ *   4. Met les BL à zéro : total_ht=0, montant_tva=0, et garde un lien
+ *      `facture_consolidee_id` vers la nouvelle facture pour traçabilité.
+ *
+ * Pas de transaction PostgreSQL "vraie" via le client JS de Supabase :
+ * en cas d'erreur sur l'une des étapes 3-4, on tente un rollback de la
+ * facture créée à l'étape 2.
+ */
+export async function fusionnerBls(
+  db: SupabaseClient,
+  input: FusionnerBlsInput,
+  userId: string,
+) {
+  const { clientId, blIds, numeroFacture, dateFacture, totalHt, montantTva, tauxTva } = input
+
+  // 1. Charge et vérifie les BL
+  const { data: bls, error: blErr } = await db
+    .from('achats_factures')
+    .select('id, fournisseur, fournisseur_id, statut, deleted_at, facture_consolidee_id')
+    .in('id', blIds)
+    .eq('client_id', clientId)
+
+  if (blErr) throw new Error(blErr.message)
+  if (!bls || bls.length !== blIds.length) {
+    throw new NotFoundError('Un ou plusieurs BL introuvables.')
+  }
+  for (const b of bls) {
+    if (b.deleted_at) throw new ValidationError(`Le BL ${b.id} est supprimé.`)
+    if (b.statut !== 'bl') throw new ValidationError(`Le document ${b.id} n'est pas un BL (statut=${b.statut}).`)
+    if (b.facture_consolidee_id) throw new ValidationError(`Le BL ${b.id} a déjà été fusionné.`)
+  }
+  const fournisseurs = new Set(bls.map((b) => (b.fournisseur || '').trim().toLowerCase()))
+  if (fournisseurs.size > 1) {
+    throw new ValidationError('Tous les BL doivent provenir du même fournisseur.')
+  }
+  const fournisseurNom = bls[0].fournisseur || ''
+  const fournisseurId = bls[0].fournisseur_id || null
+
+  // 2. Crée la facture consolidée
+  const { data: facture, error: fErr } = await db
+    .from('achats_factures')
+    .insert({
+      client_id: clientId,
+      fournisseur: fournisseurNom,
+      fournisseur_id: fournisseurId,
+      numero_facture: numeroFacture.trim(),
+      date_facture: dateFacture,
+      total_ht: totalHt,
+      montant_tva: montantTva ?? null,
+      taux_tva: tauxTva ?? null,
+      statut: 'facture',
+    })
+    .select('id')
+    .single()
+
+  if (fErr) {
+    if (fErr.code === '23505' || /duplicate key/i.test(fErr.message)) {
+      throw new ConflictError(`Une facture avec le numéro "${numeroFacture}" existe déjà.`)
+    }
+    throw new Error(fErr.message)
+  }
+
+  // 3. Déplace les lignes des BL vers la facture consolidée
+  const { error: mvErr } = await db
+    .from('achats_lignes')
+    .update({ facture_id: facture.id })
+    .in('facture_id', blIds)
+    .eq('client_id', clientId)
+
+  if (mvErr) {
+    await db.from('achats_factures').delete().eq('id', facture.id)
+    throw new Error(`Erreur lors du déplacement des lignes : ${mvErr.message}`)
+  }
+
+  // 4. Met les BL à zéro + pointe vers la facture consolidée
+  const { error: upErr } = await db
+    .from('achats_factures')
+    .update({
+      total_ht: 0,
+      montant_tva: 0,
+      facture_consolidee_id: facture.id,
+    })
+    .in('id', blIds)
+    .eq('client_id', clientId)
+
+  if (upErr) {
+    // Best-effort rollback : on remet les lignes sur leur BL d'origine.
+    // Pas possible sans tracking de l'origine de chaque ligne ; on
+    // remet juste sur le 1er BL pour ne rien perdre.
+    await db.from('achats_lignes').update({ facture_id: blIds[0] }).eq('facture_id', facture.id)
+    await db.from('achats_factures').delete().eq('id', facture.id)
+    throw new Error(`Erreur lors de la mise à zéro des BL : ${upErr.message}`)
+  }
+
+  // 5. Audit log
+  await db.from('transactions_api').insert({
+    client_id: clientId,
+    type: 'achats_fusion_bl',
+    source: 'liste_achats',
+    payload_json: {
+      facture_id: facture.id,
+      bl_ids: blIds,
+      fournisseur: fournisseurNom,
+      total_ht: totalHt,
+      montant_tva: montantTva,
+    },
+    user_id: userId,
+  })
+
+  return { facture_id: facture.id, bls_fusionnes: blIds.length }
 }
 
 export async function deleteFacture(

--- a/lib/validators/achats.schema.ts
+++ b/lib/validators/achats.schema.ts
@@ -62,6 +62,19 @@ export const deleteFactureSchema = z.object({
   clientId:  clientIdSchema,
 })
 
+// ── Fusionner plusieurs BL en une facture consolidée ──────────────────────
+export const fusionnerBlsSchema = z.object({
+  clientId:      clientIdSchema,
+  blIds:         z.array(uuidSchema).min(2, 'Sélectionne au moins 2 BL'),
+  numeroFacture: z.string().min(1, 'Numéro de facture requis').max(100),
+  dateFacture:   z.string().min(1, 'Date requise'),
+  totalHt:       z.coerce.number(),
+  montantTva:    z.coerce.number().nullable().optional(),
+  tauxTva:       z.coerce.number().min(0).max(100).nullable().optional(),
+})
+
+export type FusionnerBlsInput = z.infer<typeof fusionnerBlsSchema>
+
 // ── Check duplicate ────────────────────────────────────────────────────────
 export const checkDuplicateSchema = z.object({
   clientId:      clientIdSchema,

--- a/supabase/migrations/20260518000001_achats_factures_consolidee.sql
+++ b/supabase/migrations/20260518000001_achats_factures_consolidee.sql
@@ -1,0 +1,14 @@
+-- Permet de tracer qu'un BL a été fusionné dans une facture consolidée.
+-- Le BL conserve son entrée (et son fichier) mais ses lignes sont
+-- déplacées vers la facture cible et ses totaux mis à zéro pour éviter
+-- le double-comptage.
+
+ALTER TABLE public.achats_factures
+  ADD COLUMN IF NOT EXISTS facture_consolidee_id uuid
+  REFERENCES public.achats_factures(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.achats_factures.facture_consolidee_id IS
+  'Si renseigné, ce BL a été fusionné dans la facture pointée. Les lignes ont été déplacées et les totaux mis à zéro.';
+
+CREATE INDEX IF NOT EXISTS achats_factures_consolidee_idx
+  ON public.achats_factures (facture_consolidee_id) WHERE facture_consolidee_id IS NOT NULL;


### PR DESCRIPTION
## Contexte

Aujourd'hui un BL ne peut être confirmé en facture qu'**un par un** depuis sa page détail. Quand un fournisseur livre plusieurs fois sur une période et envoie ensuite une facture unique qui les regroupe, il n'y avait pas de moyen de consolider proprement les BL.

## Solution

Sélection multi-BL depuis la liste des achats, et fusion en une nouvelle facture définitive.

### UI
- ☐ Checkbox au début de chaque ligne BL (statut='bl' et non déjà fusionné). Vue desktop + mobile (carte).
- 📋 Barre flottante en bas dès qu'au moins 1 BL est coché : nb sélectionnés, total HT/TVA cumulé, bouton **Fusionner en facture**.
- ⚠ Bouton désactivé avec tooltip si <2 BL ou fournisseurs différents.
- 📝 Modal de saisie : N° facture, date, HT, TVA (pré-remplis avec les sommes des BL, tous éditables).
- 🏷 Sur la page détail d'un BL fusionné : bannière jaune \"Ce BL a été fusionné dans la facture XYZ\" + lien direct. Le bouton **Confirmer comme facture** est caché.

### BDD
- Nouvelle colonne \`achats_factures.facture_consolidee_id\` (uuid nullable, FK auto-référente). Migration appliquée.
- Service \`fusionnerBls\` :
  1. Vérifie : même client / même fournisseur / statut='bl' / pas déjà fusionné
  2. Crée la nouvelle facture (statut='facture')
  3. Déplace les lignes des BL vers la nouvelle facture
  4. Met les BL à zéro (HT=0, TVA=0) avec le lien \`facture_consolidee_id\` pour traçabilité
- Rollback best-effort si une étape échoue.

### API
- POST \`/api/achats/fusionner-bl\` (admin/superadmin only)
- Body : \`{ clientId, blIds[], numeroFacture, dateFacture, totalHt, montantTva }\`
- Audit logué dans \`transactions_api\` (type \`achats_fusion_bl\`)

## Test plan

- [ ] Aller sur /controle-gestion/achats
- [ ] Cocher 2 BL du même fournisseur → barre apparaît, bouton actif
- [ ] Cocher des BL de fournisseurs différents → bouton désactivé + tooltip
- [ ] Cliquer Fusionner → modal s'ouvre avec sommes pré-remplies
- [ ] Valider → redirige vers la nouvelle facture qui contient toutes les lignes
- [ ] Revenir sur la liste → les BL d'origine sont à 0 €
- [ ] Cliquer sur un BL fusionné → bannière jaune + lien vers la facture
- [ ] Vérifier que les BL fusionnés ne sont plus cochables

🤖 Generated with [Claude Code](https://claude.com/claude-code)