### PR TITLE
feat(ingredients): bouton Export Excel sur la liste

### DIFF
--- a/components/IngredientsView.jsx
+++ b/components/IngredientsView.jsx
@@ -2,6 +2,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { supabase, getClientId } from '../lib/supabase'
 import { useRouter } from 'next/navigation'
+import * as XLSX from 'xlsx'
 import { useIsMobile } from '../lib/useIsMobile'
 import { useTheme } from '../lib/useTheme'
 import { useRole } from '../lib/useRole'
@@ -267,6 +268,27 @@ export default function IngredientsView({ section = 'cuisine' }) {
     } finally { setSupprimant(false) }
   }
 
+  // ── Export Excel ──────────────────────────────────────────────────────────
+  // Exporte la liste filtrée (mêmes colonnes que le modèle d'import, pour
+  // permettre un round-trip "export → édition → ré-import").
+  const exporterExcel = () => {
+    const rows = [
+      ['Nom', 'Prix HT (€)', 'Unité', 'Catégorie'],
+      ...ingredientsFiltres.map(i => [
+        i.nom,
+        i.prix_kg != null ? Number(i.prix_kg) : '',
+        i.unite || '',
+        i.categories_ingredients?.nom || '',
+      ])
+    ]
+    const wb = XLSX.utils.book_new()
+    const ws = XLSX.utils.aoa_to_sheet(rows)
+    ws['!cols'] = [{ wch: 30 }, { wch: 15 }, { wch: 10 }, { wch: 25 }]
+    XLSX.utils.book_append_sheet(wb, ws, section === 'bar' ? 'Ingrédients bar' : 'Ingrédients')
+    const dateStr = new Date().toISOString().slice(0, 10)
+    XLSX.writeFile(wb, `ingredients_${section}_${dateStr}.xlsx`)
+  }
+
   // ── Ajout ingrédient ──────────────────────────────────────────────────────
   const ajouterIngredient = async () => {
     if (!nouveauNom.trim()) return
@@ -475,6 +497,17 @@ export default function IngredientsView({ section = 'cuisine' }) {
                     borderRadius: '8px', padding: '8px 12px', fontSize: '13px', fontWeight: '500', cursor: 'pointer'
                   }}>{supprimant ? '...' : `🗑 Supprimer (${selection.length})`}</button>
                 )}
+                <button
+                  onClick={exporterExcel}
+                  disabled={ingredientsFiltres.length === 0}
+                  title={ingredientsFiltres.length === 0 ? 'Aucun ingrédient à exporter' : `Exporter ${ingredientsFiltres.length} ingrédient${ingredientsFiltres.length > 1 ? 's' : ''}`}
+                  style={{
+                    background: c.blanc, color: c.texteMuted, border: `0.5px solid ${c.bordure}`,
+                    borderRadius: '8px', padding: '8px 12px', fontSize: '13px',
+                    cursor: ingredientsFiltres.length === 0 ? 'not-allowed' : 'pointer',
+                    opacity: ingredientsFiltres.length === 0 ? 0.5 : 1,
+                  }}
+                >{isMobile ? '📤' : '📤 Export Excel'}</button>
                 {peutModifier && (
                   <button onClick={() => router.push(cfg.importPath)} style={{
                     background: c.blanc, color: c.texteMuted, border: `0.5px solid ${c.bordure}`,


### PR DESCRIPTION
## Demande

Pouvoir exporter la liste des ingrédients en Excel (équivalent du bouton Import existant).

## Implémentation

- Nouveau bouton **📤 Export Excel** à côté du bouton Import Excel, sur les pages \`/ingredients\` (cuisine) et \`/bar/ingredients\` — un seul changement dans le composant partagé \`IngredientsView.jsx\`.
- Exporte la **liste filtrée** : si l'utilisateur a un filtre catégorie ou usage actif, seul le sous-ensemble part. Pour exporter tout, il décoche les filtres avant.
- Colonnes du fichier exporté identiques à celles du modèle d'import (\`Nom\`, \`Prix HT (€)\`, \`Unité\`, \`Catégorie\`) — permet un workflow **export → édition dans Excel → ré-import** sans avoir à reformater.
- Disponible pour tous les rôles (le bouton n'est pas conditionné à \`peutModifier\`) — un \`directeur\` qui consulte peut aussi exporter.
- Nom du fichier : \`ingredients_cuisine_2026-05-19.xlsx\` ou \`ingredients_bar_2026-05-19.xlsx\`.

## Test plan
- [ ] Sur /ingredients, cliquer Export Excel sans filtre → fichier contient tous les ingrédients cuisine, format colonnes identique au modèle d'import.
- [ ] Filtrer par catégorie "Légumes" → exporter → fichier ne contient que les légumes.
- [ ] Filtrer "Non utilisés" → exporter → fichier ne contient que les ingrédients non utilisés en fiche.
- [ ] Sur /bar/ingredients, idem — fichier nommé \`ingredients_bar_...\`.
- [ ] Réimporter le fichier exporté → l'import doit fonctionner sans erreur (round-trip).
- [ ] Bouton désactivé quand la liste filtrée est vide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)