### PR TITLE
fix(bar): contexte ?section=bar préservé sur les pages inventaire

### DIFF
--- a/app/inventaire/[id]/page.js
+++ b/app/inventaire/[id]/page.js
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect } from 'react'
 import { supabase, getClientId } from '../../../lib/supabase'
-import { useRouter, useParams } from 'next/navigation'
+import { useRouter, useParams, useSearchParams } from 'next/navigation'
 import { useTheme } from '../../../lib/useTheme'
 import { useIsMobile } from '../../../lib/useIsMobile'
 import Navbar from '../../../components/Navbar'
@@ -11,8 +11,21 @@ export default function DetailInventairePage() {
   const params = useParams()
   const inventaireId = params.id
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { c } = useTheme()
   const isMobile = useIsMobile()
+
+  // Préserve le contexte ?section= entre la liste et le détail/saisie pour
+  // que la navbar reste cohérente (cf. #113). Le param URL prime sur la
+  // section de l'inventaire — sinon un admin venant de bar perdrait son
+  // contexte en ouvrant un inventaire 'global'.
+  const sectionParam = searchParams.get('section')
+  const queryString = sectionParam === 'bar' || sectionParam === 'cuisine' ? `?section=${sectionParam}` : ''
+  const navbarSection = inv => {
+    if (sectionParam === 'bar') return 'bar'
+    if (sectionParam === 'cuisine') return 'cuisine'
+    return inv?.section === 'bar' ? 'bar' : 'cuisine'
+  }
 
   const [inventaire, setInventaire] = useState(null)
   const [lignes, setLignes] = useState([])
@@ -31,7 +44,7 @@ export default function DetailInventairePage() {
       supabase.from('inventaire_lignes').select('*').eq('inventaire_id', inventaireId).eq('client_id', clientId).order('nom_ingredient'),
     ])
 
-    if (!inv) { router.push('/inventaire'); return }
+    if (!inv) { router.push(`/inventaire${queryString}`); return }
     setInventaire(inv)
     setLignes(lig || [])
     setLoading(false)
