### PR TITLE
fix(food-cost): export Excel stylisé + nettoyage PDF

### DIFF
--- a/app/controle-gestion/food-cost/page.js
+++ b/app/controle-gestion/food-cost/page.js
@@ -529,7 +529,7 @@ export default function FoodCostPage() {
     setError(''); setOkMsg('')
     try {
       const data = await fetchExportData()
-      const wb = buildFoodCostWorkbook({
+      const wb = await buildFoodCostWorkbook({
         periodeDebut,
         periodeFin,
         caFoodHt: data.totaux.ca_food_ht,
@@ -540,7 +540,7 @@ export default function FoodCostPage() {
         factures: data.factures,
         ajustements: data.ajustements,
       })
-      downloadFoodCostXlsx(wb, `food-cost_${periodeDebut}_${periodeFin}.xlsx`)
+      await downloadFoodCostXlsx(wb, `food-cost_${periodeDebut}_${periodeFin}.xlsx`)
       setOkMsg('Export Excel téléchargé.')
     } catch (e) {
       setError(`Export Excel impossible : ${e.message}`)

--- a/lib/foodCostExport.js
+++ b/lib/foodCostExport.js
@@ -1,23 +1,24 @@
-// Export du rapport food cost en Excel (.xlsx) ou en HTML imprimable
-// (ouvert dans un nouvel onglet qui déclenche window.print() — l'utilisateur
-// choisit "Enregistrer en PDF" dans la boîte de dialogue d'impression).
+// Export du rapport food cost en Excel (.xlsx) stylisé via exceljs ou en
+// HTML imprimable (ouvert dans un nouvel onglet qui déclenche window.print() —
+// l'utilisateur choisit "Enregistrer en PDF" dans la boîte de dialogue
+// d'impression).
 //
 // Onglets Excel :
-//   1. Synthèse — période, CA HT, achats HT, inventaires, coût matière, ratio
-//   2. Factures — date | fournisseur | n° facture | HT
-//   3. Ajustements — date | libellé | montant | commentaire
+//   1. Synthèse — vraie mise en page tableau : titre fusionné, sections
+//      (Période / Chiffres clés / Calcul du coût matière), bordures grises
+//      partout, montants au format euro "1 234,56 €", ratio formaté en %.
+//   2. Factures — date | fournisseur | n° facture | HT, bordures + en-têtes
+//      gras, ligne TOTAL.
+//   3. Ajustements — date | libellé | montant | commentaire, bordures, total.
 //
-// HTML d'impression : version mise en page A4, identique aux trois onglets
-// fusionnés sur une page, avec en-tête et @page pour le format.
+// exceljs est chargé dynamiquement (await import) pour ne pas alourdir le
+// bundle initial de la page (~700 KB).
 
-import * as XLSX from 'xlsx'
+const EURO_FMT = '#,##0.00 "€";-#,##0.00 "€";"—"'
+const PCT_FMT  = '0.0 "%"'
+const DATE_FMT = 'dd/mm/yyyy'
 
 // ── Helpers ────────────────────────────────────────────────────────────────
-
-function round2(n) {
-  if (n == null || Number.isNaN(Number(n))) return 0
-  return Math.round(Number(n) * 100) / 100
-}
 
 function formatDate(iso) {
   if (!iso) return ''
@@ -47,6 +48,11 @@ function esc(s) {
   return String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }
 
+function parseIsoDate(iso) {
+  if (!iso) return null
+  return new Date(`${iso}T00:00:00`)
+}
+
 // ── Calculs ─────────────────────────────────────────────────────────────────
 
 export function computeTotaux({ inventaireDebut, inventaireFin, achatsHt, ajustements, caFoodHt }) {
@@ -58,9 +64,18 @@ export function computeTotaux({ inventaireDebut, inventaireFin, achatsHt, ajuste
   return { invD, invF, sumAjust, coutMatiere, ratio }
 }
 
-// ── Excel workbook ──────────────────────────────────────────────────────────
+// ── Styles exceljs ─────────────────────────────────────────────────────────
 
-export function buildFoodCostWorkbook({
+const BORDER_THIN = { style: 'thin', color: { argb: 'FFCCCCCC' } }
+const BORDER_ALL = { top: BORDER_THIN, bottom: BORDER_THIN, left: BORDER_THIN, right: BORDER_THIN }
+
+const FILL_HEADER  = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFF3F4F6' } }
+const FILL_SECTION = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFE5E7EB' } }
+const FILL_TOTAL   = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFF9FAFB' } }
+
+// ── Excel workbook (async) ─────────────────────────────────────────────────
+
+export async function buildFoodCostWorkbook({
   periodeDebut,
   periodeFin,
   caFoodHt,
@@ -70,80 +85,179 @@ export function buildFoodCostWorkbook({
   notes,
   factures,
   ajustements,
-  generatedAt = new Date(),
 }) {
+  const ExcelJS = (await import('exceljs')).default
   const t = computeTotaux({ inventaireDebut, inventaireFin, achatsHt, ajustements, caFoodHt })
 
-  // Onglet 1 : Synthèse
-  const synthRows = [
-    { Champ: 'Date d\'export',          Valeur: generatedAt.toLocaleString('fr-FR') },
-    { Champ: 'Période début',           Valeur: periodeDebut },
-    { Champ: 'Période fin',             Valeur: periodeFin },
-    { Champ: '',                         Valeur: '' },
-    { Champ: 'CA Food HT',              Valeur: round2(caFoodHt) },
-    { Champ: 'Achats HT cumulés',       Valeur: round2(achatsHt) },
-    { Champ: 'Inventaire début (HT)',   Valeur: inventaireDebut === '' || inventaireDebut == null ? '—' : round2(inventaireDebut) },
-    { Champ: 'Inventaire fin (HT)',     Valeur: inventaireFin === '' || inventaireFin == null ? '—' : round2(inventaireFin) },
-    { Champ: 'Variation de stock',      Valeur: round2(t.invD - t.invF) },
-    { Champ: 'Σ ajustements (signés)',  Valeur: round2(t.sumAjust) },
-    { Champ: 'Coût matière',            Valeur: round2(t.coutMatiere) },
-    { Champ: 'Ratio food cost (%)',     Valeur: t.ratio == null ? '—' : `${t.ratio.toFixed(1)} %` },
-    { Champ: '',                         Valeur: '' },
-    { Champ: 'Notes',                   Valeur: notes || '' },
+  const wb = new ExcelJS.Workbook()
+  wb.creator = 'Skalcook'
+  wb.created = new Date()
+
+  // ── Onglet 1 : Synthèse ─────────────────────────────────────────────────
+  const wsSynth = wb.addWorksheet('Synthèse')
+  wsSynth.columns = [{ width: 32 }, { width: 22 }]
+
+  // Titre fusionné
+  wsSynth.mergeCells('A1:B1')
+  const titleCell = wsSynth.getCell('A1')
+  titleCell.value = `Rapport food cost — ${formatDate(periodeDebut)} → ${formatDate(periodeFin)}`
+  titleCell.font = { size: 14, bold: true }
+  titleCell.alignment = { horizontal: 'center', vertical: 'middle' }
+  titleCell.fill = FILL_SECTION
+  titleCell.border = BORDER_ALL
+  wsSynth.getRow(1).height = 22
+
+  // Helper pour ajouter une ligne de section (entête en gras + fond)
+  const addSectionHeader = (label) => {
+    const row = wsSynth.addRow([label, ''])
+    wsSynth.mergeCells(`A${row.number}:B${row.number}`)
+    const c = wsSynth.getCell(`A${row.number}`)
+    c.font = { bold: true, size: 11 }
+    c.fill = FILL_HEADER
+    c.border = BORDER_ALL
+    c.alignment = { horizontal: 'left' }
+    return row
+  }
+
+  const addKV = (champ, valeur, opts = {}) => {
+    const row = wsSynth.addRow([champ, valeur ?? null])
+    const cChamp = wsSynth.getCell(`A${row.number}`)
+    const cVal = wsSynth.getCell(`B${row.number}`)
+    cChamp.font = { bold: !!opts.bold }
+    cVal.font = { bold: !!opts.bold }
+    cChamp.border = BORDER_ALL
+    cVal.border = BORDER_ALL
+    cChamp.alignment = { horizontal: 'left', vertical: 'middle' }
+    cVal.alignment = { horizontal: 'right', vertical: 'middle' }
+    if (opts.fmt) cVal.numFmt = opts.fmt
+    if (opts.fill) {
+      cChamp.fill = opts.fill
+      cVal.fill = opts.fill
+    }
+    if (opts.color) {
+      cVal.font = { ...cVal.font, color: { argb: opts.color } }
+    }
+    return row
+  }
+
+  // Section : Période
+  addSectionHeader('Période')
+  addKV('Période début', parseIsoDate(periodeDebut), { fmt: DATE_FMT })
+  addKV('Période fin',   parseIsoDate(periodeFin),   { fmt: DATE_FMT })
+
+  // Section : Chiffres clés
+  addSectionHeader('Chiffres clés')
+  addKV('CA Food HT',         Number(caFoodHt) || 0, { fmt: EURO_FMT })
+  addKV('Achats HT cumulés',  Number(achatsHt) || 0, { fmt: EURO_FMT })
+
+  // Section : Calcul du coût matière
+  addSectionHeader('Calcul du coût matière')
+  addKV('Inventaire début (HT)', inventaireDebut === '' || inventaireDebut == null ? null : Number(inventaireDebut), { fmt: EURO_FMT })
+  addKV('+ Achats HT',           Number(achatsHt) || 0, { fmt: EURO_FMT })
+  addKV('− Inventaire fin (HT)', inventaireFin === '' || inventaireFin == null ? null : Number(inventaireFin), { fmt: EURO_FMT })
+  addKV('+ Σ ajustements',       t.sumAjust, { fmt: EURO_FMT })
+  addKV('= Coût matière',        t.coutMatiere, { fmt: EURO_FMT, bold: true, fill: FILL_TOTAL })
+  addKV('Ratio food cost',       t.ratio == null ? null : t.ratio, {
+    fmt: PCT_FMT,
+    bold: true,
+    fill: FILL_TOTAL,
+    color: t.ratio == null ? null : t.ratio < 30 ? 'FF15803D' : t.ratio < 35 ? 'FFCA8A04' : t.ratio < 40 ? 'FFC2410C' : 'FFB91C1C',
+  })
+
+  // Section : Notes (uniquement si renseignées)
+  if (notes && notes.trim()) {
+    addSectionHeader('Notes')
+    const row = wsSynth.addRow([notes, ''])
+    wsSynth.mergeCells(`A${row.number}:B${row.number}`)
+    const c = wsSynth.getCell(`A${row.number}`)
+    c.alignment = { horizontal: 'left', vertical: 'top', wrapText: true }
+    c.border = BORDER_ALL
+    row.height = Math.min(120, 18 + Math.floor(notes.length / 60) * 16)
+  }
+
+  // ── Onglet 2 : Factures ─────────────────────────────────────────────────
+  const wsFact = wb.addWorksheet('Factures')
+  wsFact.columns = [
+    { header: 'Date',        key: 'date',        width: 14 },
+    { header: 'Fournisseur', key: 'fournisseur', width: 34 },
+    { header: 'N° facture',  key: 'numero',      width: 22 },
+    { header: 'Total HT',    key: 'ht',          width: 16 },
   ]
-  const wsSynth = XLSX.utils.json_to_sheet(synthRows)
-  wsSynth['!cols'] = [{ wch: 28 }, { wch: 40 }]
+  const factHeader = wsFact.getRow(1)
+  factHeader.font = { bold: true }
+  factHeader.fill = FILL_HEADER
+  factHeader.alignment = { horizontal: 'center' }
+  factHeader.eachCell((c) => { c.border = BORDER_ALL })
 
-  // Onglet 2 : Factures
-  const facturesRows = (factures || []).map((f) => ({
-    'Date facture':   f.date_facture,
-    'Fournisseur':    f.fournisseur || '',
-    'N° facture':     f.numero_facture || '',
-    'Total HT (€)':   round2(f.total_ht),
-  }))
-  // Ligne de total
-  if (facturesRows.length > 0) {
-    facturesRows.push({
-      'Date facture': '',
-      'Fournisseur':  '',
-      'N° facture':   'TOTAL',
-      'Total HT (€)': round2((factures || []).reduce((s, f) => s + (Number(f.total_ht) || 0), 0)),
+  for (const f of (factures || [])) {
+    const row = wsFact.addRow({
+      date:        parseIsoDate(f.date_facture),
+      fournisseur: f.fournisseur || '',
+      numero:      f.numero_facture || '',
+      ht:          Number(f.total_ht) || 0,
     })
+    row.getCell('date').numFmt = DATE_FMT
+    row.getCell('ht').numFmt = EURO_FMT
+    row.eachCell((c) => { c.border = BORDER_ALL })
   }
-  const wsFact = XLSX.utils.json_to_sheet(facturesRows, {
-    header: ['Date facture', 'Fournisseur', 'N° facture', 'Total HT (€)'],
-  })
-  wsFact['!cols'] = [{ wch: 12 }, { wch: 30 }, { wch: 18 }, { wch: 14 }]
+  if ((factures || []).length > 0) {
+    const facturesTotal = (factures || []).reduce((s, f) => s + (Number(f.total_ht) || 0), 0)
+    const totalRow = wsFact.addRow({ numero: 'TOTAL', ht: facturesTotal })
+    totalRow.font = { bold: true }
+    totalRow.fill = FILL_TOTAL
+    totalRow.getCell('ht').numFmt = EURO_FMT
+    totalRow.eachCell((c) => { c.border = BORDER_ALL })
+  }
 
-  // Onglet 3 : Ajustements
-  const ajusRows = (ajustements || []).map((a) => ({
-    'Date':         a.date_ajustement,
-    'Libellé':      a.libelle,
-    'Montant (€)':  round2(a.montant),
-    'Commentaire':  a.commentaire || '',
-  }))
-  if (ajusRows.length > 0) {
-    ajusRows.push({
-      'Date':        '',
-      'Libellé':     'TOTAL',
-      'Montant (€)': round2(t.sumAjust),
-      'Commentaire': '',
+  // ── Onglet 3 : Ajustements ──────────────────────────────────────────────
+  const wsAjus = wb.addWorksheet('Ajustements')
+  wsAjus.columns = [
+    { header: 'Date',        key: 'date',        width: 14 },
+    { header: 'Libellé',     key: 'libelle',     width: 34 },
+    { header: 'Montant',     key: 'montant',     width: 16 },
+    { header: 'Commentaire', key: 'commentaire', width: 40 },
+  ]
+  const ajusHeader = wsAjus.getRow(1)
+  ajusHeader.font = { bold: true }
+  ajusHeader.fill = FILL_HEADER
+  ajusHeader.alignment = { horizontal: 'center' }
+  ajusHeader.eachCell((c) => { c.border = BORDER_ALL })
+
+  for (const a of (ajustements || [])) {
+    const row = wsAjus.addRow({
+      date:        parseIsoDate(a.date_ajustement),
+      libelle:     a.libelle,
+      montant:     Number(a.montant) || 0,
+      commentaire: a.commentaire || '',
     })
+    row.getCell('date').numFmt = DATE_FMT
+    row.getCell('montant').numFmt = EURO_FMT
+    row.eachCell((c) => { c.border = BORDER_ALL })
   }
-  const wsAjus = XLSX.utils.json_to_sheet(ajusRows, {
-    header: ['Date', 'Libellé', 'Montant (€)', 'Commentaire'],
-  })
-  wsAjus['!cols'] = [{ wch: 12 }, { wch: 30 }, { wch: 14 }, { wch: 40 }]
+  if ((ajustements || []).length > 0) {
+    const totalRow = wsAjus.addRow({ libelle: 'TOTAL', montant: t.sumAjust })
+    totalRow.font = { bold: true }
+    totalRow.fill = FILL_TOTAL
+    totalRow.getCell('montant').numFmt = EURO_FMT
+    totalRow.eachCell((c) => { c.border = BORDER_ALL })
+  }
 
-  const wb = XLSX.utils.book_new()
-  XLSX.utils.book_append_sheet(wb, wsSynth, 'Synthèse')
-  XLSX.utils.book_append_sheet(wb, wsFact,  'Factures')
-  XLSX.utils.book_append_sheet(wb, wsAjus,  'Ajustements')
   return wb
 }
 
-export function downloadFoodCostXlsx(workbook, filename) {
-  XLSX.writeFile(workbook, filename)
+export async function downloadFoodCostXlsx(workbook, filename) {
+  const buffer = await workbook.xlsx.writeBuffer()
+  const blob = new Blob([buffer], {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
 }
 
 // ── HTML d'impression / PDF ────────────────────────────────────────────────
@@ -158,7 +272,6 @@ export function buildFoodCostPrintHtml({
   notes,
   factures,
   ajustements,
-  generatedAt = new Date(),
 }) {
   const t = computeTotaux({ inventaireDebut, inventaireFin, achatsHt, ajustements, caFoodHt })
   const rColor = ratioColor(t.ratio)
@@ -215,7 +328,6 @@ export function buildFoodCostPrintHtml({
   tr.total td { font-weight: 700; background: #f9fafb; }
   .notes { white-space: pre-wrap; padding: 8px; background: #fafafa; border: 1px solid #eee; border-radius: 4px; }
   .empty { color: #999; font-style: italic; padding: 8px; }
-  .formula { color: #666; font-size: 10px; }
   @media print {
     body { padding: 0; }
     h2 { break-after: avoid; }
@@ -226,7 +338,6 @@ export function buildFoodCostPrintHtml({
 <h1>Rapport food cost</h1>
 <div class="meta">
   Période <strong>${esc(formatDate(periodeDebut))} → ${esc(formatDate(periodeFin))}</strong>
-  · Édité le ${esc(generatedAt.toLocaleString('fr-FR'))}
 </div>
 
 <div class="kpis">
@@ -241,7 +352,7 @@ export function buildFoodCostPrintHtml({
   <tr><td>Inventaire début (HT)</td><td class="num">${inventaireDebut === '' || inventaireDebut == null ? '—' : formatEur(inventaireDebut)}</td></tr>
   <tr><td>+ Achats HT cumulés</td><td class="num">${formatEur(achatsHt)}</td></tr>
   <tr><td>− Inventaire fin (HT)</td><td class="num">${inventaireFin === '' || inventaireFin == null ? '—' : formatEur(inventaireFin)}</td></tr>
-  <tr><td>+ Σ ajustements (signés)</td><td class="num">${t.sumAjust > 0 ? '+' : ''}${formatEur(t.sumAjust)}</td></tr>
+  <tr><td>+ Σ ajustements</td><td class="num">${t.sumAjust > 0 ? '+' : ''}${formatEur(t.sumAjust)}</td></tr>
   <tr class="total"><td>= Coût matière</td><td class="num">${formatEur(t.coutMatiere)}</td></tr>
   <tr class="total"><td>Ratio food cost = coût matière ÷ CA Food HT</td><td class="num" style="color: ${rColor}">${formatPct(t.ratio)}</td></tr>
 </table>


### PR DESCRIPTION
## Contexte
Retours utilisateur sur l'export ajouté dans [skalcook#124](https://github.com/antonydespaux-bit/skalcook/pull/124) :
- Excel pas joli (pas de bordures, montants en texte brut, dates en YYYY-MM-DD)
- Date d'export inutile dans la synthèse
- Dates période en JJ/MM/AAAA
- PDF : enlever « Édité le … » et « (signés) » dans les ajustements

## Changements

### Excel — switch xlsx → exceljs
La lib `xlsx` (SheetJS community) ne supporte pas les styles (bordures, fonds, formats). `exceljs` est déjà dans les deps, on s'en sert pour ce rapport uniquement (les autres exports continuent avec `xlsx`). Import dynamique → pas d'impact sur le bundle initial de la page.

**Onglet Synthèse** : refondu en vrai tableau
- Titre fusionné `A1:B1` en gras, centré, fond gris
- Sections « Période / Chiffres clés / Calcul du coût matière / Notes » avec en-têtes gras + fond
- Bordures grises (`thin #CCCCCC`) sur toutes les cellules
- Montants au format Excel `1 234,56 €` — cellules numériques, donc manipulables
- Dates au format `JJ/MM/AAAA` — vraies dates Excel
- Ratio coloré selon les seuils habituels (vert/jaune/orange/rouge)
- Plus de ligne « Date d'export »

**Onglets Factures & Ajustements** : bordures sur toutes les cellules, en-têtes gras + fond gris, ligne TOTAL en gras avec fond, dates et montants formatés.

### PDF
- Supprimé « · Édité le … » dans la méta-info en haut
- Supprimé « (signés) » dans la ligne `+ Σ ajustements`

## Test plan
- [ ] Cliquer ⬇ Excel → ouvrir le fichier : onglet Synthèse mis en page tableau avec bordures, sections, ratio coloré
- [ ] Vérifier que les montants sont des nombres (clic = formule sommable), formatés `1 234,56 €`
- [ ] Vérifier que les dates s'affichent JJ/MM/AAAA et restent des dates (triables)
- [ ] Onglets Factures et Ajustements : bordures + en-têtes stylisés + ligne TOTAL
- [ ] Cliquer 🖨 Imprimer / PDF → vérifier l'absence de « Édité le … » et de « (signés) »

🤖 Generated with [Claude Code](https://claude.com/claude-code)