### PR TITLE
feat(bar): auto-création des catégories à l'import bar

### DIFF
--- a/app/bar/ingredients/page.js
+++ b/app/bar/ingredients/page.js
@@ -12,6 +12,7 @@ import ChefLoader from '../../../components/ChefLoader'
 
 export default function BarIngredientsPage() {
   const [ingredients, setIngredients] = useState([])
+  const [categories, setCategories] = useState([])
   const [loading, setLoading] = useState(true)
   const [recherche, setRecherche] = useState('')
   const [filtreCategorie, setFiltreCategorie] = useState('toutes')
@@ -48,14 +49,23 @@ export default function BarIngredientsPage() {
     const clientId = await getClientId()
     if (!clientId) { router.push('/'); return }
 
-    const { data } = await supabase
-      .from('ingredients_bar')
-      .select('*, fiche_bar_ingredients(id)')
-      .eq('client_id', clientId)
-      .eq('est_sous_fiche', false)
-      .order('nom')
-      .limit(5000)
-    setIngredients(data || [])
+    const [{ data: ings }, { data: cats }] = await Promise.all([
+      supabase
+        .from('ingredients_bar')
+        .select('*, fiche_bar_ingredients(id)')
+        .eq('client_id', clientId)
+        .eq('est_sous_fiche', false)
+        .order('nom')
+        .limit(5000),
+      supabase
+        .from('categories_ingredients')
+        .select('id, nom, emoji, ordre')
+        .eq('client_id', clientId)
+        .eq('section', 'bar')
+        .order('ordre')
+    ])
+    setIngredients(ings || [])
+    setCategories(cats || [])
     setSelection([])
     setLoading(false)
   }
@@ -189,6 +199,9 @@ export default function BarIngredientsPage() {
           >
             <option value="toutes">Toutes catégories</option>
             <option value="sans_categorie">📦 Sans catégorie</option>
+            {categories.map(cat => (
+              <option key={cat.id} value={cat.id}>{cat.emoji || '📦'} {cat.nom}</option>
+            ))}
           </select>
           <span style={{ fontSize: '12px', color: c.texteMuted, whiteSpace: 'nowrap' }}>
             {ingredientsFiltres.length}{selection.length > 0 && ` — ${selection.length} sél.`}

--- a/components/ImportView.jsx
+++ b/components/ImportView.jsx
@@ -14,6 +14,7 @@ const CONFIG = {
   cuisine: {
     table: 'ingredients',
     categoriesTable: 'categories_ingredients',
+    categorySection: 'cuisine',
     defaultUnit: 'kg',
     unitExamples: 'kg, L, u\u2026',
     recalculRpc: 'recalculer_cout_portions',
@@ -49,7 +50,8 @@ const CONFIG = {
   },
   bar: {
     table: 'ingredients_bar',
-    categoriesTable: null,
+    categoriesTable: 'categories_ingredients',
+    categorySection: 'bar',
     defaultUnit: 'cl',
     unitExamples: 'cl, ml, L...',
     recalculRpc: 'recalculer_cout_portions_bar',
@@ -66,13 +68,13 @@ const CONFIG = {
     recalculButtonPost: '\ud83d\udd04 Recalculer toutes les fiches bar',
     importLabel: 'Import Excel des ingr\u00e9dients bar',
     hasTemplate: false,
-    hasCategories: false,
-    showCategoryInPreview: false,
+    hasCategories: true,
+    showCategoryInPreview: true,
     afterImportRoute: '/bar/fiches',
     afterImportLabel: 'Voir les fiches bar',
     logEntite: 'ingredients_bar',
     logSection: 'bar',
-    logDetails: (total, ignores) => `${total} ingr\u00e9dients bar trait\u00e9s, ${ignores} ignor\u00e9s`,
+    logDetails: (total, ignores, categoriesAssignees) => `${total} ingr\u00e9dients bar trait\u00e9s, ${ignores} ignor\u00e9s, ${categoriesAssignees} cat\u00e9gories assign\u00e9es`,
     templateFileName: null,
     templateSheetName: null,
     templateRows: null,
@@ -131,7 +133,7 @@ export default function ImportView({ section = 'cuisine' }) {
     setCategoriesFichier([])
     setCategoriesSelectionnees([])
 
-    // Load category map for cuisine section
+    // Charge la map des catégories du même section (cuisine / bar).
     let categoriesMap = {}
     if (cfg.hasCategories) {
       const clientId = await getClientId()
@@ -139,6 +141,7 @@ export default function ImportView({ section = 'cuisine' }) {
         .from(cfg.categoriesTable)
         .select('id, nom')
         .eq('client_id', clientId)
+        .eq('section', cfg.categorySection)
       ;(cats || []).forEach(cat => {
         categoriesMap[cat.nom.toLowerCase().trim()] = cat.id
       })
@@ -224,6 +227,7 @@ export default function ImportView({ section = 'cuisine' }) {
         .from(cfg.categoriesTable)
         .select('id, nom, ordre')
         .eq('client_id', clientId)
+        .eq('section', cfg.categorySection)
       ;(existingCats || []).forEach(cat => {
         catMap[cat.nom.toLowerCase().trim()] = cat.id
       })
@@ -240,6 +244,7 @@ export default function ImportView({ section = 'cuisine' }) {
           nom,
           emoji: '📦',
           client_id: clientId,
+          section: cfg.categorySection,
           ordre: maxOrdre + idx + 1,
         }))
         const { data: created, error: errCat } = await supabase


### PR DESCRIPTION
## Contexte

Suite à [apps#112](https://github.com/antonydespaux-bit/skalcook/pull/112) qui a ajouté l'auto-création des catégories pour les imports cuisine, on porte la même logique sur les imports bar.

Portée volontairement minimale (choix utilisateur) : **auto-création à l'import uniquement**, pas de UI manuelle de gestion des catégories bar.

## Changements

### \`components/ImportView.jsx\`

- Config bar : \`hasCategories: true\` + \`categorySection: 'bar'\` + \`showCategoryInPreview: true\`. La table \`categories_ingredients\` étant partagée entre cuisine et bar (avec une colonne \`section\`), on ajoute aussi un \`categorySection: 'cuisine'\` au config cuisine et on filtre côté requête.
- Toutes les lectures et le rechargement des catégories filtrent maintenant par \`section\` — sans ça, un import cuisine aurait pu matcher par hasard une catégorie bar (et inversement après ce changement).
- L'insert d'une nouvelle catégorie pose explicitement \`section: cfg.categorySection\`.

### \`app/bar/ingredients/page.js\`

- Charge les catégories bar en parallèle des ingrédients et les liste dans le dropdown filtre. Sans ça, les catégories créées à l'import seraient invisibles depuis cette page pour filtrer les ingrédients.

## Hors scope (peut venir plus tard si besoin)

- Onglet "Catégories" avec CRUD complet sur la page bar ingredients (création/édition/suppression manuelles).
- Dropdown catégorie dans le formulaire d'ajout/édition d'un ingrédient bar.
- Colonne Catégorie dans le tableau / carte mobile.

## Test plan
- [ ] Préparer un xlsx avec un mix de catégories existantes et nouvelles, l'importer via Bar > Ingrédients > Import → bandeau "✨ X nouvelles catégories à créer" s'affiche, le récap final montre "Cat. créées : N" et "Cat. assign. : M".
- [ ] Sur la page Bar > Ingrédients, le dropdown filtre montre désormais les catégories créées (avec leur emoji 📦), permet de filtrer par catégorie.
- [ ] Vérifier qu'on ne crée pas de doublon : ré-importer le même fichier → "Cat. créées : 0" (toutes déjà en base).
- [ ] Vérifier que les catégories cuisine et bar restent bien séparées (pas de pollution croisée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)