### PR TITLE
feat(ingredients): auto-créer catégories à l'import + suppression en cascade

### DIFF
--- a/app/controle-gestion/achats/[id]/page.js
+++ b/app/controle-gestion/achats/[id]/page.js
@@ -187,11 +187,21 @@ export default function AchatsDetailPage() {
   const addEditLigne = () => {
     setEditLignes((prev) => [
       ...prev,
-      { _id: makeLigneId(), designation: '', quantite: 1, unite: '', prix_unitaire_ht: 0, remise: 0, taux_tva: null, ingredient_id: null, ingredient_nom: null },
+      { _id: makeLigneId(), designation: '', quantite: 1, unite: '', prix_unitaire_ht: '', remise: 0, taux_tva: null, ingredient_id: null, ingredient_nom: null },
     ])
   }
   const linkIngredientToEdit = (lid, ing) => {
-    setEditLignes((prev) => prev.map((l) => (l._id === lid ? { ...l, ingredient_id: ing.id, ingredient_nom: ing.nom } : l)))
+    setEditLignes((prev) => prev.map((l) => (
+      l._id === lid
+        ? {
+            ...l,
+            ingredient_id: ing.id,
+            ingredient_nom: ing.nom,
+            // Reprend l'unité de l'ingrédient si l'utilisateur n'en a pas saisi une.
+            unite: (l.unite && String(l.unite).trim()) ? l.unite : (ing.unite || ''),
+          }
+        : l
+    )))
     setLinkingIngFor(null)
     setLinkSearch('')
   }
@@ -553,9 +563,9 @@ export default function AchatsDetailPage() {
                                   <td style={{ ...td, textAlign: 'right' }}>
                                     <input
                                       style={{ ...inputS, fontSize: 13, padding: '6px 8px', textAlign: 'right', width: 80 }}
-                                      type="number" min="0" step="0.01"
-                                      value={l.prix_unitaire_ht}
-                                      onChange={e => updateEditLigne(l._id, 'prix_unitaire_ht', e.target.value)}
+                                      type="text" inputMode="decimal"
+                                      value={l.prix_unitaire_ht ?? ''}
+                                      onChange={e => updateEditLigne(l._id, 'prix_unitaire_ht', e.target.value.replace(',', '.'))}
                                     />
                                   </td>
                                   <td style={{ ...td, textAlign: 'right' }}>

--- a/app/controle-gestion/achats/[id]/page.js
+++ b/app/controle-gestion/achats/[id]/page.js
@@ -499,22 +499,17 @@ export default function AchatsDetailPage() {
                 </div>
 
                 {/* Lignes */}
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+                <div style={{ marginBottom: 12 }}>
                   <h2 style={{ margin: 0, fontSize: 16, fontWeight: 600, color: c.texte }}>
                     Articles ({editing ? editLignes.length : lignes.length})
                   </h2>
-                  {editing && (
-                    <button onClick={addEditLigne}
-                      style={{ padding: '6px 12px', borderRadius: 8, border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte, cursor: 'pointer', fontSize: 13 }}>
-                      + Ajouter une ligne
-                    </button>
-                  )}
                 </div>
 
                 {editing ? (
                   /* ── Mode édition ── */
-                  editLignes.length === 0 ? (
-                    <p style={{ color: c.texteMuted, fontSize: 14 }}>Aucune ligne. Cliquez sur « + Ajouter une ligne ».</p>
+                  <>
+                  {editLignes.length === 0 ? (
+                    <p style={{ color: c.texteMuted, fontSize: 14 }}>Aucune ligne. Cliquez sur « + Ajouter une ligne » ci-dessous.</p>
                   ) : (
                     <div style={{ background: c.blanc, borderRadius: 12, border: `0.5px solid ${c.bordure}`, overflow: 'hidden' }}>
                       <div style={{ overflowX: 'auto' }}>
@@ -646,7 +641,14 @@ export default function AchatsDetailPage() {
                         </table>
                       </div>
                     </div>
-                  )
+                  )}
+                  <div style={{ marginTop: 12 }}>
+                    <button onClick={addEditLigne}
+                      style={{ padding: '6px 12px', borderRadius: 8, border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte, cursor: 'pointer', fontSize: 13 }}>
+                      + Ajouter une ligne
+                    </button>
+                  </div>
+                  </>
                 ) : lignes.length === 0 ? (
                   <p style={{ color: c.texteMuted, fontSize: 14 }}>Aucun article enregistré.</p>
                 ) : (

--- a/app/controle-gestion/achats/import/page.js
+++ b/app/controle-gestion/achats/import/page.js
@@ -200,8 +200,8 @@ export default function AchatsImportPage() {
       _id: makeLigneId(),
       designation: '',
       quantite: 1,
-      unite: 'kg',
-      prix_unitaire_ht: 0,
+      unite: '',
+      prix_unitaire_ht: '',
       remise: 0,
     })])
   }, [isManuelMode, authReady, enrichLigneLocal])
@@ -429,8 +429,8 @@ export default function AchatsImportPage() {
       _id: makeLigneId(),
       designation: '',
       quantite: 1,
-      unite: 'kg',
-      prix_unitaire_ht: 0,
+      unite: '',
+      prix_unitaire_ht: '',
       remise: 0,
     })])
   }, [enrichLigneLocal])
