### PR TITLE
fix(ocr): retry + messages d'erreur clairs sur extraction IA

### DIFF
--- a/app/api/achats/parse-facture/route.ts
+++ b/app/api/achats/parse-facture/route.ts
@@ -2,6 +2,12 @@ import Anthropic from '@anthropic-ai/sdk'
 import { apiHandler } from '../../../../lib/apiHandler'
 import { z } from 'zod'
 
+// Étend le timeout de la function Vercel à 60s (par défaut: 10s sur Hobby,
+// 60s déjà max sur Pro sans cette directive). L'OCR Claude peut prendre
+// 20-40s sur un PDF multi-pages, sans compter les retries en cas d'erreur
+// transitoire.
+export const maxDuration = 60
+
 // Instancié lazy à la première requête : assure que process.env.ANTHROPIC_API_KEY
 // est bien chargé (utile en dev Turbopack) et permet de retourner une erreur
 // claire si la clé manque, au lieu d'un 500 opaque.
@@ -12,6 +18,48 @@ function getAnthropic(): Anthropic {
   if (!key) throw new Error('ANTHROPIC_API_KEY non défini côté serveur.')
   anthropicClient = new Anthropic({ apiKey: key })
   return anthropicClient
+}
+
+// Retry avec backoff exponentiel sur les erreurs transitoires Anthropic :
+//   429 = rate limit, 502/503 = bad gateway, 529 = overloaded.
+// Ces erreurs sont la cause #1 des "lecture IA échouée" observés en série
+// (après plusieurs scans rapprochés).
+async function callAnthropicWithRetry<T>(fn: () => Promise<T>, maxRetries = 3): Promise<T> {
+  let lastErr: unknown
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn()
+    } catch (err: unknown) {
+      lastErr = err
+      const e = err as { status?: number; response?: { status?: number } }
+      const status = e?.status ?? e?.response?.status
+      const isTransient = status === 429 || status === 502 || status === 503 || status === 529
+      if (!isTransient || attempt === maxRetries) throw err
+      const delayMs = Math.min(1000 * Math.pow(2, attempt), 8000)
+      console.warn(`[parse-facture] Erreur transitoire ${status}, retry dans ${delayMs}ms (attempt ${attempt + 1}/${maxRetries})`)
+      await new Promise((r) => setTimeout(r, delayMs))
+    }
+  }
+  throw lastErr
+}
+
+// Traduit une erreur Anthropic en message clair pour l'UI.
+function formatAnthropicError(err: unknown): { status: number; message: string } {
+  const e = err as { status?: number; message?: string }
+  const status = e?.status ?? 500
+  if (status === 429) {
+    return { status: 429, message: 'L\'IA est saturée (trop de demandes simultanées). Attendez 10-20 secondes et réessayez.' }
+  }
+  if (status === 529 || status === 503) {
+    return { status: 503, message: 'L\'IA Anthropic est temporairement surchargée. Réessayez dans une minute.' }
+  }
+  if (status === 401 || status === 403) {
+    return { status: 500, message: 'Clé API Anthropic invalide ou expirée — contacte le support.' }
+  }
+  if (status === 400) {
+    return { status: 400, message: `Format de fichier rejeté par l'IA : ${e?.message ?? 'unknown'}` }
+  }
+  return { status: 500, message: e?.message ?? 'Erreur inconnue côté IA.' }
 }
 
 const schema = z.object({
@@ -113,20 +161,27 @@ export const POST = apiHandler({
       ? { type: 'document' as const, source: { type: 'base64' as const, media_type: 'application/pdf' as const, data: fileBase64 } }
       : { type: 'image' as const, source: { type: 'base64' as const, media_type: mimeType as 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif', data: fileBase64 } }
 
-    const message = await getAnthropic().messages.create({
-      model: 'claude-opus-4-7',
-      // 8192 : marge pour un PDF multi-factures (1 facture ~ 500-1500 tokens en sortie).
-      max_tokens: 8192,
-      messages: [
-        {
-          role: 'user',
-          content: [
-            contentBlock,
-            { type: 'text', text: PROMPT_EXTRACTION },
-          ],
-        },
-      ],
-    })
+    let message
+    try {
+      message = await callAnthropicWithRetry(() => getAnthropic().messages.create({
+        model: 'claude-opus-4-7',
+        // 8192 : marge pour un PDF multi-factures (1 facture ~ 500-1500 tokens en sortie).
+        max_tokens: 8192,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              contentBlock,
+              { type: 'text', text: PROMPT_EXTRACTION },
+            ],
+          },
+        ],
+      }))
+    } catch (err) {
+      const formatted = formatAnthropicError(err)
+      console.error('[parse-facture] Erreur Anthropic après retry :', formatted, err)
+      return Response.json({ error: formatted.message }, { status: formatted.status })
+    }
 
     // Trouve le premier bloc de type 'text' (évite de planter si un thinking block précède)
     const textBlock = message.content.find((b) => b.type === 'text')

--- a/app/controle-gestion/achats/import/page.js
+++ b/app/controle-gestion/achats/import/page.js
@@ -313,11 +313,10 @@ export default function AchatsImportPage() {
 
   // ─── Extraction IA ────────────────────────────────────────────────────────
 
-  const extractFromImage = useCallback(async (file) => {
+  // Coeur de l'appel OCR, factorisé pour pouvoir réessayer sans re-upload.
+  const runExtraction = useCallback(async (base64, mime) => {
+    setExtractError('')
     try {
-      const base64 = await fileToBase64(file)
-      setFileBase64(base64)
-      setFileMime(file.type)
       const { data: { session } } = await supabase.auth.getSession()
       const res = await fetch('/api/achats/parse-facture', {
         method: 'POST',
@@ -325,7 +324,7 @@ export default function AchatsImportPage() {
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${session.access_token}`,
         },
-        body: JSON.stringify({ fileBase64: base64, mimeType: file.type, clientId }),
+        body: JSON.stringify({ fileBase64: base64, mimeType: mime, clientId }),
       })
       const result = await res.json()
       if (!res.ok) throw new Error(result.error || 'Erreur extraction')
@@ -334,7 +333,6 @@ export default function AchatsImportPage() {
       setSavedFactureIdxs(new Set())
 
       if (factures.length === 0) {
-        // OCR n'a rien retourné : on bascule en review avec un formulaire vide.
         setExtractedFactures(null)
         setCurrentFactureIdx(0)
         setLignes([])
@@ -346,7 +344,6 @@ export default function AchatsImportPage() {
       setCurrentFactureIdx(0)
       loadFactureIntoState(factures[0])
       await checkDuplicate(factures[0].numero_facture)
-
       setStep('review')
     } catch (err) {
       console.error('Extraction IA échouée :', err)
@@ -356,6 +353,21 @@ export default function AchatsImportPage() {
       setStep('review')
     }
   }, [clientId, loadFactureIntoState, checkDuplicate])
+
+  const extractFromImage = useCallback(async (file) => {
+    const base64 = await fileToBase64(file)
+    setFileBase64(base64)
+    setFileMime(file.type)
+    await runExtraction(base64, file.type)
+  }, [runExtraction])
+
+  // Permet de réessayer l'OCR sans re-sélectionner le fichier — utile quand
+  // l'IA Anthropic est saturée (rate limit, overload transitoire).
+  const retryExtraction = useCallback(async () => {
+    if (!fileBase64 || !fileMime) return
+    setStep('extracting')
+    await runExtraction(fileBase64, fileMime)
+  }, [fileBase64, fileMime, runExtraction])
 
   // ─── Sélection de fichier (mobile input + desktop drop partagé) ───────────
 
@@ -948,8 +960,16 @@ export default function AchatsImportPage() {
 
               {/* Bandeau extraction échouée */}
               {extractError && (
-                <div style={{ background: c.orangeClair, border: `1px solid ${c.orange}`, borderRadius: 8, padding: '10px 14px', fontSize: 13, color: '#92400E' }}>
-                  ⚠️ Extraction IA échouée ({extractError}). Saisissez les lignes manuellement.
+                <div style={{ background: c.orangeClair, border: `1px solid ${c.orange}`, borderRadius: 8, padding: '10px 14px', fontSize: 13, color: '#92400E', display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+                  <span style={{ flex: 1, minWidth: 0 }}>⚠️ {extractError}</span>
+                  {fileBase64 && (
+                    <button
+                      onClick={retryExtraction}
+                      style={{ padding: '5px 12px', borderRadius: 6, fontSize: 12, fontWeight: 600, border: '1px solid #F59E0B', background: '#FBBF24', color: '#78350F', cursor: 'pointer' }}
+                    >
+                      🔄 Réessayer
+                    </button>
+                  )}
                 </div>
               )}
 


### PR DESCRIPTION
## Pourquoi

L'OCR plante en série après plusieurs scans rapprochés — \"lecture IA échouée\" aléatoire dès la 3e–5e facture. Cause : pas de retry sur les erreurs transitoires d'Anthropic.

L'API Anthropic renvoie :
- **429** quand on dépasse le rate limit (trop de requêtes en peu de temps)
- **529** quand elle est surchargée (capacity overload, fréquent en heures de pointe)
- **502/503** pour des erreurs réseau ponctuelles

Sans retry, ces 4 codes remontaient directement en \"lecture IA échouée\" côté UI.

## Fix

### Côté serveur
- **Retry exponentiel** (1s, 2s, 4s, max 3 tentatives) sur les codes transitoires uniquement.
- **Messages d'erreur explicites** : \"L'IA est saturée (trop de demandes simultanées). Attendez 10-20 secondes et réessayez.\" au lieu d'un 500 opaque.
- **\`maxDuration = 60\`** sur la route pour laisser le temps aux retries de jouer sans que Vercel timeout la function.

### Côté UI
- **Bouton \"🔄 Réessayer\"** sur le bandeau d'erreur — relance l'OCR avec le fichier déjà uploadé en state, pas besoin de re-sélectionner.

## Effet attendu

La plupart des erreurs aléatoires devraient disparaître silencieusement (résolues par retry). Pour les rares cas où ça reste KO après 3 tentatives, l'utilisateur voit un message clair et peut cliquer Réessayer.

## Test plan

- [ ] Importer 10 factures à la chaîne rapidement (avant : plantait vers la 3-5e)
- [ ] Si une erreur apparaît, vérifier que le message est explicite (pas juste \"500\")
- [ ] Cliquer le bouton Réessayer → doit relancer l'OCR sans re-uploader

🤖 Generated with [Claude Code](https://claude.com/claude-code)