### PR TITLE
feat(inventaire): import Excel d'un inventaire avec date personnalisée

### DIFF
--- a/app/api/inventaire/import/route.ts
+++ b/app/api/inventaire/import/route.ts
@@ -1,0 +1,19 @@
+import { apiHandler } from '../../../../lib/apiHandler'
+import { importInventaireSchema } from '../../../../lib/validators/inventaire.schema'
+import { importInventaire } from '../../../../lib/services/inventaire.service'
+
+export const POST = apiHandler({
+  schema: importInventaireSchema,
+  guard: 'memberOfClient',
+  clientIdFrom: 'body.client_id',
+  handler: async ({ data, db }) => {
+    const result = await importInventaire(
+      db,
+      data.client_id,
+      data.section,
+      data.date_inventaire,
+      data.lignes
+    )
+    return Response.json(result)
+  },
+})

--- a/app/inventaire/import/page.js
+++ b/app/inventaire/import/page.js
@@ -1,0 +1,273 @@
+'use client'
+import { useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import * as XLSX from 'xlsx'
+import { supabase, getClientId } from '../../../lib/supabase'
+import { useTheme } from '../../../lib/useTheme'
+import { useRole } from '../../../lib/useRole'
+import { useIsMobile } from '../../../lib/useIsMobile'
+import Navbar from '../../../components/Navbar'
+import ChefLoader from '../../../components/ChefLoader'
+
+const todayIso = () => new Date().toISOString().slice(0, 10)
+
+export default function ImportInventairePage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { c } = useTheme()
+  const { role } = useRole()
+  const isMobile = useIsMobile()
+
+  const sectionParam = searchParams.get('section')
+  const sectionForced = sectionParam === 'bar' || sectionParam === 'cuisine' ? sectionParam : null
+  const navbarSection = sectionForced || (role === 'bar' ? 'bar' : 'cuisine')
+  const queryString = sectionForced ? `?section=${sectionForced}` : ''
+
+  const canChooseSection = !sectionForced && (role === 'admin' || role === 'directeur')
+
+  const [section, setSection] = useState(sectionForced || (role === 'bar' ? 'bar' : 'cuisine'))
+  const [dateInventaire, setDateInventaire] = useState(todayIso())
+  const [lignes, setLignes] = useState([])
+  const [fileName, setFileName] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+  const [result, setResult] = useState(null)
+
+  const handleFile = (e) => {
+    setError('')
+    setResult(null)
+    const f = e.target.files?.[0]
+    if (!f) return
+    setFileName(f.name)
+    const reader = new FileReader()
+    reader.onload = (evt) => {
+      try {
+        const wb = XLSX.read(evt.target.result, { type: 'binary' })
+        const sheet = wb.Sheets[wb.SheetNames[0]]
+        const rows = XLSX.utils.sheet_to_json(sheet, { header: 1 })
+        const parsed = []
+        for (let i = 1; i < rows.length; i++) {
+          const row = rows[i]
+          if (!row || row.length === 0) continue
+          const nom = String(row[0] || '').trim()
+          const qStr = String(row[1] || '').replace(',', '.').replace(/[^0-9.\-]/g, '')
+          const quantite = parseFloat(qStr)
+          if (!nom || isNaN(quantite)) continue
+          parsed.push({ nom, quantite })
+        }
+        if (parsed.length === 0) {
+          setError('Aucune ligne valide trouvée. Vérifie le format : colonne A = Nom, colonne B = Quantité.')
+          setLignes([])
+          return
+        }
+        setLignes(parsed)
+      } catch (err) {
+        setError('Lecture du fichier échouée : ' + (err.message || 'fichier invalide'))
+      }
+    }
+    reader.readAsBinaryString(f)
+  }
+
+  const telechargerModele = () => {
+    const wb = XLSX.utils.book_new()
+    const rows = [
+      ['Nom', 'Quantité'],
+      ['Beurre doux', '4.5'],
+      ['Farine T55', '12'],
+      ['Tomates cerises', '2.3'],
+    ]
+    const ws = XLSX.utils.aoa_to_sheet(rows)
+    ws['!cols'] = [{ wch: 30 }, { wch: 12 }]
+    XLSX.utils.book_append_sheet(wb, ws, 'Inventaire')
+    XLSX.writeFile(wb, 'modele_import_inventaire.xlsx')
+  }
+
+  const handleSubmit = async () => {
+    if (lignes.length === 0) {
+      setError('Uploade un fichier Excel avant de valider.')
+      return
+    }
+    setError('')
+    setSubmitting(true)
+    try {
+      const clientId = await getClientId()
+      const { data: { session } } = await supabase.auth.getSession()
+      const res = await fetch('/api/inventaire/import', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({
+          client_id: clientId,
+          section,
+          date_inventaire: dateInventaire,
+          lignes,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || 'Erreur lors de l\'import')
+        return
+      }
+      setResult(data)
+    } catch (err) {
+      setError('Erreur réseau : ' + (err.message || ''))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  // ── Render résultat ──────────────────────────────────────────────────────
+  if (result) {
+    return (
+      <div style={{ minHeight: '100vh', background: c.fond }}>
+        <Navbar section={navbarSection} />
+        <div style={{ padding: isMobile ? '16px' : '24px', maxWidth: '600px', margin: '0 auto' }}>
+          <div style={{ background: '#DCFCE7', border: '0.5px solid #86EFAC', borderRadius: '12px', padding: '20px', marginBottom: '16px' }}>
+            <div style={{ fontSize: '15px', fontWeight: '600', color: '#166534', marginBottom: '8px' }}>
+              ✓ Inventaire importé
+            </div>
+            <div style={{ fontSize: '13px', color: '#15803D' }}>
+              {result.nb_lignes} ligne{result.nb_lignes > 1 ? 's' : ''} créée{result.nb_lignes > 1 ? 's' : ''} pour le {dateInventaire}.
+              {result.nb_ingredients_crees > 0 && (
+                <> {result.nb_ingredients_crees} nouvel{result.nb_ingredients_crees > 1 ? 's' : ''} ingrédient{result.nb_ingredients_crees > 1 ? 's ont' : ' a'} été ajouté{result.nb_ingredients_crees > 1 ? 's' : ''} à la base.</>
+              )}
+            </div>
+          </div>
+          <div style={{ display: 'flex', gap: '10px' }}>
+            <button onClick={() => router.push(`/inventaire/${result.inventaire.id}${queryString}`)}
+              style={{ flex: 1, padding: '12px', background: c.accent, color: 'white', border: 'none', borderRadius: '8px', fontSize: '14px', fontWeight: '500', cursor: 'pointer' }}>
+              Voir l&apos;inventaire
+            </button>
+            <button onClick={() => router.push(`/inventaire${queryString}`)}
+              style={{ flex: 1, padding: '12px', background: c.blanc, color: c.texteMuted, border: `0.5px solid ${c.bordure}`, borderRadius: '8px', fontSize: '14px', cursor: 'pointer' }}>
+              Retour à la liste
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ minHeight: '100vh', background: c.fond }}>
+      <Navbar section={navbarSection} />
+      <div style={{ padding: isMobile ? '16px' : '24px', maxWidth: '700px', margin: '0 auto' }}>
+
+        <button onClick={() => router.push(`/inventaire${queryString}`)}
+          style={{ background: 'none', border: 'none', color: c.texteMuted, fontSize: '13px', cursor: 'pointer', padding: 0, marginBottom: '12px' }}>
+          ← Inventaires
+        </button>
+
+        <h1 style={{ fontSize: '20px', fontWeight: '600', color: c.texte, margin: '0 0 6px 0' }}>
+          Importer un inventaire
+        </h1>
+        <p style={{ fontSize: '13px', color: c.texteMuted, margin: '0 0 24px 0' }}>
+          Upload un Excel avec les quantités comptées. Les ingrédients absents de ta base seront créés automatiquement.
+          L&apos;inventaire est validé immédiatement et devient la nouvelle référence pour les calculs de stock théorique.
+        </p>
+
+        {/* Section + Date */}
+        <div style={{ background: c.blanc, borderRadius: '12px', padding: '20px', border: `0.5px solid ${c.bordure}`, marginBottom: '16px' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: canChooseSection ? '1fr 1fr' : '1fr', gap: '12px' }}>
+            {canChooseSection && (
+              <div>
+                <label style={{ fontSize: '12px', color: c.texteMuted, fontWeight: '500', display: 'block', marginBottom: '6px' }}>Section</label>
+                <select value={section} onChange={e => setSection(e.target.value)}
+                  style={{ width: '100%', padding: '10px 12px', borderRadius: '8px', border: `0.5px solid ${c.bordure}`, fontSize: '14px', background: c.blanc, outline: 'none', color: c.texte, cursor: 'pointer' }}>
+                  <option value="cuisine">🍳 Cuisine</option>
+                  <option value="bar">🍸 Bar</option>
+                </select>
+              </div>
+            )}
+            <div>
+              <label style={{ fontSize: '12px', color: c.texteMuted, fontWeight: '500', display: 'block', marginBottom: '6px' }}>
+                Date de l&apos;inventaire
+              </label>
+              <input type="date" value={dateInventaire} onChange={e => setDateInventaire(e.target.value)}
+                style={{ width: '100%', padding: '10px 12px', borderRadius: '8px', border: `0.5px solid ${c.bordure}`, fontSize: '14px', background: c.blanc, outline: 'none', color: c.texte }}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Format + modèle */}
+        <div style={{ background: c.fond, borderRadius: '8px', padding: '14px 16px', fontSize: '13px', color: c.texteMuted, marginBottom: '16px', border: `0.5px solid ${c.bordure}` }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '8px', marginBottom: '8px' }}>
+            <strong style={{ color: c.texte }}>Format attendu</strong>
+            <button onClick={telechargerModele}
+              style={{ background: c.accentClair, color: c.accent, border: `0.5px solid ${c.accent}40`, borderRadius: '6px', padding: '4px 10px', fontSize: '12px', cursor: 'pointer' }}>
+              📥 Télécharger le modèle
+            </button>
+          </div>
+          <div>
+            <strong style={{ color: c.texte }}>Colonne A</strong> — Nom de l&apos;ingrédient (la première ligne est ignorée comme en-tête)<br />
+            <strong style={{ color: c.texte }}>Colonne B</strong> — Quantité (point ou virgule décimale)
+          </div>
+        </div>
+
+        {/* File upload */}
+        <input type="file" accept=".xlsx,.xls,.csv" onChange={handleFile}
+          style={{ width: '100%', padding: '12px', border: `0.5px solid ${c.accent}`, borderRadius: '8px', fontSize: '13px', background: c.accentClair, cursor: 'pointer', color: c.texte, marginBottom: '16px' }}
+        />
+
+        {fileName && lignes.length > 0 && (
+          <div style={{ background: c.blanc, borderRadius: '8px', padding: '12px 16px', marginBottom: '16px', border: `0.5px solid ${c.bordure}`, fontSize: '13px', color: c.texte }}>
+            <strong>{fileName}</strong> — {lignes.length} ligne{lignes.length > 1 ? 's' : ''} détectée{lignes.length > 1 ? 's' : ''}
+          </div>
+        )}
+
+        {/* Preview */}
+        {lignes.length > 0 && (
+          <div style={{ background: c.blanc, borderRadius: '12px', border: `0.5px solid ${c.bordure}`, overflow: 'hidden', marginBottom: '16px' }}>
+            <div style={{ padding: '10px 16px', borderBottom: `0.5px solid ${c.bordure}`, fontSize: '12px', fontWeight: '600', color: c.texteMuted, textTransform: 'uppercase' }}>
+              Aperçu ({Math.min(10, lignes.length)} premières lignes)
+            </div>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '13px' }}>
+              <thead>
+                <tr style={{ background: c.fond }}>
+                  <th style={{ padding: '8px 16px', textAlign: 'left', fontSize: '11px', color: c.texteMuted, fontWeight: '500', textTransform: 'uppercase' }}>Nom</th>
+                  <th style={{ padding: '8px 16px', textAlign: 'right', fontSize: '11px', color: c.texteMuted, fontWeight: '500', textTransform: 'uppercase' }}>Quantité</th>
+                </tr>
+              </thead>
+              <tbody>
+                {lignes.slice(0, 10).map((l, i) => (
+                  <tr key={i} style={{ borderTop: `0.5px solid ${c.bordure}` }}>
+                    <td style={{ padding: '8px 16px', color: c.texte }}>{l.nom}</td>
+                    <td style={{ padding: '8px 16px', textAlign: 'right', color: c.texte }}>{l.quantite}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {lignes.length > 10 && (
+              <div style={{ padding: '8px 16px', fontSize: '12px', color: c.texteMuted, fontStyle: 'italic', borderTop: `0.5px solid ${c.bordure}` }}>
+                + {lignes.length - 10} autre{lignes.length - 10 > 1 ? 's' : ''} ligne{lignes.length - 10 > 1 ? 's' : ''}
+              </div>
+            )}
+          </div>
+        )}
+
+        {error && (
+          <div style={{ background: '#FEE2E2', border: '0.5px solid #FECACA', borderRadius: '8px', padding: '12px 16px', marginBottom: '16px', fontSize: '13px', color: '#991B1B' }}>
+            {error}
+          </div>
+        )}
+
+        {submitting ? (
+          <ChefLoader message="Création de l'inventaire..." />
+        ) : (
+          <button onClick={handleSubmit} disabled={lignes.length === 0}
+            style={{
+              width: '100%', padding: '14px',
+              background: lignes.length === 0 ? c.texteMuted : c.accent,
+              color: 'white', border: 'none', borderRadius: '8px', fontSize: '14px', fontWeight: '600',
+              cursor: lignes.length === 0 ? 'not-allowed' : 'pointer',
+            }}>
+            {lignes.length === 0 ? 'Sélectionne un fichier' : `Créer l'inventaire (${lignes.length} ligne${lignes.length > 1 ? 's' : ''})`}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/inventaire/page.js
+++ b/app/inventaire/page.js
@@ -147,12 +147,20 @@ export default function InventairePage() {
             </p>
           </div>
           {(role === 'admin' || role === 'cuisine' || role === 'bar') && (
-            <button
-              onClick={() => router.push(`/inventaire/nouveau${queryString}`)}
-              style={{ padding: '10px 20px', background: c.accent, color: 'white', border: 'none', borderRadius: '10px', fontSize: '14px', fontWeight: '500', cursor: 'pointer' }}
-            >
-              + Nouvel inventaire
-            </button>
+            <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+              <button
+                onClick={() => router.push(`/inventaire/import${queryString}`)}
+                style={{ padding: '10px 16px', background: c.blanc, color: c.texte, border: `0.5px solid ${c.bordure}`, borderRadius: '10px', fontSize: '14px', fontWeight: '500', cursor: 'pointer' }}
+              >
+                📥 Importer Excel
+              </button>
+              <button
+                onClick={() => router.push(`/inventaire/nouveau${queryString}`)}
+                style={{ padding: '10px 20px', background: c.accent, color: 'white', border: 'none', borderRadius: '10px', fontSize: '14px', fontWeight: '500', cursor: 'pointer' }}
+              >
+                + Nouvel inventaire
+              </button>
+            </div>
           )}
         </div>
 

--- a/lib/services/inventaire.service.ts
+++ b/lib/services/inventaire.service.ts
@@ -614,6 +614,114 @@ export async function addLigne(
   return ligne
 }
 
+// ── Import inventaire depuis Excel ─────────────────────────────────────────
+
+export async function importInventaire(
+  db: SupabaseClient,
+  clientId: string,
+  section: 'cuisine' | 'bar',
+  dateInventaire: string,
+  lignes: { nom: string; quantite: number }[]
+) {
+  const isBar = section === 'bar'
+  const table = isBar ? 'ingredients_bar' : 'ingredients'
+  const defaultUnit = isBar ? 'cl' : 'kg'
+
+  // 1. Dédoublonne les lignes par nom (insensible à la casse). Si l'utilisateur
+  // a deux fois le même ingrédient dans le fichier, on garde le dernier.
+  const lignesByNorm = new Map<string, { nom: string; quantite: number }>()
+  for (const l of lignes) {
+    const nomTrim = l.nom.trim()
+    if (!nomTrim) continue
+    lignesByNorm.set(nomTrim.toLowerCase(), { nom: nomTrim, quantite: l.quantite })
+  }
+  const lignesUniq = Array.from(lignesByNorm.values())
+
+  // 2. Charge les ingrédients existants pour ce client (filtre par nom
+  // insensible à la casse). On garde tout l'historique pour matcher.
+  const { data: existing } = await db
+    .from(table)
+    .select('id, nom, unite, prix_kg')
+    .eq('client_id', clientId)
+  const ingByNom = new Map<string, { id: string; nom: string; unite: string | null; prix_kg: number | null }>()
+  for (const ing of existing ?? []) {
+    ingByNom.set(ing.nom.toLowerCase().trim(), ing as never)
+  }
+
+  // 3. Crée les ingrédients manquants (prix=null, unite par défaut selon section).
+  const toCreate: { nom: string; client_id: string; unite: string }[] = []
+  for (const l of lignesUniq) {
+    if (!ingByNom.has(l.nom.toLowerCase())) {
+      toCreate.push({ nom: l.nom, client_id: clientId, unite: defaultUnit })
+    }
+  }
+  let nbCrees = 0
+  if (toCreate.length > 0) {
+    const { data: created, error: errCreate } = await db
+      .from(table)
+      .insert(toCreate)
+      .select('id, nom, unite, prix_kg')
+    if (errCreate) throw new Error(`Création ingrédients : ${errCreate.message}`)
+    for (const ing of created ?? []) {
+      ingByNom.set(ing.nom.toLowerCase().trim(), ing as never)
+    }
+    nbCrees = created?.length ?? 0
+  }
+
+  // 4. Crée l'inventaire (statut='valide' pour qu'il serve de baseline aux
+  // calculs de stock_theorique futurs — c'est le comportement demandé).
+  const { data: inventaire, error: invErr } = await db
+    .from('inventaires')
+    .insert({
+      client_id: clientId,
+      type: 'complet',
+      section,
+      statut: 'valide',
+      date_inventaire: dateInventaire,
+      periode_debut: null,
+      periode_fin: dateInventaire,
+      date_validation: new Date().toISOString(),
+    })
+    .select()
+    .single()
+  if (invErr) throw new Error(`Création inventaire : ${invErr.message}`)
+
+  // 5. Insère les lignes d'inventaire avec les quantités importées.
+  const ligneRows = lignesUniq.map((l) => {
+    const ing = ingByNom.get(l.nom.toLowerCase())!
+    const coutUnit = Number(ing.prix_kg) || 0
+    const qReelle = Number(l.quantite) || 0
+    return {
+      inventaire_id: inventaire.id,
+      client_id: clientId,
+      ingredient_id: ing.id,
+      section,
+      nom_ingredient: ing.nom,
+      unite: ing.unite,
+      quantite_theorique: null,
+      quantite_reelle: round3(qReelle),
+      ecart: null,
+      cout_unitaire: coutUnit,
+      valeur_stock: round3(qReelle * coutUnit),
+      est_critique: false,
+    }
+  })
+
+  // Chunk les inserts pour gros volumes (PostgREST request size limit).
+  const CHUNK = 500
+  for (let i = 0; i < ligneRows.length; i += CHUNK) {
+    const batch = ligneRows.slice(i, i + CHUNK)
+    const { error: ligErr } = await db.from('inventaire_lignes').insert(batch)
+    if (ligErr) throw new Error(`Insertion lignes : ${ligErr.message}`)
+  }
+
+  return {
+    inventaire,
+    nb_lignes: lignesUniq.length,
+    nb_ingredients_crees: nbCrees,
+  }
+}
+
 // ── Utilities ──────────────────────────────────────────────────────────────
 
 function round3(n: number): number {

--- a/lib/validators/inventaire.schema.ts
+++ b/lib/validators/inventaire.schema.ts
@@ -53,3 +53,16 @@ export const paretoQuerySchema = z.object({
   client_id: clientIdSchema,
   section:   z.enum(['cuisine', 'bar']).default('cuisine'),
 })
+
+// ── Import inventaire (Excel) ──────────────────────────────────────────────
+export const importInventaireSchema = z.object({
+  client_id: clientIdSchema,
+  section:   z.enum(['cuisine', 'bar']),
+  date_inventaire: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date au format YYYY-MM-DD requise.'),
+  lignes: z.array(z.object({
+    nom:      z.string().trim().min(1).max(200),
+    quantite: z.coerce.number().min(0),
+  })).min(1, 'Au moins une ligne requise.').max(5000, 'Maximum 5000 lignes par import.'),
+})
+
+export type ImportInventaireInput = z.infer<typeof importInventaireSchema>


### PR DESCRIPTION
## Demande

Pouvoir importer un inventaire (cuisine ou bar) depuis un Excel, avec une date personnalisable, pour servir de baseline aux calculs de stock théorique. Les ingrédients absents de la base sont créés automatiquement.

## Nouveau flux

1. Sur la liste \`/inventaire?section=bar\` (ou cuisine), nouveau bouton **📥 Importer Excel** à côté de **+ Nouvel inventaire**.
2. La page \`/inventaire/import?section=bar\` affiche :
   - Sélecteur de section (auto pour bar/cuisine, manuel pour admin/directeur)
   - Date picker (par défaut aujourd'hui, accepte les dates passées pour rattraper un comptage)
   - Bouton "Télécharger le modèle" (xlsx avec en-tête + 3 exemples)
   - Upload xlsx (.xlsx, .xls, .csv)
   - Aperçu des 10 premières lignes parsées
3. Validation → l'inventaire est créé **directement en statut='valide'** pour devenir la baseline des calculs de stock théorique futurs (\`loadStockDepart\` lit le dernier inventaire validé).

## Format Excel

| Colonne A | Colonne B |
|-----------|-----------|
| Nom de l'ingrédient | Quantité (point ou virgule décimale) |

Première ligne ignorée (en-tête). Lignes vides ou avec quantité non numérique skippées silencieusement.

## Backend (\`/api/inventaire/import\`)

1. Dédoublonne les lignes par nom insensible à la casse (si deux lignes avec le même nom, la dernière l'emporte).
2. Charge tous les ingrédients existants du client, matche par nom.
3. **Crée les ingrédients absents** en lot (insert unique) avec unité par défaut (\`kg\` pour cuisine, \`cl\` pour bar) et \`prix_kg=null\` — l'utilisateur complètera le prix plus tard.
4. Crée l'inventaire (type='complet', section, date, statut='valide').
5. Insère les \`inventaire_lignes\` chunkées à 500 par batch (PostgREST request size limit).
6. Retourne \`{ inventaire, nb_lignes, nb_ingredients_crees }\`.

## Effet sur le stock théorique

Le service \`calculateStockTheorique\` sélectionne déjà le dernier inventaire \`valide\` comme \`stock_depart\` :

\`\`\`ts
db.from('inventaires')
  .eq('statut', 'valide')
  .in('section', [section, 'global'])
  .order('date_inventaire', { ascending: false })
  .limit(1)
\`\`\`

→ Un inventaire importé avec date X devient automatiquement le baseline, et les achats / consommations postérieurs sont comptés à partir de X.

## Test plan
- [ ] Préparer un xlsx avec en-tête + une vingtaine d'ingrédients (mélange existants + nouveaux), uploader depuis /inventaire/import?section=bar → aperçu correct, "Créer l'inventaire" réussit, banner vert mentionne le nombre d'ingrédients créés.
- [ ] Cliquer "Voir l'inventaire" → atterrir sur le détail avec les quantités importées et la navbar bar conservée.
- [ ] Vérifier que les ingrédients créés apparaissent dans /bar/ingredients (avec prix null).
- [ ] Re-uploader un fichier avec une date passée (ex. 2026-05-01) → l'inventaire prend cette date.
- [ ] Lancer ensuite "+ Nouvel inventaire" → le stock_départ doit reprendre les valeurs importées (vérifie loadStockDepart).
- [ ] Modèle téléchargeable : cliquer "Télécharger le modèle" génère un xlsx exploitable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)