### PR TITLE
fix(achats): unité vide + autofill, prix sans 0 bloquant

### DIFF
--- a/app/controle-gestion/achats/[id]/page.js
+++ b/app/controle-gestion/achats/[id]/page.js
@@ -187,11 +187,21 @@ export default function AchatsDetailPage() {
   const addEditLigne = () => {
     setEditLignes((prev) => [
       ...prev,
-      { _id: makeLigneId(), designation: '', quantite: 1, unite: '', prix_unitaire_ht: 0, remise: 0, taux_tva: null, ingredient_id: null, ingredient_nom: null },
+      { _id: makeLigneId(), designation: '', quantite: 1, unite: '', prix_unitaire_ht: '', remise: 0, taux_tva: null, ingredient_id: null, ingredient_nom: null },
     ])
   }
   const linkIngredientToEdit = (lid, ing) => {
-    setEditLignes((prev) => prev.map((l) => (l._id === lid ? { ...l, ingredient_id: ing.id, ingredient_nom: ing.nom } : l)))
+    setEditLignes((prev) => prev.map((l) => (
+      l._id === lid
+        ? {
+            ...l,
+            ingredient_id: ing.id,
+            ingredient_nom: ing.nom,
+            // Reprend l'unité de l'ingrédient si l'utilisateur n'en a pas saisi une.
+            unite: (l.unite && String(l.unite).trim()) ? l.unite : (ing.unite || ''),
+          }
+        : l
+    )))
     setLinkingIngFor(null)
     setLinkSearch('')
   }
@@ -553,9 +563,9 @@ export default function AchatsDetailPage() {
                                   <td style={{ ...td, textAlign: 'right' }}>
                                     <input
                                       style={{ ...inputS, fontSize: 13, padding: '6px 8px', textAlign: 'right', width: 80 }}
-                                      type="number" min="0" step="0.01"
-                                      value={l.prix_unitaire_ht}
-                                      onChange={e => updateEditLigne(l._id, 'prix_unitaire_ht', e.target.value)}
+                                      type="text" inputMode="decimal"
+                                      value={l.prix_unitaire_ht ?? ''}
+                                      onChange={e => updateEditLigne(l._id, 'prix_unitaire_ht', e.target.value.replace(',', '.'))}
                                     />
                                   </td>
                                   <td style={{ ...td, textAlign: 'right' }}>

--- a/app/controle-gestion/achats/import/page.js
+++ b/app/controle-gestion/achats/import/page.js
@@ -200,8 +200,8 @@ export default function AchatsImportPage() {
       _id: makeLigneId(),
       designation: '',
       quantite: 1,
-      unite: 'kg',
-      prix_unitaire_ht: 0,
+      unite: '',
+      prix_unitaire_ht: '',
       remise: 0,
     })])
   }, [isManuelMode, authReady, enrichLigneLocal])
@@ -429,8 +429,8 @@ export default function AchatsImportPage() {
       _id: makeLigneId(),
       designation: '',
       quantite: 1,
-      unite: 'kg',
-      prix_unitaire_ht: 0,
+      unite: '',
+      prix_unitaire_ht: '',
       remise: 0,
     })])
   }, [enrichLigneLocal])
