### PR TITLE
fix(ingredients): import Excel — auto-détection des colonnes + template bar

### DIFF
--- a/components/ImportView.jsx
+++ b/components/ImportView.jsx
@@ -67,7 +67,7 @@ const CONFIG = {
     recalculDoneMsgShort: '\u2713 Toutes les fiches bar ont \u00e9t\u00e9 recalcul\u00e9es !',
     recalculButtonPost: '\ud83d\udd04 Recalculer toutes les fiches bar',
     importLabel: 'Import Excel des ingr\u00e9dients bar',
-    hasTemplate: false,
+    hasTemplate: true,
     hasCategories: true,
     showCategoryInPreview: true,
     afterImportRoute: '/bar/fiches',
@@ -75,10 +75,57 @@ const CONFIG = {
     logEntite: 'ingredients_bar',
     logSection: 'bar',
     logDetails: (total, ignores, categoriesAssignees) => `${total} ingr\u00e9dients bar trait\u00e9s, ${ignores} ignor\u00e9s, ${categoriesAssignees} cat\u00e9gories assign\u00e9es`,
-    templateFileName: null,
-    templateSheetName: null,
-    templateRows: null,
+    templateFileName: 'modele_import_ingredients_bar.xlsx',
+    templateSheetName: 'Ingr\u00e9dients bar',
+    templateRows: [
+      ['Nom', 'Prix HT (\u20ac)', 'Unit\u00e9', 'Cat\u00e9gorie'],
+      ['Rhum - Diplomatico - Reserva Exclusiva', '38.00', 'cl', 'Rhum'],
+      ['Vodka - Belvedere', '32.00', 'cl', 'Vodka'],
+      ['Vin rouge - Ch\u00e2teau Margaux 2018', '180.00', 'cl', 'Vins'],
+      ['Bi\u00e8re - Bob\'s Beer Blonde', '4.50', 'cl', 'Bi\u00e8res'],
+      ['Coca-Cola', '2.50', 'cl', 'Softs'],
+    ],
   },
+}
+
+// ─── Détection automatique des colonnes ─────────────────────────────────────
+// Tolère n'importe quel ordre de colonnes et n'importe quelle casse/accent
+// dans l'en-tête. Mots-clés français + anglais.
+function normalizeHeader(s) {
+  return (s ?? '')
+    .toString()
+    .toLowerCase()
+    .normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]/g, '')
+    .trim()
+}
+
+function detectColumns(headerRow) {
+  const cols = { nom: -1, prix: -1, unite: -1, categorie: -1 }
+  if (!Array.isArray(headerRow)) return { cols, detected: false }
+
+  headerRow.forEach((cell, idx) => {
+    const n = normalizeHeader(cell)
+    if (!n) return
+    if (cols.nom < 0 && (n === 'nom' || n === 'ingredient' || n === 'libelle' || n === 'name' || n.startsWith('nomdu') || n === 'designation')) {
+      cols.nom = idx
+    } else if (cols.prix < 0 && (n.startsWith('prix') || n === 'pu' || n === 'cout' || n === 'tarif' || n === 'price')) {
+      cols.prix = idx
+    } else if (cols.unite < 0 && (n === 'unite' || n === 'unit' || n === 'u' || n === 'mesure')) {
+      cols.unite = idx
+    } else if (cols.categorie < 0 && (n.startsWith('categ') || n === 'famille' || n === 'type' || n === 'groupe' || n === 'rayon')) {
+      cols.categorie = idx
+    }
+  })
+  return { cols, detected: cols.nom >= 0 }
+}
+
+function rowLooksLikeData(row) {
+  if (!Array.isArray(row) || row.length < 2) return false
+  const v = row[1]
+  if (v == null || v === '') return false
+  const num = parseFloat(String(v).replace(',', '.').replace(/[^0-9.]/g, ''))
+  return !Number.isNaN(num) && num > 0
 }
 
 export default function ImportView({ section = 'cuisine' }) {
@@ -154,17 +201,40 @@ export default function ImportView({ section = 'cuisine' }) {
       const sheet = workbook.Sheets[workbook.SheetNames[0]]
       const rows = XLSX.utils.sheet_to_json(sheet, { header: 1 })
 
+      // Auto-détection des colonnes par les mots-clés du header.
+      // Si pas de header reconnu mais que la 1ʳᵉ ligne ressemble à des
+      // données (prix numérique en col B), on commence à i=0 avec l'ordre
+      // par défaut [Nom, Prix, Unité, Catégorie].
+      const detection = detectColumns(rows[0])
+      let cols, startRow
+      if (detection.detected) {
+        cols = detection.cols
+        startRow = 1
+      } else if (rowLooksLikeData(rows[0])) {
+        cols = { nom: 0, prix: 1, unite: 2, categorie: 3 }
+        startRow = 0
+      } else {
+        // 1ʳᵉ ligne ni header reconnu ni données plausibles : on l'ignore
+        // et on suppose l'ordre par défaut.
+        cols = { nom: 0, prix: 1, unite: 2, categorie: 3 }
+        startRow = 1
+      }
+
       const ingredients = []
       const inconnues = new Set()
 
-      for (let i = 1; i < rows.length; i++) {
+      for (let i = startRow; i < rows.length; i++) {
         const row = rows[i]
-        if (!row[0]) continue
+        const nom = cols.nom >= 0 ? row[cols.nom]?.toString().trim() : ''
+        if (!nom) continue
 
-        const nomCategorie = row[3]?.toString().trim() || ''
+        const prixRaw     = cols.prix      >= 0 ? row[cols.prix]      : null
+        const uniteRaw    = cols.unite     >= 0 ? row[cols.unite]     : null
+        const categorieRaw = cols.categorie >= 0 ? row[cols.categorie] : null
+        const nomCategorie = categorieRaw?.toString().trim() || ''
+
         let categorie_id = null
         let categorieNonTrouvee = false
-
         if (cfg.hasCategories && nomCategorie) {
           const match = categoriesMap[nomCategorie.toLowerCase()]
           if (match) {
@@ -176,9 +246,9 @@ export default function ImportView({ section = 'cuisine' }) {
         }
 
         ingredients.push({
-          nom: row[0]?.toString().trim(),
-          prix_kg: normaliserPrix(row[1]),
-          unite: row[2]?.toString().trim() || cfg.defaultUnit,
+          nom,
+          prix_kg: normaliserPrix(prixRaw),
+          unite: uniteRaw?.toString().trim() || cfg.defaultUnit,
           categorie_id,
           categorieNom: nomCategorie,
           categorieNonTrouvee


### PR DESCRIPTION
## Bug
Sur **Joia bar**, un import récent d'ingrédients (10+ ingrédients créés à 13:23 aujourd'hui) a tous bien créé les noms mais avec `prix_kg = null` et `categorie_id = null`.

## Cause
Le code de [components/ImportView.jsx:160-186](components/ImportView.jsx:160) lisait les colonnes par index fixe :
```js
nom         = row[0]
prix        = row[1]
unite       = row[2]
categorie   = row[3]
```
Si le fichier de l'utilisateur n'a pas cet ordre exact, `prix` et `categorie` lisent du vide → null en DB.

Aggravant : `CONFIG.bar.hasTemplate: false` → aucun template téléchargeable pour le bar, donc aucun guide visuel sur l'ordre attendu.

## Fix

### Auto-détection des colonnes
Au lieu de prendre les colonnes par position fixe, on les détecte via les mots-clés du header :

| Champ | Mots-clés acceptés (FR + EN, casse/accents ignorés) |
|-------|------------------------------------------------------|
| Nom | `nom`, `libellé`, `désignation`, `ingrédient`, `name` |
| Prix | `prix`, `prix HT`, `tarif`, `coût`, `PU`, `price` |
| Unité | `unité`, `unit`, `U`, `mesure` |
| Catégorie | `catégorie`, `famille`, `type`, `groupe`, `rayon` |

### Fallback intelligent
- Header reconnu → on utilise les colonnes détectées
- Pas de header reconnu mais 1ʳᵉ ligne ressemble à des données (prix numérique en col B) → ordre par défaut depuis `i=0`
- Sinon → ordre par défaut, on skip la 1ʳᵉ ligne

### Template bar activé
`CONFIG.bar.hasTemplate: true` + `templateRows` adaptés (spiritueux, vins, bières, softs).

## Sur les données déjà cassées
Les 10 ingrédients de Joia bar importés sans prix/catégorie **restent en l'état**. L'utilisateur doit refaire l'import avec le fichier corrigé — la logique upsert existante de `handleImport` matche par `nom + client_id` et fera un `update`, pas de doublon.

## Test plan
- [ ] `/bar/import` : le bouton « Télécharger un modèle » apparaît maintenant
- [ ] Télécharger le modèle bar → ordre Nom / Prix HT / Unité / Catégorie, 5 lignes d'exemple
- [ ] Importer un fichier avec colonnes dans un ordre différent (ex: Nom / Catégorie / Prix / Unité) → l'aperçu montre les prix et catégories aux bons endroits
- [ ] Importer un fichier sans header (1ʳᵉ ligne = données) → l'import prend bien la 1ʳᵉ ligne
- [ ] Refaire l'import du fichier qui avait échoué sur Joia bar → les ingrédients existants reçoivent prix + catégorie

🤖 Generated with [Claude Code](https://claude.com/claude-code)