### PR TITLE
fix(inventaire): import 500 — colonnes générées + unite null

### DIFF
--- a/lib/services/inventaire.service.ts
+++ b/lib/services/inventaire.service.ts
@@ -687,6 +687,10 @@ export async function importInventaire(
   if (invErr) throw new Error(`Création inventaire : ${invErr.message}`)
 
   // 5. Insère les lignes d'inventaire avec les quantités importées.
+  // Note : `ecart` et `valeur_stock` sont des colonnes générées par Postgres
+  // (cf. migration 20260402000000), donc on ne les insère pas. `unite` est
+  // NOT NULL côté table — fallback sur l'unité par défaut de la section si
+  // l'ingrédient existant n'a pas d'unité renseignée.
   const ligneRows = lignesUniq.map((l) => {
     const ing = ingByNom.get(l.nom.toLowerCase())!
     const coutUnit = Number(ing.prix_kg) || 0
@@ -697,12 +701,10 @@ export async function importInventaire(
       ingredient_id: ing.id,
       section,
       nom_ingredient: ing.nom,
-      unite: ing.unite,
+      unite: ing.unite || defaultUnit,
       quantite_theorique: null,
       quantite_reelle: round3(qReelle),
-      ecart: null,
       cout_unitaire: coutUnit,
-      valeur_stock: round3(qReelle * coutUnit),
       est_critique: false,
     }
   })


### PR DESCRIPTION
## Problème

L'import Excel d'un inventaire (PR #119) renvoie une erreur 500 \"Erreur serveur interne\" — testé avec 964 lignes côté bar.

## Cause

Deux bugs dans \`importInventaire\` :

1. **Colonnes générées** : \`ecart\` et \`valeur_stock\` dans \`inventaire_lignes\` sont déclarées en \`GENERATED ALWAYS AS (...) STORED\` (cf. [migration 20260402000000](supabase/migrations/20260402000000_inventaires.sql)). Postgres rejette tout insert sur ces colonnes — il faut le laisser les calculer.

2. **\`unite\` NOT NULL** : la colonne \`unite\` est \`NOT NULL\` sur \`inventaire_lignes\`. Certains ingrédients existants peuvent avoir \`unite = null\` (créés sans unité via l'UI ou via un ancien import), ce qui faisait planter l'insert avec une violation de contrainte.

## Fix

- Retire \`ecart\` et \`valeur_stock\` du payload d'insert (Postgres les calcule à l'écriture).
- Fallback sur l'unité par défaut de la section (\`'kg'\` cuisine / \`'cl'\` bar) si \`ing.unite\` est null.

Cohérent avec l'insert utilisé par \`createInventaire\` qui n'inclut pas non plus ces colonnes générées.

## Test plan
- [ ] Sur /inventaire/import?section=bar, ré-uploader le fichier de 964 lignes → l'import doit réussir et créer l'inventaire validé.
- [ ] Cliquer "Voir l'inventaire" → les lignes apparaissent avec leur quantité réelle et leur valeur_stock calculée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)