### PR TITLE
feat(achats): autocomplete fournisseurs sur import + édition

### DIFF
--- a/app/controle-gestion/achats/[id]/page.js
+++ b/app/controle-gestion/achats/[id]/page.js
@@ -61,6 +61,9 @@ export default function AchatsDetailPage() {
   const [linkingIngFor, setLinkingIngFor] = useState(null)
   const [linkSearch, setLinkSearch] = useState('')
 
+  // Liste des fournisseurs connus pour autocomplete sur edit
+  const [fournisseursConnus, setFournisseursConnus] = useState([])
+
   useEffect(() => {
     let cancelled = false
     ;(async () => {
@@ -147,6 +150,22 @@ export default function AchatsDetailPage() {
   }, [clientId])
 
   useEffect(() => { if (authReady && clientId) loadIngredients() }, [authReady, clientId, loadIngredients])
+
+  // Liste des fournisseurs déjà connus du client (autocomplete sur le champ
+  // "Fournisseur" en édition — évite les doublons "Metro" vs "METRO").
+  useEffect(() => {
+    if (!clientId) return
+    let cancel = false
+    ;(async () => {
+      const { data } = await supabase
+        .from('fournisseurs')
+        .select('nom')
+        .eq('client_id', clientId)
+        .order('nom')
+      if (!cancel) setFournisseursConnus((data || []).map((f) => f.nom).filter(Boolean))
+    })()
+    return () => { cancel = true }
+  }, [clientId])
 
   const openEdit = () => {
     setEditFournisseur(facture.fournisseur || '')
@@ -402,7 +421,16 @@ export default function AchatsDetailPage() {
                     <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr', gap: 12 }}>
                       <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: c.texteMuted }}>
                         Fournisseur
-                        <input style={inputS} value={editFournisseur} onChange={e => setEditFournisseur(e.target.value)} />
+                        <input
+                          style={inputS}
+                          value={editFournisseur}
+                          onChange={e => setEditFournisseur(e.target.value)}
+                          list="fournisseurs-connus-edit"
+                          autoComplete="off"
+                        />
+                        <datalist id="fournisseurs-connus-edit">
+                          {fournisseursConnus.map((nom) => <option key={nom} value={nom} />)}
+                        </datalist>
                       </label>
                       <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: c.texteMuted }}>
                         N° de facture / BL

--- a/app/controle-gestion/achats/import/page.js
+++ b/app/controle-gestion/achats/import/page.js
@@ -65,6 +65,9 @@ export default function AchatsImportPage() {
 
   // ── Caches de réconciliation ──────────────────────────────────────────────
   const [fournisseurMapping, setFournisseurMapping] = useState({}) // norm → { ingredient_id }
+  // Liste des fournisseurs déjà connus pour ce client — autocomplete sur
+  // le champ "Fournisseur" pour éviter les doublons ("Metro" vs "METRO").
+  const [fournisseursConnus, setFournisseursConnus] = useState([])
   const [ingredientsById, setIngredientsById] = useState({})       // id   → { nom, prix_kg, unite }
   const [tvaByIngredient, setTvaByIngredient] = useState({})       // id   → dernier taux_tva utilisé
 
@@ -179,6 +182,21 @@ export default function AchatsImportPage() {
   useEffect(() => {
     if (authReady && clientId) loadReconciliation()
   }, [authReady, clientId, loadReconciliation])
+
+  // Charge la liste des fournisseurs existants pour l'autocomplete.
+  useEffect(() => {
+    if (!clientId) return
+    let cancel = false
+    ;(async () => {
+      const { data } = await supabase
+        .from('fournisseurs')
+        .select('nom')
+        .eq('client_id', clientId)
+        .order('nom')
+      if (!cancel) setFournisseursConnus((data || []).map((f) => f.nom).filter(Boolean))
+    })()
+    return () => { cancel = true }
+  }, [clientId])
 
   // ─── Réconciliation d'une ligne ───────────────────────────────────────────
 
@@ -1004,7 +1022,17 @@ export default function AchatsImportPage() {
                 <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr', gap: 10 }}>
                   <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: c.texteMuted }}>
                     Fournisseur *
-                    <input style={inputS} value={fournisseur} onChange={e => setFournisseur(e.target.value)} placeholder="Nom du fournisseur" />
+                    <input
+                      style={inputS}
+                      value={fournisseur}
+                      onChange={e => setFournisseur(e.target.value)}
+                      placeholder="Nom du fournisseur"
+                      list="fournisseurs-connus"
+                      autoComplete="off"
+                    />
+                    <datalist id="fournisseurs-connus">
+                      {fournisseursConnus.map((nom) => <option key={nom} value={nom} />)}
+                    </datalist>
                   </label>
                   <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: c.texteMuted }}>
                     Date de la facture *


### PR DESCRIPTION
## Contexte

Sur l'import OCR / la saisie manuelle d'un document, le champ \"Fournisseur\" était un simple input texte. Risque : taper \"Metro\" puis \"METRO\" puis \"Metro France\" et créer 3 fournisseurs distincts dans la base au lieu d'un seul.

\`upsertFournisseur\` côté serveur fait déjà un match case-insensitive (\`ilike\`), donc les doublons strictement identiques à la casse près n'étaient pas créés. Mais ça ne couvre pas \"Metro\" vs \"Metro France\" ni \"Coup de Mer\" vs \"Coup de mer SAS\".

## Solution

\`<datalist>\` HTML5 sur le champ Fournisseur : suggère les noms déjà connus du client. L'utilisateur voit la liste en commençant à taper et peut sélectionner pour réutiliser exactement le même nom.

Ajouté sur :
- /controle-gestion/achats/import (OCR + saisie manuelle)
- /controle-gestion/achats/[id] (mode édition)

Composant natif HTML — accessible, performant, pas de dépendance.

## Test plan

- [ ] Sur /controle-gestion/achats/import : commencer à taper dans \"Fournisseur\" → la liste déroule les fournisseurs existants
- [ ] Sélectionner un nom → il remplit le champ exactement
- [ ] Pouvoir aussi taper un nom totalement nouveau (création d'un fournisseur)
- [ ] Sur /controle-gestion/achats/[id] en mode édition : même comportement

🤖 Generated with [Claude Code](https://claude.com/claude-code)