### PR TITLE
feat(food-cost): historique des rapports + ajustements datés

### DIFF
--- a/app/api/food-cost/ajustement/route.ts
+++ b/app/api/food-cost/ajustement/route.ts
@@ -10,7 +10,10 @@ import {
   deleteAjustement,
 } from '../../../../lib/services/foodCost.service'
 
-// POST  : crée une ligne d'ajustement rattachée à un rapport
+// POST  : crée une ligne d'ajustement (date_ajustement obligatoire,
+//         rapport_id optionnel — l'ajustement vit indépendamment d'un rapport
+//         sauvegardé, il est inclus dans tout rapport dont la période couvre
+//         sa date).
 export const POST = apiHandler({
   schema: createAjustementSchema,
   guard: 'memberOfClient',
@@ -21,7 +24,7 @@ export const POST = apiHandler({
   },
 })
 
-// PATCH : met à jour libellé / montant / commentaire
+// PATCH : met à jour date / libellé / montant / commentaire
 export const PATCH = apiHandler({
   schema: patchAjustementSchema,
   guard: 'memberOfClient',

--- a/app/api/food-cost/preview/route.ts
+++ b/app/api/food-cost/preview/route.ts
@@ -1,0 +1,15 @@
+import { apiHandler } from '../../../../lib/apiHandler'
+import { previewPeriodeSchema } from '../../../../lib/validators/foodCost.schema'
+import { previewPeriode } from '../../../../lib/services/foodCost.service'
+
+// GET   : aperçu live d'une période (ajustements datés + totaux), sans rapport
+//         sauvegardé. Permet de visualiser un ratio avant de cliquer Sauvegarder.
+export const GET = apiHandler({
+  schema: previewPeriodeSchema,
+  guard: 'memberOfClient',
+  clientIdFrom: 'body.clientId',
+  handler: async ({ data, db }) => {
+    const result = await previewPeriode(db, data)
+    return Response.json(result)
+  },
+})

--- a/app/api/food-cost/rapport/route.ts
+++ b/app/api/food-cost/rapport/route.ts
@@ -1,24 +1,24 @@
 import { apiHandler } from '../../../../lib/apiHandler'
 import {
-  upsertRapportSchema,
+  createRapportSchema,
   getRapportSchema,
   patchRapportSchema,
   deleteRapportSchema,
 } from '../../../../lib/validators/foodCost.schema'
 import {
-  upsertRapport,
+  createRapport,
   getRapport,
   patchRapport,
   deleteRapport,
 } from '../../../../lib/services/foodCost.service'
 
-// POST  : upsert d'un rapport pour une période (idempotent)
+// POST  : crée explicitement un rapport sauvegardé pour une période
 export const POST = apiHandler({
-  schema: upsertRapportSchema,
+  schema: createRapportSchema,
   guard: 'memberOfClient',
   clientIdFrom: 'body.clientId',
   handler: async ({ data, user, db }) => {
-    const result = await upsertRapport(db, data, user!.id)
+    const result = await createRapport(db, data, user!.id)
     return Response.json(result)
   },
 })
@@ -35,7 +35,7 @@ export const GET = apiHandler({
   },
 })
 
-// PATCH : maj inventaires + notes
+// PATCH : maj inventaires + notes + période
 export const PATCH = apiHandler({
   schema: patchRapportSchema,
   guard: 'memberOfClient',

--- a/app/api/food-cost/rapports/route.ts
+++ b/app/api/food-cost/rapports/route.ts
@@ -1,0 +1,14 @@
+import { apiHandler } from '../../../../lib/apiHandler'
+import { listRapportsSchema } from '../../../../lib/validators/foodCost.schema'
+import { listRapports } from '../../../../lib/services/foodCost.service'
+
+// GET   : liste des rapports food cost sauvegardés du client
+export const GET = apiHandler({
+  schema: listRapportsSchema,
+  guard: 'memberOfClient',
+  clientIdFrom: 'body.clientId',
+  handler: async ({ data, db }) => {
+    const result = await listRapports(db, data)
+    return Response.json(result)
+  },
+})

--- a/app/controle-gestion/food-cost/page.js
+++ b/app/controle-gestion/food-cost/page.js
@@ -1,13 +1,13 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { supabase, getClientId } from '../../../lib/supabase'
 import { useIsMobile } from '../../../lib/useIsMobile'
 import { useTheme } from '../../../lib/useTheme'
 import { useRole } from '../../../lib/useRole'
 import Navbar from '../../../components/Navbar'
-import { getPeriodDates, toIsoDate } from '../../../lib/caAnalyses'
+import { getPeriodDates } from '../../../lib/caAnalyses'
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -21,19 +21,30 @@ function formatPct(n) {
   return `${n.toFixed(1)} %`
 }
 
+function formatDate(iso) {
+  if (!iso) return '—'
+  const [y, m, d] = iso.split('-')
+  return `${d}/${m}/${y}`
+}
+
+function todayIso() {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
 function defaultPeriod() {
-  // Par défaut : mois précédent (couverture complète du dernier mois clos)
   return getPeriodDates('mois-precedent')
 }
 
-// Debounce simple pour les autosaves
+// Debounce utilitaire — ref-based pour ne pas réinitialiser le timer à chaque render.
 function useDebouncedCallback(fn, delay) {
-  const [timer, setTimer] = useState(null)
+  const timerRef = useRef(null)
+  const fnRef = useRef(fn)
+  useEffect(() => { fnRef.current = fn }, [fn])
   return useCallback((...args) => {
-    if (timer) clearTimeout(timer)
-    const t = setTimeout(() => fn(...args), delay)
-    setTimer(t)
-  }, [fn, delay, timer])
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => fnRef.current(...args), delay)
+  }, [delay])
 }
 
 // ─── Composant ──────────────────────────────────────────────────────────────
@@ -47,17 +58,21 @@ export default function FoodCostPage() {
   const [authReady, setAuthReady] = useState(false)
   const [clientId, setClientId] = useState(null)
   const [error, setError] = useState('')
+  const [okMsg, setOkMsg] = useState('')
 
-  // Période
+  // Mode : 'new' = brouillon non sauvegardé / 'edit' = rapport chargé depuis archive
+  const [mode, setMode] = useState('new')
+  const [currentRapportId, setCurrentRapportId] = useState(null)
+
+  // Période + saisies
   const initial = useMemo(() => defaultPeriod(), [])
   const [periodeDebut, setPeriodeDebut] = useState(initial.debut)
   const [periodeFin, setPeriodeFin] = useState(initial.fin)
-
-  // Rapport courant
-  const [rapportId, setRapportId] = useState(null)
   const [inventaireDebut, setInventaireDebut] = useState('')
   const [inventaireFin, setInventaireFin] = useState('')
   const [notes, setNotes] = useState('')
+
+  // Ajustements de la période courante (chargés par date)
   const [ajustements, setAjustements] = useState([])
 
   // Totaux calculés serveur
@@ -65,13 +80,27 @@ export default function FoodCostPage() {
   const [achatsHt, setAchatsHt] = useState(0)
 
   const [loading, setLoading] = useState(false)
-  const [savingInv, setSavingInv] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [autosaving, setAutosaving] = useState(false)
 
   // Saisie nouvelle ligne d'ajustement
+  const [newDate, setNewDate] = useState(todayIso())
   const [newLibelle, setNewLibelle] = useState('')
   const [newMontant, setNewMontant] = useState('')
   const [newCommentaire, setNewCommentaire] = useState('')
   const [addingAjustement, setAddingAjustement] = useState(false)
+
+  // Édition inline d'un ajustement
+  const [editingId, setEditingId] = useState(null)
+  const [editDate, setEditDate] = useState('')
+  const [editLibelle, setEditLibelle] = useState('')
+  const [editMontant, setEditMontant] = useState('')
+  const [editCommentaire, setEditCommentaire] = useState('')
+  const [savingEdit, setSavingEdit] = useState(false)
+
+  // Archives
+  const [archives, setArchives] = useState([])
+  const [archivesLoading, setArchivesLoading] = useState(false)
 
   // ── Auth ────────────────────────────────────────────────────────────────
   useEffect(() => {
@@ -93,103 +122,259 @@ export default function FoodCostPage() {
     if (role !== 'admin' && role !== 'directeur') router.replace('/dashboard')
   }, [role, roleLoading, router])
 
-  // ── Charge / crée le rapport pour la période courante ──────────────────
-  const loadRapport = useCallback(async () => {
+  // Helper : headers authentifiés
+  const authHeaders = useCallback(async () => {
+    const { data: { session } } = await supabase.auth.getSession()
+    return { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` }
+  }, [])
+
+  // ── Charge la preview (ajustements + totaux) pour la période en mode 'new'
+  const loadPreview = useCallback(async (debut, fin) => {
     if (!clientId) return
     setLoading(true)
     setError('')
     try {
-      const { data: { session } } = await supabase.auth.getSession()
-      const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` }
-
-      // 1. Upsert (idempotent) → récupère le rapport_id
-      const upsertRes = await fetch('/api/food-cost/rapport', {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({ clientId, periodeDebut, periodeFin }),
-      })
-      const upsertJson = await upsertRes.json()
-      if (!upsertRes.ok) throw new Error(upsertJson.error || `HTTP ${upsertRes.status}`)
-      const rid = upsertJson.rapport_id
-
-      // 2. GET full data (rapport + ajustements + totaux)
-      const url = new URL('/api/food-cost/rapport', window.location.origin)
-      url.searchParams.set('rapportId', rid)
+      const headers = await authHeaders()
+      const url = new URL('/api/food-cost/preview', window.location.origin)
       url.searchParams.set('clientId', clientId)
-      const getRes = await fetch(url.toString(), { headers })
-      const getJson = await getRes.json()
-      if (!getRes.ok) throw new Error(getJson.error || `HTTP ${getRes.status}`)
-
-      setRapportId(rid)
-      setInventaireDebut(getJson.rapport.inventaire_debut_ht ?? '')
-      setInventaireFin(getJson.rapport.inventaire_fin_ht ?? '')
-      setNotes(getJson.rapport.notes ?? '')
-      setAjustements(getJson.ajustements ?? [])
-      setCaFoodHt(getJson.totaux.ca_food_ht)
-      setAchatsHt(getJson.totaux.achats_ht)
+      url.searchParams.set('periodeDebut', debut)
+      url.searchParams.set('periodeFin', fin)
+      const res = await fetch(url.toString(), { headers })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || `HTTP ${res.status}`)
+      setAjustements(json.ajustements ?? [])
+      setCaFoodHt(json.totaux.ca_food_ht)
+      setAchatsHt(json.totaux.achats_ht)
     } catch (e) {
       setError(`Chargement impossible : ${e.message}`)
     } finally {
       setLoading(false)
     }
-  }, [clientId, periodeDebut, periodeFin])
+  }, [clientId, authHeaders])
 
+  // ── Charge un rapport existant (mode 'edit')
+  const loadRapport = useCallback(async (rapportId) => {
+    if (!clientId || !rapportId) return
+    setLoading(true)
+    setError('')
+    setOkMsg('')
+    try {
+      const headers = await authHeaders()
+      const url = new URL('/api/food-cost/rapport', window.location.origin)
+      url.searchParams.set('rapportId', rapportId)
+      url.searchParams.set('clientId', clientId)
+      const res = await fetch(url.toString(), { headers })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || `HTTP ${res.status}`)
+      setMode('edit')
+      setCurrentRapportId(rapportId)
+      setPeriodeDebut(json.rapport.periode_debut)
+      setPeriodeFin(json.rapport.periode_fin)
+      setInventaireDebut(json.rapport.inventaire_debut_ht ?? '')
+      setInventaireFin(json.rapport.inventaire_fin_ht ?? '')
+      setNotes(json.rapport.notes ?? '')
+      setAjustements(json.ajustements ?? [])
+      setCaFoodHt(json.totaux.ca_food_ht)
+      setAchatsHt(json.totaux.achats_ht)
+    } catch (e) {
+      setError(`Chargement impossible : ${e.message}`)
+    } finally {
+      setLoading(false)
+    }
+  }, [clientId, authHeaders])
+
+  // ── Charge la liste des archives
+  const loadArchives = useCallback(async () => {
+    if (!clientId) return
+    setArchivesLoading(true)
+    try {
+      const headers = await authHeaders()
+      const url = new URL('/api/food-cost/rapports', window.location.origin)
+      url.searchParams.set('clientId', clientId)
+      const res = await fetch(url.toString(), { headers })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || `HTTP ${res.status}`)
+      setArchives(json.rapports ?? [])
+    } catch (e) {
+      console.warn('Erreur chargement archives :', e?.message || e)
+    } finally {
+      setArchivesLoading(false)
+    }
+  }, [clientId, authHeaders])
+
+  // Premier chargement : preview de la période par défaut + archives
   useEffect(() => {
     if (!authReady || !clientId) return
-    loadRapport()
-  }, [authReady, clientId, loadRapport])
+    loadPreview(periodeDebut, periodeFin)
+    loadArchives()
+    // intentionnellement pas de [periodeDebut, periodeFin] ici — voir hook ci-dessous
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authReady, clientId])
 