@@ -516,7 +516,7 @@ export default function AchatsImportPage() {
     const prixActuel = ing.prix_kg ? Number(ing.prix_kg) : null
     const prixLigneFinal = userHadOwnPrice
       ? Number(ligne.prix_unitaire_ht)
-      : (prixActuel && Number.isFinite(prixActuel) ? prixActuel : 0)
+      : (prixActuel && Number.isFinite(prixActuel) ? prixActuel : '')
     const remiseFactor = 1 - (Number(ligne.remise) || 0) / 100
     const prixEff = prixLigneFinal * remiseFactor
     const deltaPrix = prixActuel && prixEff && userHadOwnPrice
@@ -533,6 +533,8 @@ export default function AchatsImportPage() {
         // Préserve l'override de désignation envoyé par le caller (ex: autocomplete
         // qui force le nom canonique de l'ingrédient sélectionné).
         designation:      ligne.designation ?? l.designation,
+        // Reprend l'unité de l'ingrédient si l'utilisateur n'en a pas saisi une.
+        unite:            (l.unite && String(l.unite).trim()) ? l.unite : (ing.unite || ''),
         prix_unitaire_ht: prixLigneFinal,
         prix_auto:        !userHadOwnPrice,
         taux_tva:         tauxTvaFinal,
@@ -1258,9 +1260,9 @@ export default function AchatsImportPage() {
                               <td style={{ ...td, textAlign: 'right' }}>
                                 <input
                                   style={{ ...inputS, textAlign: 'right', width: 80 }}
-                                  type="number" min="0" step="0.01"
-                                  value={l.prix_unitaire_ht}
-                                  onChange={e => updateLigne(l._id, 'prix_unitaire_ht', e.target.value)}
+                                  type="text" inputMode="decimal"
+                                  value={l.prix_unitaire_ht ?? ''}
+                                  onChange={e => updateLigne(l._id, 'prix_unitaire_ht', e.target.value.replace(',', '.'))}
                                 />
                               </td>
                               <td style={{ ...td, textAlign: 'right' }}>
@@ -1483,8 +1485,8 @@ export default function AchatsImportPage() {
                             </label>
                             <label style={{ display: 'flex', flexDirection: 'column', gap: 3, fontSize: 11, color: c.texteMuted }}>
                               Prix HT/u
-                              <input style={inputS} type="number" min="0" step="0.01" value={l.prix_unitaire_ht}
-                                onChange={e => updateLigne(l._id, 'prix_unitaire_ht', e.target.value)} />
+                              <input style={inputS} type="text" inputMode="decimal" value={l.prix_unitaire_ht ?? ''}
+                                onChange={e => updateLigne(l._id, 'prix_unitaire_ht', e.target.value.replace(',', '.'))} />
                             </label>
                             <label style={{ display: 'flex', flexDirection: 'column', gap: 3, fontSize: 11, color: c.texteMuted }}>
                               TVA %


### PR DESCRIPTION
## Contexte

Deux petits soucis sur la saisie manuelle de factures (mode manuel de l'import + édition d'une facture existante).

## Changements

### 1. Unité de mesure
- **Avant** : nouvelle ligne pré-remplie avec `unite = "kg"`, et même quand l'utilisateur sélectionnait un article existant (autocomplete ou link), l'unité de l'article (stockée en base) n'était jamais reportée.
- **Après** : unité vide par défaut. Quand un article connu est sélectionné, l'unité de l'article est automatiquement reportée — sauf si l'utilisateur a déjà saisi une valeur manuellement (on ne l'écrase pas).

### 2. Champ prix
- **Avant** : `type="number"` + valeur par défaut `0` → le `0` initial bloque (faut le sélectionner avant de taper), et `type="number"` rejette la virgule en français → la saisie est effacée quand on tape `12,5`.
- **Après** : champ vide par défaut, `type="text" inputMode="decimal"` (clavier numérique sur mobile), la virgule est convertie automatiquement en point. Plus de perte de saisie.

## Fichiers touchés
- [app/controle-gestion/achats/import/page.js](app/controle-gestion/achats/import/page.js) — saisie manuelle de facture
- [app/controle-gestion/achats/[id]/page.js](app/controle-gestion/achats/[id]/page.js) — édition d'une facture existante

## Test plan
- [ ] Aller sur **Achats → Import → Saisie manuelle**, vérifier qu'une nouvelle ligne a unité et prix vides.
- [ ] Cliquer "Ajouter une ligne" → idem.
- [ ] Taper une désignation et sélectionner un article connu dans l'autocomplete → l'unité de l'article apparaît automatiquement.
- [ ] Taper une unité manuellement puis sélectionner un article → l'unité saisie est préservée.
- [ ] Saisir un prix avec une virgule (`12,5`) → la valeur n'est plus effacée, elle s'affiche `12.5`.
- [ ] Refaire le test sur l'édition d'une facture existante.

🤖 Generated with [Claude Code](https://claude.com/claude-code)