@@ -516,7 +516,7 @@ export default function AchatsImportPage() {
     const prixActuel = ing.prix_kg ? Number(ing.prix_kg) : null
     const prixLigneFinal = userHadOwnPrice
       ? Number(ligne.prix_unitaire_ht)
-      : (prixActuel && Number.isFinite(prixActuel) ? prixActuel : 0)
+      : (prixActuel && Number.isFinite(prixActuel) ? prixActuel : '')
     const remiseFactor = 1 - (Number(ligne.remise) || 0) / 100
     const prixEff = prixLigneFinal * remiseFactor
     const deltaPrix = prixActuel && prixEff && userHadOwnPrice
@@ -533,6 +533,8 @@ export default function AchatsImportPage() {
         // Préserve l'override de désignation envoyé par le caller (ex: autocomplete
         // qui force le nom canonique de l'ingrédient sélectionné).
         designation:      ligne.designation ?? l.designation,
+        // Reprend l'unité de l'ingrédient si l'utilisateur n'en a pas saisi une.
+        unite:            (l.unite && String(l.unite).trim()) ? l.unite : (ing.unite || ''),
         prix_unitaire_ht: prixLigneFinal,
         prix_auto:        !userHadOwnPrice,
         taux_tva:         tauxTvaFinal,
@@ -1258,9 +1260,9 @@ export default function AchatsImportPage() {
                               <td style={{ ...td, textAlign: 'right' }}>
                                 <input
                                   style={{ ...inputS, textAlign: 'right', width: 80 }}
-                                  type="number" min="0" step="0.01"
-                                  value={l.prix_unitaire_ht}
-                                  onChange={e => updateLigne(l._id, 'prix_unitaire_ht', e.target.value)}
+                                  type="text" inputMode="decimal"
+                                  value={l.prix_unitaire_ht ?? ''}
+                                  onChange={e => updateLigne(l._id, 'prix_unitaire_ht', e.target.value.replace(',', '.'))}
                                 />
                               </td>
                               <td style={{ ...td, textAlign: 'right' }}>
@@ -1483,8 +1485,8 @@ export default function AchatsImportPage() {
                             </label>
                             <label style={{ display: 'flex', flexDirection: 'column', gap: 3, fontSize: 11, color: c.texteMuted }}>
                               Prix HT/u
-                              <input style={inputS} type="number" min="0" step="0.01" value={l.prix_unitaire_ht}
-                                onChange={e => updateLigne(l._id, 'prix_unitaire_ht', e.target.value)} />
+                              <input style={inputS} type="text" inputMode="decimal" value={l.prix_unitaire_ht ?? ''}
+                                onChange={e => updateLigne(l._id, 'prix_unitaire_ht', e.target.value.replace(',', '.'))} />
                             </label>
                             <label style={{ display: 'flex', flexDirection: 'column', gap: 3, fontSize: 11, color: c.texteMuted }}>
                               TVA %

--- a/app/controle-gestion/achats/import/page.js
+++ b/app/controle-gestion/achats/import/page.js
@@ -1186,18 +1186,15 @@ export default function AchatsImportPage() {
           {/* ── Lignes (incluses dans la colonne droite en mode side-by-side) ── */}
           <div style={{ marginTop: 0, display: 'flex', flexDirection: 'column', gap: 16 }}>
             <div style={{ background: c.blanc, border: `1px solid ${c.bordure}`, borderRadius: 12, overflow: 'hidden' }}>
-              <div style={{ padding: '12px 16px', borderBottom: `1px solid ${c.bordure}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <div style={{ padding: '12px 16px', borderBottom: `1px solid ${c.bordure}` }}>
                 <p style={{ margin: 0, fontWeight: 600, fontSize: 14, color: c.texte }}>
                   Lignes de la facture{lignes.length > 0 && ` (${lignes.length})`}
                 </p>
-                <button style={{ ...btnSecondary, padding: '6px 12px', fontSize: 13, width: 'auto' }} onClick={addLigne}>
-                  + Ajouter une ligne
-                </button>
               </div>
 
                 {lignes.length === 0 && (
                   <p style={{ padding: 20, margin: 0, fontSize: 13, color: c.texteMuted, textAlign: 'center' }}>
-                    Aucune ligne. Cliquez sur &laquo;&nbsp;+ Ajouter une ligne&nbsp;&raquo; pour commencer.
+                    Aucune ligne. Cliquez sur &laquo;&nbsp;+ Ajouter une ligne&nbsp;&raquo; ci-dessous pour commencer.
                   </p>
                 )}
 
@@ -1524,6 +1521,12 @@ export default function AchatsImportPage() {
                     })}
                   </div>
                 )}
+
+                <div style={{ padding: '12px 16px', borderTop: lignes.length > 0 ? `1px solid ${c.bordure}` : 'none' }}>
+                  <button style={{ ...btnSecondary, padding: '6px 12px', fontSize: 13, width: 'auto' }} onClick={addLigne}>
+                    + Ajouter une ligne
+                  </button>
+                </div>
             </div>
 
             {/* Récapitulatif total */}

--- a/app/ingredients/page.js
+++ b/app/ingredients/page.js
@@ -172,17 +172,57 @@ export default function IngredientsPage() {
 
   // ── Suppression ───────────────────────────────────────────────────────────
   const supprimerSelection = async () => {
-    if (!confirm(`Supprimer ${selection.length} ingrédient${selection.length > 1 ? 's' : ''} ? Action irréversible.`)) return
+    const selSet = new Set(selection)
+    const ingsConcernes = ingredients.filter(i => selSet.has(i.id))
+    const nbLiesAFiches = ingsConcernes.reduce(
+      (s, i) => s + (Array.isArray(i.fiche_ingredients) ? i.fiche_ingredients.length : 0),
+      0
+    )
+    const message = nbLiesAFiches > 0
+      ? `Supprimer ${selection.length} ingrédient${selection.length > 1 ? 's' : ''} ?\n\n${nbLiesAFiches} ligne${nbLiesAFiches > 1 ? 's' : ''} de fiches techniques ${nbLiesAFiches > 1 ? 'seront retirées' : 'sera retirée'} en cascade (les coûts des fiches concernées devront être recalculés).\n\nAction irréversible.`
+      : `Supprimer ${selection.length} ingrédient${selection.length > 1 ? 's' : ''} ? Action irréversible.`
+    if (!confirm(message)) return
     setSupprimant(true)
     try {
       const clientId = await getClientId()
-      const { error } = await supabase.from('ingredients').delete().in('id', selection).eq('client_id', clientId)
-      if (error) throw error
-      await log({ action: 'SUPPRESSION', entite: 'ingredient', entite_nom: `${selection.length} ingrédients`, section: 'cuisine', details: `IDs: ${selection.join(', ')}` })
+      // 1709 UUIDs en un seul .in() risque de dépasser la longueur d'URL côté
+      // PostgREST. On chunke à 500 IDs par opération.
+      const CHUNK = 500
+      const chunks = []
+      for (let i = 0; i < selection.length; i += CHUNK) {
+        chunks.push(selection.slice(i, i + CHUNK))
+      }
+      for (const ids of chunks) {
+        // Cascade : supprime d'abord les lignes de fiches techniques liées
+        // (sinon la FK fiche_ingredients.ingredient_id bloque la suppression).
+        const { error: errFiches } = await supabase
+          .from('fiche_ingredients')
+          .delete()
+          .in('ingredient_id', ids)
+          .eq('client_id', clientId)
+        if (errFiches) throw errFiches
+        // Détache l'historique (achats, inventaires, mapping fournisseur) pour
+        // garder les factures/inventaires lisibles même après suppression.
+        await Promise.all([
+          supabase.from('achats_lignes').update({ ingredient_id: null }).in('ingredient_id', ids).eq('client_id', clientId),
+          supabase.from('inventaire_lignes').update({ ingredient_id: null }).in('ingredient_id', ids).eq('client_id', clientId),
+          supabase.from('fournisseur_mapping').update({ ingredient_id: null }).in('ingredient_id', ids).eq('client_id', clientId),
+        ])
+        // Suppression des ingrédients de ce chunk
+        const { error } = await supabase.from('ingredients').delete().in('id', ids).eq('client_id', clientId)
+        if (error) throw error
+      }
+      await log({
+        action: 'SUPPRESSION',
+        entite: 'ingredient',
+        entite_nom: `${selection.length} ingrédients`,
+        section: 'cuisine',
+        details: `${selection.length} supprimés, ${nbLiesAFiches} lignes de fiches retirées en cascade`,
+      })
       await loadAll()
     } catch (err) {
       console.error('Delete error:', err)
-      alert('Erreur lors de la suppression')
+      alert(`Erreur lors de la suppression : ${err.message || err.code || 'inconnue'}`)
     } finally { setSupprimant(false) }
   }
 

--- a/components/ImportView.jsx
+++ b/components/ImportView.jsx
@@ -214,6 +214,57 @@ export default function ImportView({ section = 'cuisine' }) {
       return
     }
 
+    // Création automatique des catégories absentes du fichier.
+    // On recharge l'état serveur (au cas où la page est ouverte depuis un
+    // moment) pour ne pas créer un doublon d'une catégorie existante.
+    let categoriesCreees = 0
+    const catMap = {}
+    if (cfg.hasCategories) {
+      const { data: existingCats } = await supabase
+        .from(cfg.categoriesTable)
+        .select('id, nom, ordre')
+        .eq('client_id', clientId)
+      ;(existingCats || []).forEach(cat => {
+        catMap[cat.nom.toLowerCase().trim()] = cat.id
+      })
+
+      const unknownNames = [...new Set(
+        donneesSelectionnees
+          .map(ing => (ing.categorieNom || '').trim())
+          .filter(nom => nom && !catMap[nom.toLowerCase()])
+      )]
+
+      if (unknownNames.length > 0) {
+        const maxOrdre = (existingCats || []).reduce((m, c) => Math.max(m, c.ordre || 0), 0)
+        const toInsert = unknownNames.map((nom, idx) => ({
+          nom,
+          emoji: '📦',
+          client_id: clientId,
+          ordre: maxOrdre + idx + 1,
+        }))
+        const { data: created, error: errCat } = await supabase
+          .from(cfg.categoriesTable)
+          .insert(toInsert)
+          .select('id, nom')
+        if (errCat) {
+          setLoading(false)
+          alert(`Erreur lors de la création des catégories : ${errCat.message}`)
+          return
+        }
+        ;(created || []).forEach(cat => {
+          catMap[cat.nom.toLowerCase().trim()] = cat.id
+        })
+        categoriesCreees = (created || []).length
+      }
+    }
+
+    const itemsToImport = donneesSelectionnees.map(ing => {
+      if (!cfg.hasCategories) return ing
+      const lookup = (ing.categorieNom || '').toLowerCase().trim()
+      const resolvedId = lookup ? catMap[lookup] : null
+      return { ...ing, categorie_id: resolvedId || null }
+    })
+
     const { count: dejaPresents, error: errCount } = await supabase
       .from(cfg.table)
       .select('*', { count: 'exact', head: true })
@@ -236,8 +287,8 @@ export default function ImportView({ section = 'cuisine' }) {
     let categoriesAssignees = 0
     const total = totalSelectionnes
 
-    for (let i = 0; i < donneesSelectionnees.length; i += batchSize) {
-      const batch = donneesSelectionnees.slice(i, i + batchSize)
+    for (let i = 0; i < itemsToImport.length; i += batchSize) {
+      const batch = itemsToImport.slice(i, i + batchSize)
       for (const ing of batch) {
         try {
           if (cfg.hasCategories) {
@@ -333,7 +384,10 @@ export default function ImportView({ section = 'cuisine' }) {
 
     setLoading(false)
     const res = { importes, misAJour, erreurs, total, ignores }
-    if (cfg.hasCategories) res.categoriesAssignees = categoriesAssignees
+    if (cfg.hasCategories) {
+      res.categoriesAssignees = categoriesAssignees
+      res.categoriesCreees = categoriesCreees
+    }
     setResultat(res)
     setEtape('')
   }
@@ -411,11 +465,11 @@ export default function ImportView({ section = 'cuisine' }) {
                 <strong style={{ color: c.texte }}>Colonne A</strong><span>Nom de l&apos;article <span style={{ color: '#DC2626' }}>*</span></span>
                 <strong style={{ color: c.texte }}>Colonne B</strong><span>Prix HT en € (avec . ou ,)</span>
                 <strong style={{ color: c.texte }}>Colonne C</strong><span>Unité ({cfg.unitExamples})</span>
-                <strong style={{ color: accent }}>Colonne D</strong><span style={{ color: accent }}>Catégorie (doit correspondre exactement)</span>
+                <strong style={{ color: accent }}>Colonne D</strong><span style={{ color: accent }}>Catégorie (créée automatiquement si elle n&apos;existe pas)</span>
               </div>
               <div style={{ marginTop: '10px', paddingTop: '10px', borderTop: `0.5px solid ${c.bordure}`, fontSize: '12px' }}>
                 <div style={{ color: green, marginBottom: '2px' }}>✓ Les prix existants seront mis à jour automatiquement</div>
-                <div style={{ color: accent }}>✓ La catégorie doit correspondre exactement à une catégorie existante</div>
+                <div style={{ color: accent }}>✓ Les catégories absentes sont créées et liées aux ingrédients</div>
               </div>
             </div>
           ) : (
@@ -434,19 +488,19 @@ export default function ImportView({ section = 'cuisine' }) {
 
           {/* Alerte cat\u00e9gories inconnues (cuisine only) */}
           {cfg.hasCategories && categoriesInconnues.length > 0 && (
-            <div style={{ background: '#FEF3C7', border: '0.5px solid #FDE68A', borderRadius: '8px', padding: '12px 16px', marginBottom: '16px' }}>
-              <div style={{ fontSize: '13px', fontWeight: '500', color: '#92400E', marginBottom: '8px' }}>
-                ⚠️ {categoriesInconnues.length} catégorie{categoriesInconnues.length > 1 ? 's' : ''} non reconnue{categoriesInconnues.length > 1 ? 's' : ''} :
+            <div style={{ background: accentBg, border: `0.5px solid ${accent}40`, borderRadius: '8px', padding: '12px 16px', marginBottom: '16px' }}>
+              <div style={{ fontSize: '13px', fontWeight: '500', color: accent, marginBottom: '8px' }}>
+                ✨ {categoriesInconnues.length} nouvelle{categoriesInconnues.length > 1 ? 's' : ''} catégorie{categoriesInconnues.length > 1 ? 's' : ''} à créer :
               </div>
               <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
                 {categoriesInconnues.map(cat => (
-                  <span key={cat} style={{ background: '#FDE68A', color: '#92400E', borderRadius: '20px', padding: '2px 10px', fontSize: '12px', fontWeight: '500' }}>
+                  <span key={cat} style={{ background: c.blanc, color: accent, borderRadius: '20px', padding: '2px 10px', fontSize: '12px', fontWeight: '500', border: `0.5px solid ${accent}40` }}>
                     {cat}
                   </span>
                 ))}
               </div>
-              <div style={{ fontSize: '12px', color: '#92400E', marginTop: '8px' }}>
-                Ces ingrédients seront importés sans catégorie. Créez d&apos;abord les catégories manquantes dans la page Ingrédients.
+              <div style={{ fontSize: '12px', color: accent, marginTop: '8px' }}>
+                Ces catégories seront créées automatiquement à l&apos;import et les ingrédients y seront rattachés.
               </div>
             </div>
           )}
@@ -562,11 +616,12 @@ export default function ImportView({ section = 'cuisine' }) {
             </div>
 
             {cfg.hasCategories ? (
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '10px', marginBottom: '14px' }}>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: '10px', marginBottom: '14px' }}>
                 {[
                   { label: 'Nouveaux', value: resultat.importes, color: green },
                   { label: 'Mis \u00e0 jour', value: resultat.misAJour, color: '#D97706' },
-                  { label: 'Cat\u00e9gories', value: resultat.categoriesAssignees, color: accent },
+                  { label: 'Cat. cr\u00e9\u00e9es', value: resultat.categoriesCreees || 0, color: accent },
+                  { label: 'Cat. assign.', value: resultat.categoriesAssignees, color: accent },
                   { label: 'Erreurs', value: resultat.erreurs, color: resultat.erreurs > 0 ? '#DC2626' : c.texte },
                 ].map((s, i) => (
                   <div key={i} style={{ background: c.blanc, borderRadius: '8px', padding: '12px', textAlign: 'center' }}>

--- a/lib/achatsHelpers.js
+++ b/lib/achatsHelpers.js
@@ -99,7 +99,6 @@ export function enrichLigne(ligne, fournisseurMapping, ingredientsById, ingredie
 
   const ingId = ing?.id ?? null
   const prixActuel = ing ? Number(ing.prix_kg) : null
-  const prixLigneActuel = Number(ligne.prix_unitaire_ht) || 0
 
   // Distingue "prix auto-rempli" (depuis la mercuriale) vs "prix saisi par l'utilisateur".
   // - true : le prix vient d'un pré-remplissage automatique, on peut le réécrire/effacer
@@ -113,20 +112,25 @@ export function enrichLigne(ligne, fournisseurMapping, ingredientsById, ingredie
   let nouveauPrixAuto
   if (ing && prixAuto) {
     // Ingrédient reconnu + l'utilisateur n'a pas saisi son propre prix → prix de réf
-    prixLigne = prixActuel != null && Number.isFinite(prixActuel) ? prixActuel : 0
+    // (vide si l'ingrédient n'a pas de prix historique, pour ne pas afficher "0").
+    prixLigne = prixActuel != null && Number.isFinite(prixActuel) ? prixActuel : ''
     nouveauPrixAuto = true
   } else if (!ing && prixAuto) {
-    // Plus reconnu et le prix venait d'un pré-remplissage auto → reset à 0
-    prixLigne = 0
+    // Plus reconnu : reset à 0 pour les lignes OCR (qui avaient un prix
+    // extrait), mais préserve la chaîne vide pour une nouvelle ligne manuelle.
+    prixLigne = ligne.prix_unitaire_ht === '' || ligne.prix_unitaire_ht == null ? '' : 0
     nouveauPrixAuto = true
   } else {
-    // L'utilisateur a saisi son propre prix → on le respecte
-    prixLigne = prixLigneActuel
+    // L'utilisateur a saisi son propre prix → on respecte la chaîne brute.
+    // Convertir en Number ici casserait la saisie d'un décimal en cours
+    // (ex : "12." deviendrait 12 et le point serait perdu à chaque frappe).
+    prixLigne = ligne.prix_unitaire_ht ?? ''
     nouveauPrixAuto = false
   }
 
-  const delta = prixActuel && prixLigne && !nouveauPrixAuto
-    ? ((prixLigne - prixActuel) / prixActuel) * 100
+  const prixLigneNum = Number(prixLigne) || 0
+  const delta = prixActuel && prixLigneNum && !nouveauPrixAuto
+    ? ((prixLigneNum - prixActuel) / prixActuel) * 100
     : null
 
   // ── Pré-remplissage TVA ────────────────────────────────────────────────


### PR DESCRIPTION
## Problèmes signalés

1. À l'import Excel d'une liste d'ingrédients, plusieurs catégories n'étaient pas reconnues et n'étaient pas créées automatiquement → les ingrédients arrivaient sans catégorie.
2. Tentative de suppression de 1709 articles d'un coup → erreur silencieuse.

## Changements

### Auto-création des catégories à l'import (`components/ImportView.jsx`)

- Avant le batch d'import, on collecte les noms de catégories du fichier qui n'existent pas en base, on les insère dans `categories_ingredients` (avec `emoji: 📦` par défaut), puis on rattache les ingrédients à leur nouvelle catégorie.
- Bandeau d'avertissement repris en ton "création" plutôt que warning : "✨ X nouvelles catégories à créer".
- Nouveau compteur **Cat. créées** dans le récap final.
- Format attendu mis à jour : "Catégorie (créée automatiquement si elle n'existe pas)".

### Suppression en cascade (`app/ingredients/page.js`)

Choix utilisateur : **tout supprimer en cascade**, y compris les ingrédients utilisés dans des fiches techniques.

- Avant de supprimer les ingrédients : `DELETE FROM fiche_ingredients WHERE ingredient_id IN (...)` — sinon la FK bloque la suppression.
- Détache aussi `achats_lignes.ingredient_id`, `inventaire_lignes.ingredient_id` et `fournisseur_mapping.ingredient_id` pour ne pas perdre l'historique des factures/inventaires (les lignes restent visibles, juste plus liées à l'ingrédient supprimé).
- **Batching** : 1709 UUIDs dans un seul `.in()` flirte avec la limite de longueur d'URL côté PostgREST. On chunke par 500.
- **Confirmation enrichie** : affiche aussi le nombre de lignes de fiches qui seront retirées en cascade (pour que l'utilisateur sache que les coûts des fiches devront être recalculés).
- **Erreur explicite** : affiche le message Supabase si quelque chose plante, au lieu du "Erreur lors de la suppression" muet précédent.

## Test plan
- [ ] Préparer un xlsx avec 3-4 catégories nouvelles, importer → bandeau "✨ X nouvelles catégories à créer", récap affiche "Cat. créées : N", page Ingrédients montre les nouvelles catégories avec les ingrédients dedans.
- [ ] Vérifier qu'un import avec catégories existantes seules ne crée rien en doublon (matching par nom insensible à la casse).
- [ ] Sur `/ingredients`, sélectionner ~100 ingrédients dont certains utilisés dans des fiches, supprimer → la confirmation mentionne le nombre de lignes de fiches retirées, l'opération réussit, les fiches concernées ont leurs lignes retirées.
- [ ] Vérifier les factures/inventaires historiques : les lignes des ingrédients supprimés sont toujours visibles (designation conservée, ingredient_id à null).
- [ ] Sélectionner les 1709 ingrédients via le filtre "Sans catégorie" → suppression réussit (chunkée à 500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)