-  // ── Save inventaires + notes (debounced) ───────────────────────────────
+  // Refetch quand la période change
+  useEffect(() => {
+    if (!authReady || !clientId) return
+    if (mode === 'new') loadPreview(periodeDebut, periodeFin)
+    // en mode 'edit' : le patch de période recharge les ajustements lui-même
+  }, [periodeDebut, periodeFin, mode, authReady, clientId, loadPreview])
+
+  // ── Auto-save (mode 'edit') des inventaires + notes + période ──────────
   const patchRapport = useCallback(async (updates) => {
-    if (!rapportId || !clientId) return
-    setSavingInv(true)
+    if (!currentRapportId || !clientId) return
+    setAutosaving(true)
     try {
-      const { data: { session } } = await supabase.auth.getSession()
-      await fetch('/api/food-cost/rapport', {
+      const headers = await authHeaders()
+      const res = await fetch('/api/food-cost/rapport', {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({ rapportId, clientId, ...updates }),
+        headers,
+        body: JSON.stringify({ rapportId: currentRapportId, clientId, ...updates }),
       })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error(j.error || `HTTP ${res.status}`)
+      }
+      // Si la période a changé en mode 'edit', il faut recharger les ajustements
+      // pour la nouvelle fenêtre.
+      if (updates.periodeDebut || updates.periodeFin) {
+        await loadPreview(updates.periodeDebut || periodeDebut, updates.periodeFin || periodeFin)
+      }
+    } catch (e) {
+      setError(`Enregistrement impossible : ${e.message}`)
     } finally {
-      setSavingInv(false)
+      setAutosaving(false)
     }
-  }, [rapportId, clientId])
+  }, [currentRapportId, clientId, authHeaders, loadPreview, periodeDebut, periodeFin])
 
   const debouncedPatch = useDebouncedCallback(patchRapport, 500)
 
   const onInventaireDebutChange = (v) => {
     setInventaireDebut(v)
-    debouncedPatch({ inventaireDebutHt: v === '' ? null : Number(v) })
+    if (mode === 'edit') debouncedPatch({ inventaireDebutHt: v === '' ? null : Number(v) })
   }
   const onInventaireFinChange = (v) => {
     setInventaireFin(v)
-    debouncedPatch({ inventaireFinHt: v === '' ? null : Number(v) })
+    if (mode === 'edit') debouncedPatch({ inventaireFinHt: v === '' ? null : Number(v) })
   }
   const onNotesChange = (v) => {
     setNotes(v)
-    debouncedPatch({ notes: v })
+    if (mode === 'edit') debouncedPatch({ notes: v })
+  }
+  const onPeriodeDebutChange = (v) => {
+    setPeriodeDebut(v)
+    if (mode === 'edit') debouncedPatch({ periodeDebut: v })
+  }
+  const onPeriodeFinChange = (v) => {
+    setPeriodeFin(v)
+    if (mode === 'edit') debouncedPatch({ periodeFin: v })
+  }
+
+  // ── Boutons Nouveau / Sauvegarder / Supprimer rapport ──────────────────
+  const handleNouveau = () => {
+    setMode('new')
+    setCurrentRapportId(null)
+    const p = defaultPeriod()
+    setPeriodeDebut(p.debut)
+    setPeriodeFin(p.fin)
+    setInventaireDebut('')
+    setInventaireFin('')
+    setNotes('')
+    setError('')
+    setOkMsg('')
+  }
+
+  const handleSauvegarder = async () => {
+    if (!clientId) return
+    setSaving(true)
+    setError('')
+    setOkMsg('')
+    try {
+      const headers = await authHeaders()
+      const res = await fetch('/api/food-cost/rapport', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          clientId,
+          periodeDebut,
+          periodeFin,
+          inventaireDebutHt: inventaireDebut === '' ? null : Number(inventaireDebut),
+          inventaireFinHt: inventaireFin === '' ? null : Number(inventaireFin),
+          notes,
+        }),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || `HTTP ${res.status}`)
+
+      if (json.duplicate) {
+        // Un rapport existe déjà → on le charge en mode 'edit'.
+        await loadRapport(json.rapport_id)
+        setOkMsg('Un rapport existait déjà pour cette période — chargé en édition.')
+      } else {
+        setMode('edit')
+        setCurrentRapportId(json.rapport_id)
+        setOkMsg('Rapport sauvegardé.')
+      }
+      await loadArchives()
+    } catch (e) {
+      setError(`Sauvegarde impossible : ${e.message}`)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleSupprimerRapport = async () => {
+    if (!currentRapportId || !clientId) return
+    if (!window.confirm('Supprimer ce rapport food cost ? Les ajustements datés restent conservés.')) return
+    try {
+      const headers = await authHeaders()
+      const res = await fetch('/api/food-cost/rapport', {
+        method: 'DELETE',
+        headers,
+        body: JSON.stringify({ rapportId: currentRapportId, clientId }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error(j.error || `HTTP ${res.status}`)
+      }
+      setOkMsg('Rapport supprimé.')
+      handleNouveau()
+      await loadArchives()
+    } catch (e) {
+      setError(`Suppression impossible : ${e.message}`)
+    }
   }
 
   // ── Ajustements CRUD ───────────────────────────────────────────────────
   const addAjustement = async () => {
-    if (!rapportId || !clientId) return
+    if (!clientId) return
     const libelle = newLibelle.trim()
     const montant = Number(newMontant)
     if (!libelle) { setError('Libellé requis pour l\'ajustement.'); return }
     if (!Number.isFinite(montant)) { setError('Montant numérique requis.'); return }
+    if (!newDate) { setError('Date requise pour l\'ajustement.'); return }
     setAddingAjustement(true)
     setError('')
     try {
-      const { data: { session } } = await supabase.auth.getSession()
+      const headers = await authHeaders()
       const res = await fetch('/api/food-cost/ajustement', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({ clientId, rapportId, libelle, montant, commentaire: newCommentaire.trim() }),
+        headers,
+        body: JSON.stringify({
+          clientId,
+          rapportId: currentRapportId,
+          dateAjustement: newDate,
+          libelle,
+          montant,
+          commentaire: newCommentaire.trim(),
+        }),
       })
       const json = await res.json()
       if (!res.ok) throw new Error(json.error || `HTTP ${res.status}`)
-      setAjustements(prev => [...prev, json])
-      setNewLibelle(''); setNewMontant(''); setNewCommentaire('')
+
+      // Inclure l'ajustement dans la liste uniquement s'il tombe dans la période courante.
+      if (json.date_ajustement >= periodeDebut && json.date_ajustement <= periodeFin) {
+        setAjustements(prev => [...prev, json].sort((a, b) => a.date_ajustement.localeCompare(b.date_ajustement)))
+      }
+      setNewLibelle(''); setNewMontant(''); setNewCommentaire(''); setNewDate(todayIso())
     } catch (e) {
       setError(`Ajout impossible : ${e.message}`)
     } finally {
@@ -197,13 +382,69 @@ export default function FoodCostPage() {
     }
   }
 
+  const startEditAjustement = (a) => {
+    setEditingId(a.id)
+    setEditDate(a.date_ajustement)
+    setEditLibelle(a.libelle)
+    setEditMontant(String(a.montant))
+    setEditCommentaire(a.commentaire || '')
+  }
+
+  const cancelEditAjustement = () => {
+    setEditingId(null)
+    setEditDate(''); setEditLibelle(''); setEditMontant(''); setEditCommentaire('')
+  }
+
+  const saveEditAjustement = async () => {
+    if (!editingId || !clientId) return
+    const libelle = editLibelle.trim()
+    const montant = Number(editMontant)
+    if (!libelle) { setError('Libellé requis.'); return }
+    if (!Number.isFinite(montant)) { setError('Montant numérique requis.'); return }
+    if (!editDate) { setError('Date requise.'); return }
+    setSavingEdit(true)
+    setError('')
+    try {
+      const headers = await authHeaders()
+      const res = await fetch('/api/food-cost/ajustement', {
+        method: 'PATCH',
+        headers,
+        body: JSON.stringify({
+          clientId,
+          ajustementId: editingId,
+          dateAjustement: editDate,
+          libelle,
+          montant,
+          commentaire: editCommentaire.trim(),
+        }),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || `HTTP ${res.status}`)
+
+      // L'ajustement reste-t-il dans la période courante ?
+      const stillInPeriode = json.date_ajustement >= periodeDebut && json.date_ajustement <= periodeFin
+      setAjustements(prev => {
+        const filtered = prev.filter(a => a.id !== editingId)
+        if (stillInPeriode) {
+          return [...filtered, json].sort((a, b) => a.date_ajustement.localeCompare(b.date_ajustement))
+        }
+        return filtered
+      })
+      cancelEditAjustement()
+    } catch (e) {
+      setError(`Modification impossible : ${e.message}`)
+    } finally {
+      setSavingEdit(false)
+    }
+  }
+
   const deleteAjustement = async (id) => {
     if (!window.confirm('Supprimer cet ajustement ?')) return
     try {
-      const { data: { session } } = await supabase.auth.getSession()
+      const headers = await authHeaders()
       await fetch(`/api/food-cost/ajustement?ajustementId=${id}&clientId=${clientId}`, {
         method: 'DELETE',
-        headers: { Authorization: `Bearer ${session.access_token}` },
+        headers,
       })
       setAjustements(prev => prev.filter(a => a.id !== id))
     } catch (e) {
@@ -215,8 +456,8 @@ export default function FoodCostPage() {
   const applyPreset = (k) => {
     const p = getPeriodDates(k)
     if (!p) return
-    setPeriodeDebut(p.debut)
-    setPeriodeFin(p.fin)
+    onPeriodeDebutChange(p.debut)
+    onPeriodeFinChange(p.fin)
   }
 
   // ── Calculs dérivés (live) ─────────────────────────────────────────────
@@ -257,6 +498,10 @@ export default function FoodCostPage() {
     padding: '6px 12px', borderRadius: 8, fontSize: 12,
     border: `1px solid ${c.bordure}`, background: c.blanc, color: c.texte, cursor: 'pointer',
   }
+  const btnDanger = {
+    padding: '8px 14px', borderRadius: 8, fontSize: 13, border: `1px solid #FECACA`,
+    background: '#FEF2F2', color: '#B91C1C', cursor: 'pointer', fontWeight: 500,
+  }
 
   // Couleur du ratio : <30 vert, <35 orange clair, <40 orange, ≥40 rouge
   const ratioColor = totaux.ratio == null
@@ -269,162 +514,245 @@ export default function FoodCostPage() {
   return (
     <div style={{ minHeight: '100vh', background: c.fond }}>
       <Navbar section="cuisine" />
-      <div style={{ padding: isMobile ? 16 : 24, maxWidth: 1100, margin: '0 auto' }}>
-        <h1 style={{ margin: '0 0 4px', fontSize: isMobile ? 22 : 26, fontWeight: 600, color: c.texte }}>
-          Ratio Food Cost
-        </h1>
-        <p style={{ margin: '0 0 20px', fontSize: 14, color: c.texteMuted }}>
-          Coût matière sur CA Food. Inventaires début/fin + ajustements libres.
-        </p>
+      <div style={{ padding: isMobile ? 16 : 24, maxWidth: 1300, margin: '0 auto' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', flexWrap: 'wrap', gap: 12, marginBottom: 16 }}>
+          <div>
+            <h1 style={{ margin: '0 0 4px', fontSize: isMobile ? 22 : 26, fontWeight: 600, color: c.texte }}>
+              Ratio Food Cost
+            </h1>
+            <p style={{ margin: 0, fontSize: 14, color: c.texteMuted }}>
+              {mode === 'edit'
+                ? `Rapport sauvegardé · ${formatDate(periodeDebut)} → ${formatDate(periodeFin)}`
+                : 'Nouveau rapport (brouillon non sauvegardé)'}
+              {autosaving && <span style={{ marginLeft: 8, fontStyle: 'italic' }}>· enregistrement…</span>}
+            </p>
+          </div>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            {mode === 'edit' && (
+              <button onClick={handleNouveau} style={btnSecondary}>Nouveau</button>
+            )}
+            {mode === 'new' ? (
+              <button onClick={handleSauvegarder} disabled={saving} style={{ ...btnPrimary, opacity: saving ? 0.6 : 1 }}>
+                {saving ? '…' : '💾 Sauvegarder'}
+              </button>
+            ) : (
+              <button onClick={handleSupprimerRapport} style={btnDanger}>Supprimer</button>
+            )}
+          </div>
+        </div>
 
         {error && (
           <div style={{ background: '#FEE2E2', color: '#991B1B', padding: '10px 14px', borderRadius: 8, fontSize: 13, marginBottom: 16 }}>
             {error}
           </div>
         )}
-
-        {/* ── Période ───────────────────────────────────────────────────── */}
-        <div style={card}>
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center', marginBottom: 12 }}>
-            <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, color: c.texteMuted }}>
-              Du
-              <input type="date" value={periodeDebut} onChange={(e) => setPeriodeDebut(e.target.value)}
-                style={{ ...input, width: 'auto', padding: '6px 10px' }} />
-            </label>
-            <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, color: c.texteMuted }}>
-              au
-              <input type="date" value={periodeFin} onChange={(e) => setPeriodeFin(e.target.value)}
-                style={{ ...input, width: 'auto', padding: '6px 10px' }} />
-            </label>
-            {[
-              { k: 'mois-en-cours',  label: 'Ce mois' },
-              { k: 'mois-precedent', label: 'Mois préc.' },
-              { k: '30j',            label: '30 j' },
-              { k: 'trimestre',      label: 'Trimestre' },
-              { k: 'annee',          label: 'Année' },
-            ].map(p => (
-              <button key={p.k} onClick={() => applyPreset(p.k)} style={btnSecondary}>{p.label}</button>
-            ))}
+        {okMsg && (
+          <div style={{ background: '#DCFCE7', color: '#166534', padding: '10px 14px', borderRadius: 8, fontSize: 13, marginBottom: 16 }}>
+            {okMsg}
           </div>
-          {loading && <div style={{ fontSize: 12, color: c.texteMuted }}>Chargement des données…</div>}
-        </div>
+        )}
 
-        {/* ── KPI ───────────────────────────────────────────────────────── */}
-        <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : 'repeat(4, 1fr)', gap: 12, marginBottom: 16 }}>
-          <KpiCard label="CA Food HT" value={formatEuro(caFoodHt)} c={c} />
-          <KpiCard label="Achats HT cumulés" value={formatEuro(achatsHt)} c={c} />
-          <KpiCard label="Coût matière" value={formatEuro(totaux.coutMatiere)} c={c} sub={
-            <span style={{ fontSize: 11, color: c.texteMuted }}>
-              inv. début + achats − inv. fin + Σ ajust.
-            </span>
-          } />
-          <KpiCard
-            label="Ratio food cost"
-            value={formatPct(totaux.ratio)}
-            valueColor={ratioColor}
-            c={c}
-            sub={!hasInventaires ? (
-              <span style={{ fontSize: 11, color: '#B45309' }}>⚠ inventaires manquants — ratio approximatif</span>
-            ) : null}
-          />
-        </div>
-
-        {/* ── Inventaires ──────────────────────────────────────────────── */}
-        <div style={card}>
-          <h3 style={{ margin: '0 0 4px', fontSize: 15, fontWeight: 600, color: c.texte }}>
-            Variation de stock
-          </h3>
-          <p style={{ margin: '0 0 14px', fontSize: 12, color: c.texteMuted }}>
-            Valeurs HT. Laisse vide si tu n&apos;as pas fait d&apos;inventaire physique.
-            {savingInv && <span style={{ marginLeft: 8, fontStyle: 'italic' }}>· enregistrement…</span>}
-          </p>
-          <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr', gap: 12 }}>
-            <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-              <span style={{ fontSize: 12, color: c.texteMuted, fontWeight: 500 }}>Inventaire début (HT €)</span>
-              <input type="number" step="0.01" value={inventaireDebut} onChange={(e) => onInventaireDebutChange(e.target.value)} placeholder="ex. 12000.00" style={input} />
-            </label>
-            <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-              <span style={{ fontSize: 12, color: c.texteMuted, fontWeight: 500 }}>Inventaire fin (HT €)</span>
-              <input type="number" step="0.01" value={inventaireFin} onChange={(e) => onInventaireFinChange(e.target.value)} placeholder="ex. 11500.00" style={input} />
-            </label>
-          </div>
-        </div>
-
-        {/* ── Ajustements ──────────────────────────────────────────────── */}
-        <div style={card}>
-          <h3 style={{ margin: '0 0 4px', fontSize: 15, fontWeight: 600, color: c.texte }}>
-            Ajustements
-          </h3>
-          <p style={{ margin: '0 0 14px', fontSize: 12, color: c.texteMuted }}>
-            Montant signé : <strong>positif</strong> = ajout au coût (ex. transferts entrants), <strong>négatif</strong> = déduction (ex. repas staff, casse, cadeaux clients).
-          </p>
-
-          {ajustements.length > 0 && (
-            <div style={{ overflowX: 'auto', marginBottom: 14, border: `1px solid ${c.bordure}`, borderRadius: 8 }}>
-              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-                <thead>
-                  <tr style={{ background: c.fond }}>
-                    <th style={th(c)}>Libellé</th>
-                    <th style={{ ...th(c), textAlign: 'right' }}>Montant</th>
-                    <th style={th(c)}>Commentaire</th>
-                    <th style={{ ...th(c), width: 60 }}></th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {ajustements.map((a) => (
-                    <tr key={a.id}>
-                      <td style={td(c)}>{a.libelle}</td>
-                      <td style={{ ...td(c), textAlign: 'right', fontVariantNumeric: 'tabular-nums', color: Number(a.montant) < 0 ? '#15803D' : '#B91C1C' }}>
-                        {Number(a.montant) > 0 ? '+' : ''}{formatEuro(a.montant)}
-                      </td>
-                      <td style={{ ...td(c), color: c.texteMuted, fontSize: 12 }}>{a.commentaire || '—'}</td>
-                      <td style={td(c)}>
-                        <button onClick={() => deleteAjustement(a.id)} style={{ background: 'none', border: 'none', color: '#B91C1C', cursor: 'pointer', fontSize: 12 }}>Suppr.</button>
-                      </td>
-                    </tr>
-                  ))}
-                  <tr style={{ background: c.fond, fontWeight: 600 }}>
-                    <td style={td(c)}>Total ajustements</td>
-                    <td style={{ ...td(c), textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
-                      {totaux.sumAjust > 0 ? '+' : ''}{formatEuro(totaux.sumAjust)}
-                    </td>
-                    <td style={td(c)} colSpan={2} />
-                  </tr>
-                </tbody>
-              </table>
+        <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 280px', gap: 16, alignItems: 'flex-start' }}>
+          {/* ── Colonne principale ─────────────────────────────────────── */}
+          <div>
+            {/* Période */}
+            <div style={card}>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center', marginBottom: 12 }}>
+                <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, color: c.texteMuted }}>
+                  Du
+                  <input type="date" value={periodeDebut} onChange={(e) => onPeriodeDebutChange(e.target.value)}
+                    style={{ ...input, width: 'auto', padding: '6px 10px' }} />
+                </label>
+                <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, color: c.texteMuted }}>
+                  au
+                  <input type="date" value={periodeFin} onChange={(e) => onPeriodeFinChange(e.target.value)}
+                    style={{ ...input, width: 'auto', padding: '6px 10px' }} />
+                </label>
+                {[
+                  { k: 'mois-en-cours',  label: 'Ce mois' },
+                  { k: 'mois-precedent', label: 'Mois préc.' },
+                  { k: '30j',            label: '30 j' },
+                  { k: 'trimestre',      label: 'Trimestre' },
+                  { k: 'annee',          label: 'Année' },
+                ].map(p => (
+                  <button key={p.k} onClick={() => applyPreset(p.k)} style={btnSecondary}>{p.label}</button>
+                ))}
+              </div>
+              {loading && <div style={{ fontSize: 12, color: c.texteMuted }}>Chargement des données…</div>}
             </div>
-          )}
 
-          {/* Form d'ajout */}
-          <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '2fr 1fr 3fr auto', gap: 8, alignItems: 'end' }}>
-            <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-              <span style={{ fontSize: 11, color: c.texteMuted, fontWeight: 500 }}>Libellé</span>
-              <input value={newLibelle} onChange={(e) => setNewLibelle(e.target.value)} placeholder="ex. Repas staff" style={input} />
-            </label>
-            <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-              <span style={{ fontSize: 11, color: c.texteMuted, fontWeight: 500 }}>Montant (signé)</span>
-              <input type="number" step="0.01" value={newMontant} onChange={(e) => setNewMontant(e.target.value)} placeholder="-350.00" style={input} />
-            </label>
-            <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-              <span style={{ fontSize: 11, color: c.texteMuted, fontWeight: 500 }}>Commentaire (optionnel)</span>
-              <input value={newCommentaire} onChange={(e) => setNewCommentaire(e.target.value)} placeholder="précision" style={input} />
-            </label>
-            <button onClick={addAjustement} disabled={addingAjustement || !newLibelle.trim() || !newMontant} style={{ ...btnPrimary, opacity: (addingAjustement || !newLibelle.trim() || !newMontant) ? 0.6 : 1 }}>
-              {addingAjustement ? '…' : '+ Ajouter'}
-            </button>
+            {/* KPI */}
+            <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr 1fr' : 'repeat(4, 1fr)', gap: 12, marginBottom: 16 }}>
+              <KpiCard label="CA Food HT" value={formatEuro(caFoodHt)} c={c} />
+              <KpiCard label="Achats HT cumulés" value={formatEuro(achatsHt)} c={c} />
+              <KpiCard label="Coût matière" value={formatEuro(totaux.coutMatiere)} c={c} sub={
+                <span style={{ fontSize: 11, color: c.texteMuted }}>
+                  inv. début + achats − inv. fin + Σ ajust.
+                </span>
+              } />
+              <KpiCard
+                label="Ratio food cost"
+                value={formatPct(totaux.ratio)}
+                valueColor={ratioColor}
+                c={c}
+                sub={!hasInventaires ? (
+                  <span style={{ fontSize: 11, color: '#B45309' }}>⚠ inventaires manquants — ratio approximatif</span>
+                ) : null}
+              />
+            </div>
+
+            {/* Inventaires */}
+            <div style={card}>
+              <h3 style={{ margin: '0 0 4px', fontSize: 15, fontWeight: 600, color: c.texte }}>
+                Variation de stock
+              </h3>
+              <p style={{ margin: '0 0 14px', fontSize: 12, color: c.texteMuted }}>
+                Valeurs HT. Laisse vide si tu n&apos;as pas fait d&apos;inventaire physique.
+              </p>
+              <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr', gap: 12 }}>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  <span style={{ fontSize: 12, color: c.texteMuted, fontWeight: 500 }}>Inventaire début (HT €)</span>
+                  <input type="number" step="0.01" value={inventaireDebut} onChange={(e) => onInventaireDebutChange(e.target.value)} placeholder="ex. 12000.00" style={input} />
+                </label>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  <span style={{ fontSize: 12, color: c.texteMuted, fontWeight: 500 }}>Inventaire fin (HT €)</span>
+                  <input type="number" step="0.01" value={inventaireFin} onChange={(e) => onInventaireFinChange(e.target.value)} placeholder="ex. 11500.00" style={input} />
+                </label>
+              </div>
+            </div>
+
+            {/* Ajustements */}
+            <div style={card}>
+              <h3 style={{ margin: '0 0 4px', fontSize: 15, fontWeight: 600, color: c.texte }}>
+                Ajustements
+              </h3>
+              <p style={{ margin: '0 0 14px', fontSize: 12, color: c.texteMuted }}>
+                Chaque ajustement est daté et persistant. Il est inclus dans tout rapport dont la période couvre sa date.
+                Montant signé : <strong>positif</strong> = ajout au coût (transferts entrants), <strong>négatif</strong> = déduction (repas staff, casse, cadeaux).
+              </p>
+
+              {ajustements.length > 0 && (
+                <div style={{ overflowX: 'auto', marginBottom: 14, border: `1px solid ${c.bordure}`, borderRadius: 8 }}>
+                  <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                    <thead>
+                      <tr style={{ background: c.fond }}>
+                        <th style={{ ...th(c), width: 110 }}>Date</th>
+                        <th style={th(c)}>Libellé</th>
+                        <th style={{ ...th(c), textAlign: 'right', width: 120 }}>Montant</th>
+                        <th style={th(c)}>Commentaire</th>
+                        <th style={{ ...th(c), width: 130 }}></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {ajustements.map((a) => editingId === a.id ? (
+                        <tr key={a.id} style={{ background: c.fond }}>
+                          <td style={td(c)}>
+                            <input type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} style={{ ...input, padding: '4px 8px', fontSize: 12 }} />
+                          </td>
+                          <td style={td(c)}>
+                            <input value={editLibelle} onChange={(e) => setEditLibelle(e.target.value)} style={{ ...input, padding: '4px 8px', fontSize: 12 }} />
+                          </td>
+                          <td style={td(c)}>
+                            <input type="number" step="0.01" value={editMontant} onChange={(e) => setEditMontant(e.target.value)} style={{ ...input, padding: '4px 8px', fontSize: 12, textAlign: 'right' }} />
+                          </td>
+                          <td style={td(c)}>
+                            <input value={editCommentaire} onChange={(e) => setEditCommentaire(e.target.value)} style={{ ...input, padding: '4px 8px', fontSize: 12 }} />
+                          </td>
+                          <td style={td(c)}>
+                            <button onClick={saveEditAjustement} disabled={savingEdit} style={{ background: 'none', border: 'none', color: '#15803D', cursor: 'pointer', fontSize: 12, marginRight: 6 }}>
+                              {savingEdit ? '…' : 'OK'}
+                            </button>
+                            <button onClick={cancelEditAjustement} style={{ background: 'none', border: 'none', color: c.texteMuted, cursor: 'pointer', fontSize: 12 }}>Annuler</button>
+                          </td>
+                        </tr>
+                      ) : (
+                        <tr key={a.id}>
+                          <td style={{ ...td(c), fontSize: 12, color: c.texteMuted }}>{formatDate(a.date_ajustement)}</td>
+                          <td style={td(c)}>{a.libelle}</td>
+                          <td style={{ ...td(c), textAlign: 'right', fontVariantNumeric: 'tabular-nums', color: Number(a.montant) < 0 ? '#15803D' : '#B91C1C' }}>
+                            {Number(a.montant) > 0 ? '+' : ''}{formatEuro(a.montant)}
+                          </td>
+                          <td style={{ ...td(c), color: c.texteMuted, fontSize: 12 }}>{a.commentaire || '—'}</td>
+                          <td style={td(c)}>
+                            <button onClick={() => startEditAjustement(a)} style={{ background: 'none', border: 'none', color: c.texte, cursor: 'pointer', fontSize: 12, marginRight: 8 }}>Modifier</button>
+                            <button onClick={() => deleteAjustement(a.id)} style={{ background: 'none', border: 'none', color: '#B91C1C', cursor: 'pointer', fontSize: 12 }}>Suppr.</button>
+                          </td>
+                        </tr>
+                      ))}
+                      <tr style={{ background: c.fond, fontWeight: 600 }}>
+                        <td style={td(c)} colSpan={2}>Total ajustements</td>
+                        <td style={{ ...td(c), textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+                          {totaux.sumAjust > 0 ? '+' : ''}{formatEuro(totaux.sumAjust)}
+                        </td>
+                        <td style={td(c)} colSpan={2} />
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              )}
+
+              {/* Form d'ajout */}
+              <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '110px 2fr 1fr 3fr auto', gap: 8, alignItems: 'end' }}>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  <span style={{ fontSize: 11, color: c.texteMuted, fontWeight: 500 }}>Date</span>
+                  <input type="date" value={newDate} onChange={(e) => setNewDate(e.target.value)} style={input} />
+                </label>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  <span style={{ fontSize: 11, color: c.texteMuted, fontWeight: 500 }}>Libellé</span>
+                  <input value={newLibelle} onChange={(e) => setNewLibelle(e.target.value)} placeholder="ex. Repas staff" style={input} />
+                </label>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  <span style={{ fontSize: 11, color: c.texteMuted, fontWeight: 500 }}>Montant (signé)</span>
+                  <input type="number" step="0.01" value={newMontant} onChange={(e) => setNewMontant(e.target.value)} placeholder="-350.00" style={input} />
+                </label>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  <span style={{ fontSize: 11, color: c.texteMuted, fontWeight: 500 }}>Commentaire (optionnel)</span>
+                  <input value={newCommentaire} onChange={(e) => setNewCommentaire(e.target.value)} placeholder="précision" style={input} />
+                </label>
+                <button onClick={addAjustement} disabled={addingAjustement || !newLibelle.trim() || !newMontant || !newDate} style={{ ...btnPrimary, opacity: (addingAjustement || !newLibelle.trim() || !newMontant || !newDate) ? 0.6 : 1 }}>
+                  {addingAjustement ? '…' : '+ Ajouter'}
+                </button>
+              </div>
+            </div>
+
+            {/* Notes */}
+            <div style={card}>
+              <h3 style={{ margin: '0 0 8px', fontSize: 15, fontWeight: 600, color: c.texte }}>Notes</h3>
+              <textarea
+                value={notes}
+                onChange={(e) => onNotesChange(e.target.value)}
+                placeholder="Commentaire libre sur ce rapport food cost"
+                rows={3}
+                style={{ ...input, fontFamily: 'inherit', resize: 'vertical' }}
+              />
+            </div>
           </div>
