### PR TITLE
fix(bar): suppression d'ingrédients bar en cascade

### DIFF
--- a/app/bar/ingredients/page.js
+++ b/app/bar/ingredients/page.js
@@ -100,18 +100,50 @@ export default function BarIngredientsPage() {
   }
 
   const supprimerSelection = async () => {
-    if (!confirm(`Supprimer ${selection.length} ingrédient${selection.length > 1 ? 's' : ''} ?`)) return
+    const selSet = new Set(selection)
+    const ingsConcernes = ingredients.filter(i => selSet.has(i.id))
+    const nbLiesAFiches = ingsConcernes.reduce(
+      (s, i) => s + (Array.isArray(i.fiche_bar_ingredients) ? i.fiche_bar_ingredients.length : 0),
+      0
+    )
+    const message = nbLiesAFiches > 0
+      ? `Supprimer ${selection.length} ingrédient${selection.length > 1 ? 's' : ''} bar ?\n\n${nbLiesAFiches} ligne${nbLiesAFiches > 1 ? 's' : ''} de fiches bar ${nbLiesAFiches > 1 ? 'seront retirées' : 'sera retirée'} en cascade (les coûts des fiches concernées devront être recalculés).\n\nAction irréversible.`
+      : `Supprimer ${selection.length} ingrédient${selection.length > 1 ? 's' : ''} bar ? Action irréversible.`
+    if (!confirm(message)) return
     setSupprimant(true)
-    const clientId = await getClientId()
-    if (!clientId) { setSupprimant(false); return }
-    await supabase.from('ingredients_bar').delete().in('id', selection).eq('client_id', clientId)
-    await log({
-      action: 'SUPPRESSION', entite: 'ingredient_bar',
-      entite_nom: `${selection.length} ingrédients`, section: 'bar',
-      details: `IDs: ${selection.join(', ')}`
-    })
-    await loadIngredients()
-    setSupprimant(false)
+    try {
+      const clientId = await getClientId()
+      if (!clientId) return
+      const CHUNK = 500
+      const chunks = []
+      for (let i = 0; i < selection.length; i += CHUNK) {
+        chunks.push(selection.slice(i, i + CHUNK))
+      }
+      for (const ids of chunks) {
+        // Cascade : supprime d'abord les lignes de fiches bar liées
+        // (sinon la FK fiche_bar_ingredients.ingredient_id bloque).
+        const { error: errFiches } = await supabase
+          .from('fiche_bar_ingredients')
+          .delete()
+          .in('ingredient_id', ids)
+          .eq('client_id', clientId)
+        if (errFiches) throw errFiches
+        // Détache l'historique des inventaires (les lignes restent visibles).
+        await supabase.from('inventaire_lignes').update({ ingredient_id: null }).in('ingredient_id', ids).eq('client_id', clientId)
+        // Suppression des ingrédients bar de ce chunk
+        const { error } = await supabase.from('ingredients_bar').delete().in('id', ids).eq('client_id', clientId)
+        if (error) throw error
+      }
+      await log({
+        action: 'SUPPRESSION', entite: 'ingredient_bar',
+        entite_nom: `${selection.length} ingrédients`, section: 'bar',
+        details: `${selection.length} supprimés, ${nbLiesAFiches} lignes de fiches bar retirées en cascade`,
+      })
+      await loadIngredients()
+    } catch (err) {
+      console.error('Delete bar error:', err)
+      alert(`Erreur lors de la suppression : ${err.message || err.code || 'inconnue'}`)
+    } finally { setSupprimant(false) }
   }
 
   const ajouterIngredient = async () => {

--- a/app/bar/ingredients/page.js
+++ b/app/bar/ingredients/page.js
@@ -12,6 +12,7 @@ import ChefLoader from '../../../components/ChefLoader'
 
 export default function BarIngredientsPage() {
   const [ingredients, setIngredients] = useState([])
+  const [categories, setCategories] = useState([])
   const [loading, setLoading] = useState(true)
   const [recherche, setRecherche] = useState('')
   const [filtreCategorie, setFiltreCategorie] = useState('toutes')
@@ -48,14 +49,23 @@ export default function BarIngredientsPage() {
     const clientId = await getClientId()
     if (!clientId) { router.push('/'); return }
 
-    const { data } = await supabase
-      .from('ingredients_bar')
-      .select('*, fiche_bar_ingredients(id)')
-      .eq('client_id', clientId)
-      .eq('est_sous_fiche', false)
-      .order('nom')
-      .limit(5000)
-    setIngredients(data || [])
+    const [{ data: ings }, { data: cats }] = await Promise.all([
+      supabase
+        .from('ingredients_bar')
+        .select('*, fiche_bar_ingredients(id)')
+        .eq('client_id', clientId)
+        .eq('est_sous_fiche', false)
+        .order('nom')
+        .limit(5000),
+      supabase
+        .from('categories_ingredients')
+        .select('id, nom, emoji, ordre')
+        .eq('client_id', clientId)
+        .eq('section', 'bar')
+        .order('ordre')
+    ])
+    setIngredients(ings || [])
+    setCategories(cats || [])
     setSelection([])
     setLoading(false)
   }
@@ -189,6 +199,9 @@ export default function BarIngredientsPage() {
           >
             <option value="toutes">Toutes catégories</option>
             <option value="sans_categorie">📦 Sans catégorie</option>
+            {categories.map(cat => (
+              <option key={cat.id} value={cat.id}>{cat.emoji || '📦'} {cat.nom}</option>
+            ))}
           </select>
           <span style={{ fontSize: '12px', color: c.texteMuted, whiteSpace: 'nowrap' }}>
             {ingredientsFiltres.length}{selection.length > 0 && ` — ${selection.length} sél.`}

--- a/components/ImportView.jsx
+++ b/components/ImportView.jsx
@@ -14,6 +14,7 @@ const CONFIG = {
   cuisine: {
     table: 'ingredients',
     categoriesTable: 'categories_ingredients',
+    categorySection: 'cuisine',
     defaultUnit: 'kg',
     unitExamples: 'kg, L, u\u2026',
     recalculRpc: 'recalculer_cout_portions',
@@ -49,7 +50,8 @@ const CONFIG = {
   },
   bar: {
     table: 'ingredients_bar',
-    categoriesTable: null,
+    categoriesTable: 'categories_ingredients',
+    categorySection: 'bar',
     defaultUnit: 'cl',
     unitExamples: 'cl, ml, L...',
     recalculRpc: 'recalculer_cout_portions_bar',
@@ -66,13 +68,13 @@ const CONFIG = {
     recalculButtonPost: '\ud83d\udd04 Recalculer toutes les fiches bar',
     importLabel: 'Import Excel des ingr\u00e9dients bar',
     hasTemplate: false,
-    hasCategories: false,
-    showCategoryInPreview: false,
+    hasCategories: true,
+    showCategoryInPreview: true,
     afterImportRoute: '/bar/fiches',
     afterImportLabel: 'Voir les fiches bar',
     logEntite: 'ingredients_bar',
     logSection: 'bar',
-    logDetails: (total, ignores) => `${total} ingr\u00e9dients bar trait\u00e9s, ${ignores} ignor\u00e9s`,
+    logDetails: (total, ignores, categoriesAssignees) => `${total} ingr\u00e9dients bar trait\u00e9s, ${ignores} ignor\u00e9s, ${categoriesAssignees} cat\u00e9gories assign\u00e9es`,
     templateFileName: null,
     templateSheetName: null,
     templateRows: null,
@@ -131,7 +133,7 @@ export default function ImportView({ section = 'cuisine' }) {
     setCategoriesFichier([])
     setCategoriesSelectionnees([])
 
-    // Load category map for cuisine section
+    // Charge la map des catégories du même section (cuisine / bar).
     let categoriesMap = {}
     if (cfg.hasCategories) {
       const clientId = await getClientId()
@@ -139,6 +141,7 @@ export default function ImportView({ section = 'cuisine' }) {
         .from(cfg.categoriesTable)
         .select('id, nom')
         .eq('client_id', clientId)
+        .eq('section', cfg.categorySection)
       ;(cats || []).forEach(cat => {
         categoriesMap[cat.nom.toLowerCase().trim()] = cat.id
       })
@@ -224,6 +227,7 @@ export default function ImportView({ section = 'cuisine' }) {
         .from(cfg.categoriesTable)
         .select('id, nom, ordre')
         .eq('client_id', clientId)
+        .eq('section', cfg.categorySection)
       ;(existingCats || []).forEach(cat => {
         catMap[cat.nom.toLowerCase().trim()] = cat.id
       })
@@ -240,6 +244,7 @@ export default function ImportView({ section = 'cuisine' }) {
           nom,
           emoji: '📦',
           client_id: clientId,
+          section: cfg.categorySection,
           ordre: maxOrdre + idx + 1,
         }))
         const { data: created, error: errCat } = await supabase


### PR DESCRIPTION
## Problème

La suppression d'ingrédients bar (en lot ou unitaire) ne fait rien : popup de confirmation OK, puis "rien ne se passe", les ingrédients restent.

## Cause

Symétrique au problème [apps#112](https://github.com/antonydespaux-bit/skalcook/pull/112) côté cuisine, mais en pire : le code bar n'a jamais vérifié l'erreur Supabase, donc la FK \`fiche_bar_ingredients.ingredient_id\` qui bloque la suppression échouait silencieusement.

\`\`\`js
await supabase.from('ingredients_bar').delete().in('id', selection)...
// Pas de check d'erreur, puis await loadIngredients() qui rafraîchit
// → l'utilisateur voit les mêmes ingrédients
\`\`\`

## Fix

Aligne le comportement bar sur le fix cuisine de [apps#112](https://github.com/antonydespaux-bit/skalcook/pull/112) :

- Avant de supprimer : \`DELETE FROM fiche_bar_ingredients WHERE ingredient_id IN (...)\` pour lever le blocage FK.
- Détache aussi \`inventaire_lignes.ingredient_id\` (les lignes d'inventaires bar restent lisibles après coup).
- Chunks de 500 IDs (au cas où l'utilisateur sélectionne plusieurs centaines).
- Confirmation enrichie : montre le nombre de lignes de fiches bar qui partiront en cascade.
- **Message d'erreur explicite** si la suppression échoue (au lieu du précédent échec silencieux).

## Test plan
- [ ] Sélectionner un ou plusieurs ingrédients bar dont au moins un est utilisé dans une fiche bar → la confirmation mentionne le nombre de lignes de fiches qui seront retirées.
- [ ] Cliquer Supprimer → les ingrédients sont bien retirés, la page se recharge avec moins d'ingrédients.
- [ ] Vérifier qu'une fiche qui contenait un de ces ingrédients a maintenant cette ligne supprimée (coût à recalculer).
- [ ] Sélectionner un ingrédient bar non utilisé en fiche → confirmation simple, suppression propre.
- [ ] Si la suppression échoue (ex. permission), un message d'erreur explicite s'affiche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)