@@ -67,7 +80,7 @@ export default function DetailInventairePage() {
 
   if (loading) return (
     <div style={{ minHeight: '100vh', background: c.fond }}>
-      <Navbar section="cuisine" />
+      <Navbar section={sectionParam === 'bar' ? 'bar' : 'cuisine'} />
       <ChefLoader />
     </div>
   )
@@ -96,14 +109,14 @@ export default function DetailInventairePage() {
 
   return (
     <div style={{ minHeight: '100vh', background: c.fond }}>
-      <Navbar section={inventaire?.section === 'bar' ? 'bar' : 'cuisine'} />
+      <Navbar section={navbarSection(inventaire)} />
 
       <div style={{ padding: isMobile ? '12px' : '24px', maxWidth: '800px', margin: '0 auto' }}>
 
         {/* Header */}
         <div style={{ marginBottom: '20px' }}>
           <button
-            onClick={() => router.push('/inventaire')}
+            onClick={() => router.push(`/inventaire${queryString}`)}
             style={{ background: 'none', border: 'none', color: c.texteMuted, fontSize: '13px', cursor: 'pointer', padding: 0, marginBottom: '12px' }}
           >
             ← Inventaires
@@ -211,7 +224,7 @@ export default function DetailInventairePage() {
         {isBrouillon && (
           <div style={{ display: 'flex', gap: '10px', marginTop: '20px', flexWrap: 'wrap' }}>
             <button
-              onClick={() => router.push(`/inventaire/${inventaireId}/saisie`)}
+              onClick={() => router.push(`/inventaire/${inventaireId}/saisie${queryString}`)}
               style={{
                 flex: 1, padding: '14px', background: c.blanc,
                 border: `1px solid ${c.accent}`, color: c.accent,

--- a/app/inventaire/[id]/saisie/page.js
+++ b/app/inventaire/[id]/saisie/page.js
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { supabase, getClientId } from '../../../../lib/supabase'
-import { useRouter, useParams } from 'next/navigation'
+import { useRouter, useParams, useSearchParams } from 'next/navigation'
 import { useTheme } from '../../../../lib/useTheme'
 import { useRole } from '../../../../lib/useRole'
 import { useIsMobile } from '../../../../lib/useIsMobile'
@@ -13,9 +13,15 @@ export default function SaisieInventairePage() {
   const params = useParams()
   const inventaireId = params.id
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { c } = useTheme()
   const { role } = useRole()
   const isMobile = useIsMobile()
+
+  // Préserve le contexte ?section= (bar / cuisine) entre les pages
+  // inventaire pour que la navbar reste cohérente.
+  const sectionParam = searchParams.get('section')
+  const queryString = sectionParam === 'bar' || sectionParam === 'cuisine' ? `?section=${sectionParam}` : ''
 
   const [inventaire, setInventaire] = useState(null)
   const [lignes, setLignes] = useState([])
@@ -49,8 +55,8 @@ export default function SaisieInventairePage() {
       .eq('client_id', clientId)
       .maybeSingle()
 
-    if (!inv) { router.push('/inventaire'); return }
-    if (inv.statut === 'valide') { router.push(`/inventaire/${inventaireId}`); return }
+    if (!inv) { router.push(`/inventaire${queryString}`); return }
+    if (inv.statut === 'valide') { router.push(`/inventaire/${inventaireId}${queryString}`); return }
     setInventaire(inv)
 
     // Charger les lignes
@@ -146,7 +152,7 @@ export default function SaisieInventairePage() {
         body: JSON.stringify({ inventaireId, clientId })
       })
       if (res.ok) {
-        router.push(`/inventaire/${inventaireId}`)
+        router.push(`/inventaire/${inventaireId}${queryString}`)
       } else {
         const json = await res.json()
         alert(json.error || 'Erreur lors de la validation.')
@@ -203,14 +209,14 @@ export default function SaisieInventairePage() {
 
   if (loading) return (
     <div style={{ minHeight: '100vh', background: c.fond }}>
-      <Navbar section="cuisine" />
+      <Navbar section={sectionParam === 'bar' ? 'bar' : 'cuisine'} />
       <ChefLoader />
     </div>
   )
 
   return (
     <div style={{ minHeight: '100vh', background: c.fond }}>
-      <Navbar section={inventaire?.section === 'bar' ? 'bar' : 'cuisine'} />
+      <Navbar section={sectionParam === 'bar' ? 'bar' : sectionParam === 'cuisine' ? 'cuisine' : (inventaire?.section === 'bar' ? 'bar' : 'cuisine')} />
 
       <div style={{ padding: isMobile ? '12px' : '24px', maxWidth: '700px', margin: '0 auto' }}>
 
@@ -218,7 +224,7 @@ export default function SaisieInventairePage() {
         <div style={{ marginBottom: '16px' }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' }}>
             <button
-              onClick={() => router.push('/inventaire')}
+              onClick={() => router.push(`/inventaire${queryString}`)}
               style={{ background: 'none', border: 'none', color: c.texteMuted, fontSize: '13px', cursor: 'pointer', padding: 0 }}
             >
               ← Inventaires
@@ -416,7 +422,7 @@ export default function SaisieInventairePage() {
         <div style={{ position: 'sticky', bottom: '16px', padding: '12px 0', marginTop: '16px' }}>
           <div style={{ display: 'flex', gap: '8px' }}>
             <button
-              onClick={() => router.push('/inventaire')}
+              onClick={() => router.push(`/inventaire${queryString}`)}
               style={{
                 flex: 1, padding: '14px', background: c.blanc,
                 border: `0.5px solid ${c.bordure}`, borderRadius: '12px',

--- a/app/inventaire/nouveau/page.js
+++ b/app/inventaire/nouveau/page.js
@@ -1,7 +1,7 @@
 'use client'
 import { useState } from 'react'
 import { supabase, getClientId } from '../../../lib/supabase'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useTheme } from '../../../lib/useTheme'
 import { useRole } from '../../../lib/useRole'
 import { useIsMobile } from '../../../lib/useIsMobile'
@@ -16,11 +16,21 @@ export default function NouvelInventairePage() {
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState('')
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { c } = useTheme()
   const { role } = useRole()
   const isMobile = useIsMobile()
 
-  const canChooseSection = role === 'admin' || role === 'directeur'
+  // ?section=bar/cuisine passé depuis la navbar bar : pré-sélectionne la
+  // section et force la navbar dans le bon contexte.
+  const sectionParam = searchParams.get('section')
+  const sectionForced = sectionParam === 'bar' || sectionParam === 'cuisine' ? sectionParam : null
+  const navbarSection = sectionForced || (role === 'bar' ? 'bar' : 'cuisine')
+  const queryString = sectionForced ? `?section=${sectionForced}` : ''
+
+  // Si une section est imposée par l'URL, on n'autorise plus le choix manuel
+  // (l'utilisateur reste dans le contexte d'où il vient).
+  const canChooseSection = !sectionForced && (role === 'admin' || role === 'directeur')
 
   const handleCreate = async (chosenSection, chosenType, chosenCategorieIds) => {
     setCreating(true)
@@ -55,7 +65,7 @@ export default function NouvelInventairePage() {
         return
       }
 
-      router.push(`/inventaire/${data.inventaire.id}/saisie`)
+      router.push(`/inventaire/${data.inventaire.id}/saisie${queryString}`)
     } catch (err) {
       setError('Erreur réseau.')
       setCreating(false)
@@ -89,7 +99,9 @@ export default function NouvelInventairePage() {
   const selectType = (t) => {
     setType(t)
     if (!canChooseSection) {
-      const sec = role === 'bar' ? 'bar' : 'cuisine'
+      // Si la section est imposée par l'URL, on l'utilise directement.
+      // Sinon, fallback au rôle (bar → bar, autre → cuisine).
+      const sec = sectionForced || (role === 'bar' ? 'bar' : 'cuisine')
       goToCategoryStep(sec, t)
     } else {
       setStep(2)
@@ -126,7 +138,7 @@ export default function NouvelInventairePage() {
 
   return (
     <div style={{ minHeight: '100vh', background: c.fond }}>
-      <Navbar section={role === 'bar' ? 'bar' : 'cuisine'} />
+      <Navbar section={navbarSection} />
 
       <div style={{ padding: isMobile ? '16px' : '24px', maxWidth: '600px', margin: '0 auto' }}>
 

--- a/app/inventaire/page.js
+++ b/app/inventaire/page.js
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect, useMemo } from 'react'
 import { supabase, getClientId } from '../../lib/supabase'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useTheme } from '../../lib/useTheme'
 import { useRole } from '../../lib/useRole'
 import { useIsMobile } from '../../lib/useIsMobile'
@@ -19,21 +19,34 @@ export default function InventairePage() {
   const [filtre, setFiltre] = useState('tous')
   const [deleting, setDeleting] = useState(null)
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { c } = useTheme()
   const { role } = useRole()
   const isMobile = useIsMobile()
 
-  useEffect(() => { loadInventaires() }, [])
+  // ?section=bar (depuis la navbar bar) ou ?section=cuisine filtre la liste
+  // et force la navbar côté contexte utilisateur. Sans param, l'utilisateur
+  // voit tout (utile pour admin/directeur).
+  const sectionParam = searchParams.get('section')
+  const sectionFiltre = sectionParam === 'bar' || sectionParam === 'cuisine' ? sectionParam : null
+  const navbarSection = sectionFiltre || (role === 'bar' ? 'bar' : 'cuisine')
+  const queryString = sectionFiltre ? `?section=${sectionFiltre}` : ''
+
+  useEffect(() => { loadInventaires() }, [sectionFiltre])
 
   const loadInventaires = async () => {
     const clientId = await getClientId()
     if (!clientId) { router.push('/'); return }
 
-    const { data } = await supabase
+    let query = supabase
       .from('inventaires')
       .select('*')
       .eq('client_id', clientId)
-      .order('date_inventaire', { ascending: false })
+    if (sectionFiltre) {
+      // Inclut les inventaires "global" qui couvrent les deux sections.
+      query = query.in('section', [sectionFiltre, 'global'])
+    }
+    const { data } = await query.order('date_inventaire', { ascending: false })
 
     setInventaires(data || [])
 
@@ -114,14 +127,14 @@ export default function InventairePage() {
 
   if (loading) return (
     <div style={{ minHeight: '100vh', background: c.fond }}>
-      <Navbar section={role === 'bar' ? 'bar' : 'cuisine'} />
+      <Navbar section={navbarSection} />
       <ChefLoader />
     </div>
   )
 
   return (
     <div style={{ minHeight: '100vh', background: c.fond }}>
-      <Navbar section={role === 'bar' ? 'bar' : 'cuisine'} />
+      <Navbar section={navbarSection} />
 
       <div style={{ padding: isMobile ? '12px' : '24px', maxWidth: '1000px', margin: '0 auto' }}>
 
@@ -135,7 +148,7 @@ export default function InventairePage() {
           </div>
           {(role === 'admin' || role === 'cuisine' || role === 'bar') && (
             <button
-              onClick={() => router.push('/inventaire/nouveau')}
+              onClick={() => router.push(`/inventaire/nouveau${queryString}`)}
               style={{ padding: '10px 20px', background: c.accent, color: 'white', border: 'none', borderRadius: '10px', fontSize: '14px', fontWeight: '500', cursor: 'pointer' }}
             >
               + Nouvel inventaire
@@ -224,7 +237,7 @@ export default function InventairePage() {
         {/* ── Banner brouillon ── */}
         {brouillon && (
           <div
-            onClick={() => router.push(`/inventaire/${brouillon.id}/saisie`)}
+            onClick={() => router.push(`/inventaire/${brouillon.id}/saisie${queryString}`)}
             style={{
               padding: '16px', background: '#FFFBEB', border: '0.5px solid #FDE68A',
               borderRadius: '12px', marginBottom: '16px', cursor: 'pointer',
@@ -272,7 +285,7 @@ export default function InventairePage() {
             {filtered.map(inv => (
               <div
                 key={inv.id}
-                onClick={() => router.push(inv.statut === 'brouillon' ? `/inventaire/${inv.id}/saisie` : `/inventaire/${inv.id}`)}
+                onClick={() => router.push((inv.statut === 'brouillon' ? `/inventaire/${inv.id}/saisie` : `/inventaire/${inv.id}`) + queryString)}
                 style={{
                   padding: '16px', background: c.blanc,
                   border: `0.5px solid ${c.bordure}`, borderRadius: '12px',
@@ -302,7 +315,7 @@ export default function InventairePage() {
                 <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                   {(role === 'admin' || role === 'cuisine' || role === 'bar') && inv.statut === 'brouillon' && (
                     <button
-                      onClick={(e) => { e.stopPropagation(); router.push(`/inventaire/${inv.id}/saisie`) }}
+                      onClick={(e) => { e.stopPropagation(); router.push(`/inventaire/${inv.id}/saisie${queryString}`) }}
                       style={{
                         padding: '6px 10px', background: 'none',
                         border: `0.5px solid ${c.bordure}`, borderRadius: '8px',

--- a/components/IngredientsView.jsx
+++ b/components/IngredientsView.jsx
@@ -2,6 +2,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { supabase, getClientId } from '../lib/supabase'
 import { useRouter } from 'next/navigation'
+import * as XLSX from 'xlsx'
 import { useIsMobile } from '../lib/useIsMobile'
 import { useTheme } from '../lib/useTheme'
 import { useRole } from '../lib/useRole'
@@ -267,6 +268,27 @@ export default function IngredientsView({ section = 'cuisine' }) {
     } finally { setSupprimant(false) }
   }
 
+  // ── Export Excel ──────────────────────────────────────────────────────────
+  // Exporte la liste filtrée (mêmes colonnes que le modèle d'import, pour
+  // permettre un round-trip "export → édition → ré-import").
+  const exporterExcel = () => {
+    const rows = [
+      ['Nom', 'Prix HT (€)', 'Unité', 'Catégorie'],
+      ...ingredientsFiltres.map(i => [
+        i.nom,
+        i.prix_kg != null ? Number(i.prix_kg) : '',
+        i.unite || '',
+        i.categories_ingredients?.nom || '',
+      ])
+    ]
+    const wb = XLSX.utils.book_new()
+    const ws = XLSX.utils.aoa_to_sheet(rows)
+    ws['!cols'] = [{ wch: 30 }, { wch: 15 }, { wch: 10 }, { wch: 25 }]
+    XLSX.utils.book_append_sheet(wb, ws, section === 'bar' ? 'Ingrédients bar' : 'Ingrédients')
+    const dateStr = new Date().toISOString().slice(0, 10)
+    XLSX.writeFile(wb, `ingredients_${section}_${dateStr}.xlsx`)
+  }
+
   // ── Ajout ingrédient ──────────────────────────────────────────────────────
   const ajouterIngredient = async () => {
     if (!nouveauNom.trim()) return
@@ -475,6 +497,17 @@ export default function IngredientsView({ section = 'cuisine' }) {
                     borderRadius: '8px', padding: '8px 12px', fontSize: '13px', fontWeight: '500', cursor: 'pointer'
                   }}>{supprimant ? '...' : `🗑 Supprimer (${selection.length})`}</button>
                 )}
+                <button
+                  onClick={exporterExcel}
+                  disabled={ingredientsFiltres.length === 0}
+                  title={ingredientsFiltres.length === 0 ? 'Aucun ingrédient à exporter' : `Exporter ${ingredientsFiltres.length} ingrédient${ingredientsFiltres.length > 1 ? 's' : ''}`}
+                  style={{
+                    background: c.blanc, color: c.texteMuted, border: `0.5px solid ${c.bordure}`,
+                    borderRadius: '8px', padding: '8px 12px', fontSize: '13px',
+                    cursor: ingredientsFiltres.length === 0 ? 'not-allowed' : 'pointer',
+                    opacity: ingredientsFiltres.length === 0 ? 0.5 : 1,
+                  }}
+                >{isMobile ? '📤' : '📤 Export Excel'}</button>
                 {peutModifier && (
                   <button onClick={() => router.push(cfg.importPath)} style={{
                     background: c.blanc, color: c.texteMuted, border: `0.5px solid ${c.bordure}`,

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -155,7 +155,7 @@ export default function Navbar({ section = 'cuisine' }) {
           label: 'Gestion',
           paths: ['/inventaire'],
           items: [
-            { label: 'Inventaire', path: '/inventaire' },
+            { label: 'Inventaire', path: '/inventaire?section=bar' },
           ]
         }] : []),
       ].filter(g => g.items.length > 0)


### PR DESCRIPTION
## Problème

Quand un utilisateur clique sur "Inventaire" depuis la navbar **bar**, il atterrissait sur \`/inventaire\` avec :
- La navbar **cuisine** affichée (pour admin/directeur dont \`role === 'bar'\` est faux).
- La liste mélangée des inventaires cuisine + bar + global.

Effet utilisateur : "je bascule dans l'espace cuisine, ce n'est pas normal".

## Fix

Introduction d'un paramètre URL \`?section=bar\` (ou \`cuisine\`) propagé entre toutes les pages inventaire :

| Page | Comportement avec \`?section=bar\` |
|------|-----------------------------------|
| \`/inventaire?section=bar\` | Liste filtrée à \`section IN ('bar', 'global')\`, navbar bar |
| \`/inventaire/nouveau?section=bar\` | Étape "choix section" sautée pour admin/directeur, section bar pré-sélectionnée, navbar bar |
| \`/inventaire/[id]?section=bar\` | Navbar bar pendant et après le chargement |
| \`/inventaire/[id]/saisie?section=bar\` | Navbar bar pendant et après le chargement |

Le param URL **prime sur** \`inventaire.section\` pour ne pas perdre le contexte sur un inventaire "global". Tous les liens internes (boutons "← Inventaires", "+ Nouvel inventaire", clic sur une ligne, etc.) préservent \`?section=bar\`.

La navbar bar > Gestion > Inventaire pointe désormais sur \`/inventaire?section=bar\` au lieu de \`/inventaire\`.

## Pourquoi pas de routes dédiées /bar/inventaire ?

Approche plus légère : un paramètre URL propage le contexte sans dupliquer les routes. Si la pollution d'URL gêne, on peut basculer en routes dédiées plus tard sur le modèle ingrédients (PR #116).

## Test plan
- [ ] Navbar bar > Gestion > Inventaire : la navbar reste bar, la liste ne montre que les inventaires bar + global.
- [ ] Cliquer "+ Nouvel inventaire" : navbar reste bar, l'étape "Choisir section" est sautée (admin/directeur passe direct au type → catégories → création), inventaire créé en section='bar'.
- [ ] Cliquer sur une ligne d'inventaire bar : navbar reste bar pendant le chargement et après.
- [ ] Cliquer sur "← Inventaires" depuis le détail : retour sur la liste filtrée bar.
- [ ] Sur le détail/saisie, l'URL contient bien ?section=bar.
- [ ] Depuis la navbar cuisine, /inventaire sans param montre tout (admin) ou la cuisine (cuisine), inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)