-        </div>
 
-        {/* ── Notes libres ─────────────────────────────────────────────── */}
-        <div style={card}>
-          <h3 style={{ margin: '0 0 8px', fontSize: 15, fontWeight: 600, color: c.texte }}>Notes</h3>
-          <textarea
-            value={notes}
-            onChange={(e) => onNotesChange(e.target.value)}
-            placeholder="Commentaire libre sur ce rapport food cost"
-            rows={3}
-            style={{ ...input, fontFamily: 'inherit', resize: 'vertical' }}
-          />
+          {/* ── Sidebar Archives ───────────────────────────────────────── */}
+          <div style={{ ...card, position: isMobile ? 'static' : 'sticky', top: 16, marginBottom: 0 }}>
+            <h3 style={{ margin: '0 0 12px', fontSize: 14, fontWeight: 600, color: c.texte, textTransform: 'uppercase', letterSpacing: 0.4 }}>
+              Historique
+            </h3>
+            {archivesLoading ? (
+              <div style={{ fontSize: 12, color: c.texteMuted }}>Chargement…</div>
+            ) : archives.length === 0 ? (
+              <div style={{ fontSize: 12, color: c.texteMuted, fontStyle: 'italic' }}>
+                Aucun rapport sauvegardé. Saisis une période et clique sur « Sauvegarder » pour démarrer ton historique.
+              </div>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxHeight: isMobile ? 'none' : 'calc(100vh - 220px)', overflowY: 'auto' }}>
+                {archives.map((r) => (
+                  <ArchiveRow
+                    key={r.id}
+                    c={c}
+                    rapport={r}
+                    active={r.id === currentRapportId}
+                    onLoad={() => loadRapport(r.id)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>
@@ -441,6 +769,45 @@ function KpiCard({ label, value, valueColor, sub, c }) {
       {sub && <div style={{ marginTop: 4 }}>{sub}</div>}
     </div>
   )
+}
+
+function ArchiveRow({ c, rapport, active, onLoad }) {
+  const [d, m, y] = formatDateParts(rapport.periode_debut)
+  const [d2, m2, y2] = formatDateParts(rapport.periode_fin)
+  const sameYear = y === y2
+  const label = sameYear
+    ? `${d}/${m} → ${d2}/${m2}/${y2}`
+    : `${d}/${m}/${y} → ${d2}/${m2}/${y2}`
+  const hasInv = rapport.inventaire_debut_ht != null && rapport.inventaire_fin_ht != null
+  return (
+    <button
+      onClick={onLoad}
+      style={{
+        textAlign: 'left',
+        padding: '8px 10px',
+        borderRadius: 8,
+        border: active ? `1px solid ${c.accent}` : `1px solid ${c.bordure}`,
+        background: active ? c.fond : c.blanc,
+        color: c.texte,
+        cursor: 'pointer',
+        fontSize: 12,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+      }}
+    >
+      <span style={{ fontWeight: 600 }}>{label}</span>
+      <span style={{ fontSize: 11, color: c.texteMuted }}>
+        {hasInv ? 'Inventaires complets' : 'Inventaires partiels'}
+        {rapport.notes ? ' · note' : ''}
+      </span>
+    </button>
+  )
+}
+
+function formatDateParts(iso) {
+  if (!iso) return ['—', '—', '—']
+  return iso.split('-').reverse()
 }
 
 const th = (c) => ({

--- a/lib/services/foodCost.service.ts
+++ b/lib/services/foodCost.service.ts
@@ -3,18 +3,25 @@
  *
  * Un rapport = (client, periode_debut, periode_fin) avec :
  *   - inventaires début/fin (saisis, HT, optionnels)
- *   - liste d'ajustements libres (libellé + montant signé + commentaire)
+ *   - notes libres
  *
- * Le CA Food HT et la somme des achats sur la période sont *calculés à la
- * volée* depuis ca_journalier et achats_factures. On ne les persiste pas.
+ * Les ajustements sont indépendants des rapports : chacun a sa propre
+ * date_ajustement. Le rapport courant inclut tous les ajustements du client
+ * dont date_ajustement ∈ [periode_debut, periode_fin]. Idem pour la preview
+ * d'une période non sauvegardée.
+ *
+ * Le CA Food HT et la somme des achats sur la période sont calculés à la
+ * volée depuis ca_journalier et achats_factures (non persistés).
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type {
-  UpsertRapportInput,
+  CreateRapportInput,
   PatchRapportInput,
   DeleteRapportInput,
   GetRapportInput,
+  ListRapportsInput,
+  PreviewPeriodeInput,
   CreateAjustementInput,
   PatchAjustementInput,
   DeleteAjustementInput,
@@ -59,16 +66,34 @@ export async function computeAchatsHt(
   return (data ?? []).reduce((s, r) => s + (Number((r as { total_ht: number | null }).total_ht) || 0), 0)
 }
 
+async function fetchAjustementsForPeriode(
+  db: SupabaseClient,
+  clientId: string,
+  debut: string,
+  fin: string,
+) {
+  const { data, error } = await db
+    .from('food_cost_ajustements')
+    .select('id, date_ajustement, libelle, montant, commentaire, rapport_id, created_at')
+    .eq('client_id', clientId)
+    .gte('date_ajustement', debut)
+    .lte('date_ajustement', fin)
+    .order('date_ajustement', { ascending: true })
+    .order('created_at', { ascending: true })
+  if (error) throw new Error(error.message)
+  return data ?? []
+}
+
 // ── Rapport CRUD ───────────────────────────────────────────────────────────
 
-export async function upsertRapport(
+export async function createRapport(
   db: SupabaseClient,
-  input: UpsertRapportInput,
+  input: CreateRapportInput,
   userId: string,
 ) {
-  const { clientId, periodeDebut, periodeFin } = input
+  const { clientId, periodeDebut, periodeFin, inventaireDebutHt, inventaireFinHt, notes } = input
 
-  // 1. Rapport existant pour cette période ?
+  // Refus si un rapport actif existe déjà pour cette période exacte.
   const { data: existing } = await db
     .from('food_cost_rapports')
     .select('id')
@@ -77,22 +102,25 @@ export async function upsertRapport(
     .eq('periode_fin', periodeFin)
     .is('deleted_at', null)
     .maybeSingle()
+  if (existing) {
+    return { rapport_id: existing.id, created: false, duplicate: true }
+  }
 
-  if (existing) return { rapport_id: existing.id, created: false }
-
-  // 2. Création
   const { data: created, error } = await db
     .from('food_cost_rapports')
     .insert({
       client_id: clientId,
       periode_debut: periodeDebut,
       periode_fin: periodeFin,
+      inventaire_debut_ht: inventaireDebutHt ?? null,
+      inventaire_fin_ht: inventaireFinHt ?? null,
+      notes: notes ?? '',
       created_by: userId,
     })
     .select('id')
     .single()
   if (error) throw new Error(error.message)
-  return { rapport_id: created.id, created: true }
+  return { rapport_id: created.id, created: true, duplicate: false }
 }
 
 export async function getRapport(db: SupabaseClient, input: GetRapportInput) {
@@ -108,22 +136,15 @@ export async function getRapport(db: SupabaseClient, input: GetRapportInput) {
   if (error) throw new Error(error.message)
   if (!rapport) return null
 
-  const { data: ajustements } = await db
-    .from('food_cost_ajustements')
-    .select('id, libelle, montant, commentaire, created_at')
-    .eq('rapport_id', rapportId)
-    .eq('client_id', clientId)
-    .order('created_at', { ascending: true })
-
-  // Calculs live
-  const [caFoodHt, achatsHt] = await Promise.all([
+  const [ajustements, caFoodHt, achatsHt] = await Promise.all([
+    fetchAjustementsForPeriode(db, clientId, rapport.periode_debut, rapport.periode_fin),
     computeCaFoodHt(db, clientId, rapport.periode_debut, rapport.periode_fin),
     computeAchatsHt(db, clientId, rapport.periode_debut, rapport.periode_fin),
   ])
 
   return {
     rapport,
-    ajustements: ajustements ?? [],
+    ajustements,
     totaux: {
       ca_food_ht: caFoodHt,
       achats_ht: achatsHt,
@@ -131,10 +152,38 @@ export async function getRapport(db: SupabaseClient, input: GetRapportInput) {
   }
 }
 
+export async function listRapports(db: SupabaseClient, input: ListRapportsInput) {
+  const { clientId } = input
+  const { data, error } = await db
+    .from('food_cost_rapports')
+    .select('id, periode_debut, periode_fin, inventaire_debut_ht, inventaire_fin_ht, notes, created_at, updated_at')
+    .eq('client_id', clientId)
+    .is('deleted_at', null)
+    .order('periode_debut', { ascending: false })
+    .limit(100)
+  if (error) throw new Error(error.message)
+  return { rapports: data ?? [] }
+}
+
+export async function previewPeriode(db: SupabaseClient, input: PreviewPeriodeInput) {
+  const { clientId, periodeDebut, periodeFin } = input
+  const [ajustements, caFoodHt, achatsHt] = await Promise.all([
+    fetchAjustementsForPeriode(db, clientId, periodeDebut, periodeFin),
+    computeCaFoodHt(db, clientId, periodeDebut, periodeFin),
+    computeAchatsHt(db, clientId, periodeDebut, periodeFin),
+  ])
+  return {
+    ajustements,
+    totaux: { ca_food_ht: caFoodHt, achats_ht: achatsHt },
+  }
+}
+
 export async function patchRapport(db: SupabaseClient, input: PatchRapportInput) {
-  const { rapportId, clientId, inventaireDebutHt, inventaireFinHt, notes } = input
+  const { rapportId, clientId, periodeDebut, periodeFin, inventaireDebutHt, inventaireFinHt, notes } = input
 
   const updates: Record<string, unknown> = {}
+  if (periodeDebut !== undefined) updates.periode_debut = periodeDebut
+  if (periodeFin !== undefined) updates.periode_fin = periodeFin
   if (inventaireDebutHt !== undefined) updates.inventaire_debut_ht = inventaireDebutHt
   if (inventaireFinHt !== undefined) updates.inventaire_fin_ht = inventaireFinHt
   if (notes !== undefined) updates.notes = notes
@@ -170,38 +219,42 @@ export async function createAjustement(
   input: CreateAjustementInput,
   userId: string,
 ) {
-  const { clientId, rapportId, libelle, montant, commentaire } = input
+  const { clientId, rapportId, dateAjustement, libelle, montant, commentaire } = input
   const { data, error } = await db
     .from('food_cost_ajustements')
     .insert({
       client_id: clientId,
-      rapport_id: rapportId,
+      rapport_id: rapportId ?? null,
+      date_ajustement: dateAjustement,
       libelle,
       montant,
       commentaire: commentaire ?? '',
       created_by: userId,
     })
-    .select('id, libelle, montant, commentaire, created_at')
+    .select('id, date_ajustement, libelle, montant, commentaire, rapport_id, created_at')
     .single()
   if (error) throw new Error(error.message)
   return data
 }
 
 export async function patchAjustement(db: SupabaseClient, input: PatchAjustementInput) {
-  const { clientId, ajustementId, libelle, montant, commentaire } = input
+  const { clientId, ajustementId, dateAjustement, libelle, montant, commentaire } = input
   const updates: Record<string, unknown> = {}
+  if (dateAjustement !== undefined) updates.date_ajustement = dateAjustement
   if (libelle !== undefined) updates.libelle = libelle
   if (montant !== undefined) updates.montant = montant
   if (commentaire !== undefined) updates.commentaire = commentaire
   if (Object.keys(updates).length === 0) return { updated: false }
 
-  const { error } = await db
+  const { data, error } = await db
     .from('food_cost_ajustements')
     .update(updates)
     .eq('id', ajustementId)
     .eq('client_id', clientId)
+    .select('id, date_ajustement, libelle, montant, commentaire, rapport_id, created_at')
+    .single()
   if (error) throw new Error(error.message)
-  return { updated: true }
+  return data
 }
 
 export async function deleteAjustement(db: SupabaseClient, input: DeleteAjustementInput) {

--- a/lib/validators/foodCost.schema.ts
+++ b/lib/validators/foodCost.schema.ts
@@ -4,25 +4,33 @@ import { clientIdSchema, uuidSchema } from './achats.schema'
 // Période ISO YYYY-MM-DD
 const dateIso = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date attendue au format YYYY-MM-DD')
 
-// ── Upsert d'un rapport food cost pour une période donnée ─────────────────
-// Crée si absent, retourne l'existant si déjà présent (idempotent sur
-// le couple client_id + periode_debut + periode_fin).
-export const upsertRapportSchema = z.object({
-  clientId:           clientIdSchema,
-  periodeDebut:       dateIso,
-  periodeFin:         dateIso,
+// ── Création explicite d'un rapport food cost pour une période donnée ─────
+// Remplace l'ancien upsert. Renvoie une erreur si un rapport actif existe déjà
+// pour le même triplet (client_id, periode_debut, periode_fin).
+export const createRapportSchema = z.object({
+  clientId:     clientIdSchema,
+  periodeDebut: dateIso,
+  periodeFin:   dateIso,
+  inventaireDebutHt: z.coerce.number().nullable().optional(),
+  inventaireFinHt:   z.coerce.number().nullable().optional(),
+  notes:        z.string().max(2000).optional(),
 }).refine(d => d.periodeFin >= d.periodeDebut, {
   message: 'periodeFin doit être >= periodeDebut',
   path: ['periodeFin'],
 })
 
-// ── Patch d'un rapport (inventaires + notes) ───────────────────────────────
+// ── Patch d'un rapport (inventaires + notes + période) ─────────────────────
 export const patchRapportSchema = z.object({
-  rapportId:           uuidSchema,
-  clientId:            clientIdSchema,
-  inventaireDebutHt:   z.coerce.number().nullable().optional(),
-  inventaireFinHt:     z.coerce.number().nullable().optional(),
-  notes:               z.string().max(2000).optional(),
+  rapportId:         uuidSchema,
+  clientId:          clientIdSchema,
+  periodeDebut:      dateIso.optional(),
+  periodeFin:        dateIso.optional(),
+  inventaireDebutHt: z.coerce.number().nullable().optional(),
+  inventaireFinHt:   z.coerce.number().nullable().optional(),
+  notes:             z.string().max(2000).optional(),
+}).refine(d => !d.periodeDebut || !d.periodeFin || d.periodeFin >= d.periodeDebut, {
+  message: 'periodeFin doit être >= periodeDebut',
+  path: ['periodeFin'],
 })
 
 // ── Delete (soft) d'un rapport ─────────────────────────────────────────────
@@ -31,27 +39,49 @@ export const deleteRapportSchema = z.object({
   clientId:  clientIdSchema,
 })
 
-// ── Get rapport + computed totals ──────────────────────────────────────────
+// ── Get rapport unique + computed totals ───────────────────────────────────
 export const getRapportSchema = z.object({
   rapportId: uuidSchema,
   clientId:  clientIdSchema,
 })
 
+// ── Liste des rapports sauvegardés ─────────────────────────────────────────
+export const listRapportsSchema = z.object({
+  clientId: clientIdSchema,
+})
+
+// ── Aperçu live d'une période (sans rapport sauvegardé) ────────────────────
+// Permet de visualiser le ratio pour une période arbitraire, en chargeant les
+// ajustements datés qui tombent dedans, sans créer de rapport en base.
+export const previewPeriodeSchema = z.object({
+  clientId:     clientIdSchema,
+  periodeDebut: dateIso,
+  periodeFin:   dateIso,
+}).refine(d => d.periodeFin >= d.periodeDebut, {
+  message: 'periodeFin doit être >= periodeDebut',
+  path: ['periodeFin'],
+})
+
 // ── Ajustements ─────────────────────────────────────────────────────────────
+// rapportId optionnel : un ajustement peut être créé en dehors de tout rapport
+// sauvegardé. dateAjustement obligatoire : c'est elle qui détermine quels
+// rapports le voient.
 export const createAjustementSchema = z.object({
-  clientId:    clientIdSchema,
-  rapportId:   uuidSchema,
-  libelle:     z.string().min(1, 'Libellé requis').max(255),
-  montant:     z.coerce.number(),  // signé
-  commentaire: z.string().max(2000).optional().default(''),
+  clientId:        clientIdSchema,
+  rapportId:       uuidSchema.optional().nullable(),
+  dateAjustement:  dateIso,
+  libelle:         z.string().min(1, 'Libellé requis').max(255),
+  montant:         z.coerce.number(),  // signé
+  commentaire:     z.string().max(2000).optional().default(''),
 })
 
 export const patchAjustementSchema = z.object({
-  clientId:    clientIdSchema,
-  ajustementId: uuidSchema,
-  libelle:     z.string().min(1).max(255).optional(),
-  montant:     z.coerce.number().optional(),
-  commentaire: z.string().max(2000).optional(),
+  clientId:        clientIdSchema,
+  ajustementId:    uuidSchema,
+  dateAjustement:  dateIso.optional(),
+  libelle:         z.string().min(1).max(255).optional(),
+  montant:         z.coerce.number().optional(),
+  commentaire:     z.string().max(2000).optional(),
 })
 
 export const deleteAjustementSchema = z.object({
@@ -59,10 +89,12 @@ export const deleteAjustementSchema = z.object({
   ajustementId: uuidSchema,
 })
 
-export type UpsertRapportInput   = z.infer<typeof upsertRapportSchema>
+export type CreateRapportInput   = z.infer<typeof createRapportSchema>
 export type PatchRapportInput    = z.infer<typeof patchRapportSchema>
 export type DeleteRapportInput   = z.infer<typeof deleteRapportSchema>
 export type GetRapportInput      = z.infer<typeof getRapportSchema>
+export type ListRapportsInput    = z.infer<typeof listRapportsSchema>
+export type PreviewPeriodeInput  = z.infer<typeof previewPeriodeSchema>
 export type CreateAjustementInput = z.infer<typeof createAjustementSchema>
 export type PatchAjustementInput  = z.infer<typeof patchAjustementSchema>
 export type DeleteAjustementInput = z.infer<typeof deleteAjustementSchema>

--- a/supabase/migrations/20260520000000_food_cost_ajustements_par_date.sql
+++ b/supabase/migrations/20260520000000_food_cost_ajustements_par_date.sql
@@ -1,0 +1,56 @@
+-- ============================================================================
+-- food_cost_ajustements : passage à un modèle daté + indépendant des rapports.
+--
+-- Avant : chaque ajustement appartenait à UN rapport (rapport_id NOT NULL),
+-- donc à une période exacte [periode_debut, periode_fin]. Conséquence : si on
+-- changeait la période d'affichage, on perdait les ajustements précédemment
+-- saisis (un autre rapport = un autre jeu d'ajustements).
+--
+-- Après : chaque ajustement porte une date (date_ajustement). Quand on calcule
+-- le ratio food cost pour une période, on inclut tous les ajustements du client
+-- dont date_ajustement tombe dans [periode_debut, periode_fin]. Le rapport ne
+-- sert plus qu'à mémoriser les inventaires/notes de la période sauvegardée.
+--
+-- Migration des données existantes :
+--   - date_ajustement = periode_fin du rapport associé (date plausible la plus
+--     proche, puisqu'on n'a pas mieux). Si rapport_id NULL → created_at::date.
+--   - rapport_id reste pour historique mais devient nullable (les nouveaux
+--     ajustements peuvent être créés sans rapport sauvegardé).
+-- ============================================================================
+
+-- 1. Ajout de la colonne date_ajustement, initialement nullable pour permettre
+--    le backfill, puis NOT NULL.
+ALTER TABLE public.food_cost_ajustements
+  ADD COLUMN IF NOT EXISTS date_ajustement date;
+
+-- 2. Backfill depuis le rapport parent (periode_fin = date la plus représentative).
+UPDATE public.food_cost_ajustements a
+SET date_ajustement = r.periode_fin
+FROM public.food_cost_rapports r
+WHERE a.rapport_id = r.id
+  AND a.date_ajustement IS NULL;
+
+-- 3. Filet de sécurité : tout ajustement orphelin (rapport supprimé / null) →
+--    on utilise created_at comme fallback.
+UPDATE public.food_cost_ajustements
+SET date_ajustement = created_at::date
+WHERE date_ajustement IS NULL;
+
+-- 4. Verrouillage NOT NULL.
+ALTER TABLE public.food_cost_ajustements
+  ALTER COLUMN date_ajustement SET NOT NULL;
+
+-- 5. Rendre rapport_id nullable : les nouveaux ajustements n'ont plus besoin
+--    d'être rattachés à un rapport sauvegardé.
+ALTER TABLE public.food_cost_ajustements
+  ALTER COLUMN rapport_id DROP NOT NULL;
+
+-- 6. Index sur (client_id, date_ajustement) pour la requête principale
+--    "ajustements d'une période".
+CREATE INDEX IF NOT EXISTS food_cost_ajustements_client_date_idx
+  ON public.food_cost_ajustements (client_id, date_ajustement);
+
+COMMENT ON COLUMN public.food_cost_ajustements.date_ajustement IS
+  'Date à laquelle l''ajustement s''applique. Inclut l''ajustement dans tout rapport food cost dont la période couvre cette date.';
+COMMENT ON COLUMN public.food_cost_ajustements.rapport_id IS
+  'Rapport food cost dans lequel l''ajustement a été créé (historique uniquement). Peut être NULL si l''ajustement a été créé hors d''un rapport sauvegardé.';


### PR DESCRIPTION
## Contexte

Sur la page Ratio Food Cost, deux limitations :
1. Pas de **trace** des anciens food costs (contrairement aux rapports d'analyse hebdo qui ont leurs archives).
2. Les ajustements étaient liés à `(client, periode_debut, periode_fin)` exact : changer la période = perdre les ajustements précédents. Pas de modification possible en UI non plus.

## Changements

### UI
- **Sidebar Historique** à droite : liste les rapports sauvegardés, clic pour recharger.
- **Bouton « Sauvegarder »** explicite à la place de l'auto-upsert silencieux (qui créait un rapport vide à chaque navigation de période).
- **Bouton « Nouveau »** pour repartir d'un brouillon vierge.
- **Bouton « Supprimer »** (soft-delete) sur le rapport en édition.
- **Date sur chaque ajustement** + **bouton Modifier** (édition inline). CRUD complet.
- Bandeau de statut : « Nouveau rapport (brouillon non sauvegardé) » vs « Rapport sauvegardé · 01/05/2026 → 31/05/2026 ».

### Modèle de données
- `food_cost_ajustements.date_ajustement` (NOT NULL) — date à laquelle l'ajustement s'applique.
- `food_cost_ajustements.rapport_id` devient **nullable** — les ajustements vivent indépendamment des rapports. Le champ reste pour traçabilité historique.
- Index `(client_id, date_ajustement)` pour la lookup principale.
- **Backfill** : ajustements existants reçoivent `date_ajustement = periode_fin` de leur rapport parent (fallback : `created_at::date`).

### Calcul du ratio
Avant : ajustements pris dans `WHERE rapport_id = ?`.
Maintenant : `WHERE client_id = ? AND date_ajustement BETWEEN periode_debut AND periode_fin`. Conséquence directe attendue par l'utilisateur : un ajustement saisi une fois est **automatiquement réutilisé** dans toute période future qui couvre sa date.

### Nouvelles routes API
- `GET /api/food-cost/rapports?clientId=…` — liste des rapports.
- `GET /api/food-cost/preview?clientId=…&periodeDebut=…&periodeFin=…` — aperçu live (ajustements + totaux) pour une période non sauvegardée.

L'ancien `POST /api/food-cost/rapport` (upsert idempotent) devient un **create explicite** qui renvoie `{ duplicate: true, rapport_id }` si la période existe déjà — la page charge alors le rapport existant.

## ⚠️ Ordre de déploiement

La migration `20260520000000_food_cost_ajustements_par_date.sql` doit être appliquée **avant** le merge du code, sinon l'insert d'un ajustement avec `rapport_id = null` (mode brouillon) échouera sur la contrainte NOT NULL existante.

## Test plan
- [ ] Appliquer la migration sur la prod Supabase
- [ ] Ouvrir `/controle-gestion/food-cost` : statut « Nouveau rapport », la période mois précédent s'affiche avec ses ajustements existants (backfillés)
- [ ] Cliquer « Sauvegarder » → apparaît dans la sidebar Historique
- [ ] Changer la période vers le mois en cours → mode reste « rapport sauvegardé », ajustements de la nouvelle fenêtre chargés
- [ ] Cliquer « Nouveau » → mode brouillon, période mois précédent
- [ ] Créer un ajustement daté du 15 du mois précédent
- [ ] Changer la période sur le mois précédent → l'ajustement apparaît bien
- [ ] Modifier un ajustement (bouton Modifier) → date / libellé / montant / commentaire édités
- [ ] Supprimer un ajustement
- [ ] Supprimer un rapport archivé → disparaît de la sidebar, ajustements datés restent (vérifier sur un autre rapport)
- [ ] Recharger un rapport depuis la sidebar → édition reprend là où on était

🤖 Generated with [Claude Code](https://claude.com/claude-code)