### PR TITLE
fix(budget): override par lieu = affecter au dernier jour-de-semaine du mois

### DIFF
--- a/app/controle-gestion/ventes/page.js
+++ b/app/controle-gestion/ventes/page.js
@@ -7,6 +7,7 @@ import { supabase, getClientId } from '../../../lib/supabase'
 import { useIsMobile } from '../../../lib/useIsMobile'
 import { useTheme } from '../../../lib/useTheme'
 import Navbar from '../../../components/Navbar'
+import { buildElectedDatesMap, isCellElectedForDate } from '../../../lib/caJoursHelpers'
 
 const DEBUG_FALLBACK_CLIENT_ID = 'fa725e66-2cad-4ea4-892a-7eb3e90496a7'
 
@@ -138,7 +139,7 @@ export default function VentesMensuelPage() {
           .or(`mois.is.null,mois.eq.${m}`),
         supabase
           .from('ca_budget_jours_override')
-          .select('mois, jour_semaine, service, lieu_service_id, nb_jours')
+          .select('annee, mois, jour_semaine, service, lieu_service_id, nb_jours')
           .eq('client_id', clientId)
           .eq('annee', y)
           .eq('mois', m),
@@ -207,11 +208,18 @@ export default function VentesMensuelPage() {
     return result
   }, [rawRows, mois])
 
-  // Budget journalier total par jour ISO (1 = lundi … 7 = dimanche)
-  // pour le mois affiché. Override mensuel (mois = m) prioritaire sur le
-  // défaut (mois = NULL) au niveau de la cellule (jds, lieu, service).
-  const budgetByIsoJds = useMemo(() => {
-    const monthNum = Number(mois.split('-')[1])
+  // Budget journalier par date ISO du mois affiché.
+  // Override mensuel (mois = m) prioritaire sur le défaut (mois = NULL) au
+  // niveau de la cellule (jds, lieu, service).
+  // Pour les overrides par lieu (ex : « Privat = 1 mardi/mois »), seules
+  // les N dernières occurrences du jour-de-semaine reçoivent le budget de
+  // la cellule (cf. caJoursHelpers.isCellElectedForDate). Les autres mardis
+  // affichent 0 pour cette cellule → le cumul mensuel reste cohérent avec
+  // `monthlyBudgetAligned` et la coloration jour-par-jour reste juste.
+  const budgetByDateIso = useMemo(() => {
+    const [yStr, mStr] = mois.split('-')
+    const annee = Number(yStr)
+    const monthNum = Number(mStr)
     const cellMap = new Map() // key = `${jds}_${lieu}_${svc}`
     for (const b of budgetRows) {
       const key = `${b.jour_semaine}_${b.lieu_service_id}_${b.service}`
@@ -221,25 +229,28 @@ export default function VentesMensuelPage() {
         cellMap.set(key, b)
       }
     }
-    const out = new Map()
-    for (const cell of cellMap.values()) {
-      const total =
-        Number(cell.ca_food_cible || 0) +
-        Number(cell.ca_bev_20_cible || 0) +
-        Number(cell.ca_bev_10_cible || 0) +
-        Number(cell.ca_autre_cible || 0)
-      out.set(cell.jour_semaine, (out.get(cell.jour_semaine) || 0) + total)
+    const electedMap = buildElectedDatesMap(joursOverrideRows)
+    const out = new Map() // key = iso date → total budget
+    for (const d of days) {
+      const isoJds = jsWeekdayToIso(d.weekday)
+      let total = 0
+      for (const cell of cellMap.values()) {
+        if (cell.jour_semaine !== isoJds) continue
+        if (!isCellElectedForDate(cell, d.iso, annee, monthNum, electedMap)) continue
+        total +=
+          Number(cell.ca_food_cible || 0) +
+          Number(cell.ca_bev_20_cible || 0) +
+          Number(cell.ca_bev_10_cible || 0) +
+          Number(cell.ca_autre_cible || 0)
+      }
+      out.set(d.iso, total)
     }
     return out
-  }, [budgetRows, mois])
+  }, [budgetRows, joursOverrideRows, mois, days])
 
   const daysWithBudget = useMemo(() => {
-    return days.map((d) => {
-      const isoJds = jsWeekdayToIso(d.weekday)
-      const budget = budgetByIsoJds.get(isoJds) || 0
-      return { ...d, budget }
-    })
-  }, [days, budgetByIsoJds])
+    return days.map((d) => ({ ...d, budget: budgetByDateIso.get(d.iso) || 0 }))
+  }, [days, budgetByDateIso])
 
   // Budget MENSUEL aligné sur le Récapitulatif annuel de la page Budgets :
   // - Ne prend que les cellules ca_budgets avec mois = monthNum (ignore les

--- a/app/controle-gestion/ventes/rapport-hebdo/page.js
+++ b/app/controle-gestion/ventes/rapport-hebdo/page.js
@@ -42,6 +42,7 @@ export default function RapportHebdoPage() {
   const [lieux, setLieux] = useState([])
   const [caRows, setCaRows] = useState([])
   const [budgetRows, setBudgetRows] = useState([])
+  const [joursOverrideRows, setJoursOverrideRows] = useState([])
   const [joursFermesRows, setJoursFermesRows] = useState([])
   const [joursFermesHebdoRows, setJoursFermesHebdoRows] = useState([])
   const [loading, setLoading] = useState(false)
@@ -114,7 +115,7 @@ export default function RapportHebdoPage() {
       const firstOfMonth = `${y2}-${String(m2).padStart(2, '0')}-01`
       const debutPourCumul = firstOfMonth < debut ? firstOfMonth : debut
 
-      const [lieuxRes, caRes, budgetRes, jfRes, jfhRes] = await Promise.all([
+      const [lieuxRes, caRes, budgetRes, overrideRes, jfRes, jfhRes] = await Promise.all([
         supabase
           .from('lieux_service')
           .select('id, nom, ordre, actif, parent_lieu_service_id, couverts_indicatifs')
@@ -132,6 +133,13 @@ export default function RapportHebdoPage() {
           .select('annee, mois, jour_semaine, lieu_service_id, service, couverts_cible, ca_food_cible, ca_bev_20_cible, ca_bev_10_cible, ca_autre_cible')
           .eq('client_id', clientId)
           .in('annee', annees),
+        // Overrides nb_jours : indispensable pour respecter "Privat = 1 mardi/mois"
+        // côté budget. Le service ne traite que les rows avec lieu_service_id défini.
+        supabase
+          .from('ca_budget_jours_override')
+          .select('annee, mois, jour_semaine, service, lieu_service_id, nb_jours')
+          .eq('client_id', clientId)
+          .in('annee', annees),
         supabase
           .from('ca_jours_fermes')
           .select('date, motif')
@@ -146,11 +154,13 @@ export default function RapportHebdoPage() {
       if (lieuxRes.error) throw lieuxRes.error
       if (caRes.error) throw caRes.error
       if (budgetRes.error) throw budgetRes.error
+      if (overrideRes.error) throw overrideRes.error
       if (jfRes.error) throw jfRes.error
       if (jfhRes.error) throw jfhRes.error
       setLieux(lieuxRes.data || [])
       setCaRows(caRes.data || [])
       setBudgetRows(budgetRes.data || [])
+      setJoursOverrideRows(overrideRes.data || [])
       setJoursFermesRows(jfRes.data || [])
       setJoursFermesHebdoRows(jfhRes.data || [])
       // (CA cumul mois inclus dans la query principale via debutPourCumul)
@@ -246,6 +256,9 @@ export default function RapportHebdoPage() {
   const budgetRowsRemap = useMemo(
     () => budgetRows.map((r) => ({
       ...r,
+      // On conserve l'ID enfant d'origine pour matcher les overrides nb_jours
+      // (stockés en DB avec le lieu enfant) — voir isCellElectedForDate.
+      lieu_service_id_source: r.lieu_service_id,
       lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id,
       couverts_cible: lieuxIndicatifs.has(r.lieu_service_id) ? 0 : r.couverts_cible,
     })),
@@ -265,8 +278,8 @@ export default function RapportHebdoPage() {
   }, [joursFermesRows, joursFermesHebdoRows, debut, fin])
 
   const data = useMemo(() => buildRapportData({
-    caRows: caRowsRemap, budgetRows: budgetRowsRemap, lieuxMap, debut, fin, joursFermesIso,
-  }), [caRowsRemap, budgetRowsRemap, lieuxMap, debut, fin, joursFermesIso])
+    caRows: caRowsRemap, budgetRows: budgetRowsRemap, lieuxMap, debut, fin, joursFermesIso, joursOverrideRows,
+  }), [caRowsRemap, budgetRowsRemap, lieuxMap, debut, fin, joursFermesIso, joursOverrideRows])
 
   // ── Actions ─────────────────────────────────────────────────────────────
   const handleSemainePrec = () => {

--- a/components/rapport-hebdo/ComparaisonPanel.js
+++ b/components/rapport-hebdo/ComparaisonPanel.js
@@ -30,7 +30,7 @@ export default function ComparaisonPanel({ c, isMobile, clientId, currentPeriode
     const [y1] = debut.split('-').map(Number)
     const [y2] = fin.split('-').map(Number)
     const annees = Array.from(new Set([y1, y2]))
-    const [lieuxRes, caRes, budgetRes, jfRes, jfhRes] = await Promise.all([
+    const [lieuxRes, caRes, budgetRes, overrideRes, jfRes, jfhRes] = await Promise.all([
       supabase.from('lieux_service').select('id, nom, parent_lieu_service_id, couverts_indicatifs').eq('client_id', clientId).eq('actif', true),
       supabase.from('ca_journalier')
         .select('jour, service, lieu_service_id, couverts, ca_food, ca_bev_20, ca_bev_10, ca_autre')
@@ -38,12 +38,16 @@ export default function ComparaisonPanel({ c, isMobile, clientId, currentPeriode
       supabase.from('ca_budgets')
         .select('annee, mois, jour_semaine, lieu_service_id, service, couverts_cible, ca_food_cible, ca_bev_20_cible, ca_bev_10_cible, ca_autre_cible')
         .eq('client_id', clientId).in('annee', annees),
+      supabase.from('ca_budget_jours_override')
+        .select('annee, mois, jour_semaine, service, lieu_service_id, nb_jours')
+        .eq('client_id', clientId).in('annee', annees),
       supabase.from('ca_jours_fermes').select('date, motif').eq('client_id', clientId).gte('date', debut).lte('date', fin),
       supabase.from('ca_jours_fermes_hebdo').select('jour_semaine, motif').eq('client_id', clientId),
     ])
     if (lieuxRes.error) throw lieuxRes.error
     if (caRes.error) throw caRes.error
     if (budgetRes.error) throw budgetRes.error
+    if (overrideRes.error) throw overrideRes.error
     if (jfRes.error) throw jfRes.error
     if (jfhRes.error) throw jfhRes.error
     // lieuxMap : remappe les enfants vers le label du parent (Table du chef
@@ -64,6 +68,9 @@ export default function ComparaisonPanel({ c, isMobile, clientId, currentPeriode
     })
     const remapBudget = (r) => ({
       ...r,
+      // ID enfant d'origine conservé pour matcher les overrides nb_jours
+      // (stockés avec le lieu enfant) — voir isCellElectedForDate.
+      lieu_service_id_source: r.lieu_service_id,
       lieu_service_id: lieuToParent.get(r.lieu_service_id) || r.lieu_service_id,
       couverts_cible: lieuxIndicatifs.has(r.lieu_service_id) ? 0 : r.couverts_cible,
     })
@@ -71,6 +78,7 @@ export default function ComparaisonPanel({ c, isMobile, clientId, currentPeriode
       caRows: (caRes.data || []).map(remapCa),
       budgetRows: (budgetRes.data || []).map(remapBudget),
       lieuxMap,
+      joursOverrideRows: overrideRes.data || [],
       joursFermesRows: jfRes.data || [],
       joursFermesHebdoRows: jfhRes.data || [],
     }
@@ -135,6 +143,7 @@ export default function ComparaisonPanel({ c, isMobile, clientId, currentPeriode
         lieuxMap: ds.lieuxMap,
         debut: p.debut, fin: p.fin,
         joursFermesIso,
+        joursOverrideRows: ds.joursOverrideRows,
       })
       return { periode: p, data }
     })

--- a/lib/__tests__/caJoursHelpers.test.ts
+++ b/lib/__tests__/caJoursHelpers.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import {
+  countIsoJdsInMonth,
+  pickLastNOccurrencesOfDow,
+  buildElectedDatesMap,
+  isCellElectedForDate,
+} from '../caJoursHelpers'
+
+describe('countIsoJdsInMonth', () => {
+  it('compte 4 mardis en mai 2026 (5, 12, 19, 26)', () => {
+    expect(countIsoJdsInMonth(2026, 5, 2)).toBe(4)
+  })
+  it('compte 5 vendredis en mai 2026 (1, 8, 15, 22, 29)', () => {
+    expect(countIsoJdsInMonth(2026, 5, 5)).toBe(5)
+  })
+  it('dimanche = isoJds 7 (pas 0)', () => {
+    // Mai 2026 a 5 dimanches : 3, 10, 17, 24, 31
+    expect(countIsoJdsInMonth(2026, 5, 7)).toBe(5)
+  })
+  it('février non-bissextile 2026 a 4 occurrences de chaque jour', () => {
+    expect(countIsoJdsInMonth(2026, 2, 2)).toBe(4)
+  })
+})
+
+describe('pickLastNOccurrencesOfDow', () => {
+  it('mai 2026, dernier mardi → 2026-05-26', () => {
+    expect(pickLastNOccurrencesOfDow(2026, 5, 2, 1)).toEqual(['2026-05-26'])
+  })
+  it('mai 2026, 2 derniers mardis → 19, 26', () => {
+    expect(pickLastNOccurrencesOfDow(2026, 5, 2, 2)).toEqual(['2026-05-19', '2026-05-26'])
+  })
+  it('n=4 demande exactement tous les mardis du mois', () => {
+    expect(pickLastNOccurrencesOfDow(2026, 5, 2, 4)).toEqual([
+      '2026-05-05', '2026-05-12', '2026-05-19', '2026-05-26',
+    ])
+  })
+  it('n>=total → cappé à toutes les occurrences', () => {
+    expect(pickLastNOccurrencesOfDow(2026, 5, 2, 10)).toEqual([
+      '2026-05-05', '2026-05-12', '2026-05-19', '2026-05-26',
+    ])
+  })
+  it('n=0 → liste vide', () => {
+    expect(pickLastNOccurrencesOfDow(2026, 5, 2, 0)).toEqual([])
+  })
+  it('n=null → toutes les occurrences', () => {
+    expect(pickLastNOccurrencesOfDow(2026, 5, 2, null)).toHaveLength(4)
+  })
+})
+
+describe('buildElectedDatesMap', () => {
+  it('indexe par (annee, mois, jds, svc, lieu) avec les dates élues', () => {
+    const rows = [
+      { annee: 2026, mois: 5, jour_semaine: 2, service: 'dinner', lieu_service_id: 'LPRIVAT', nb_jours: 1 },
+    ]
+    const map = buildElectedDatesMap(rows)
+    const set = map.get('2026_5_2_dinner_LPRIVAT')
+    expect(set).toBeDefined()
+    expect(set?.has('2026-05-26')).toBe(true)
+    expect(set?.has('2026-05-19')).toBe(false)
+  })
+  it('ignore les overrides sans lieu_service_id (global / service)', () => {
+    const rows = [
+      { annee: 2026, mois: 5, jour_semaine: 2, service: 'dinner', lieu_service_id: null, nb_jours: 1 },
+      { annee: 2026, mois: 5, jour_semaine: 3, service: 'lunch', lieu_service_id: 'LPRIVAT', nb_jours: 2 },
+    ]
+    const map = buildElectedDatesMap(rows)
+    expect(map.size).toBe(1) // seul le 2e a été indexé
+    expect(map.has('2026_5_3_lunch_LPRIVAT')).toBe(true)
+  })
+  it('tolère rows vides ou null', () => {
+    expect(buildElectedDatesMap(null).size).toBe(0)
+    expect(buildElectedDatesMap([]).size).toBe(0)
+  })
+})
+
+describe('isCellElectedForDate', () => {
+  const electedMap = buildElectedDatesMap([
+    { annee: 2026, mois: 5, jour_semaine: 2, service: 'dinner', lieu_service_id: 'LPRIVAT', nb_jours: 1 },
+  ])
+
+  it('cellule sans override → toujours true', () => {
+    const cell = { jour_semaine: 2, service: 'dinner', lieu_service_id: 'L1' }
+    expect(isCellElectedForDate(cell, '2026-05-12', 2026, 5, electedMap)).toBe(true)
+    expect(isCellElectedForDate(cell, '2026-05-26', 2026, 5, electedMap)).toBe(true)
+  })
+
+  it('cellule avec override → true uniquement pour la date élue', () => {
+    const cell = { jour_semaine: 2, service: 'dinner', lieu_service_id: 'LPRIVAT' }
+    expect(isCellElectedForDate(cell, '2026-05-05', 2026, 5, electedMap)).toBe(false)
+    expect(isCellElectedForDate(cell, '2026-05-12', 2026, 5, electedMap)).toBe(false)
+    expect(isCellElectedForDate(cell, '2026-05-19', 2026, 5, electedMap)).toBe(false)
+    expect(isCellElectedForDate(cell, '2026-05-26', 2026, 5, electedMap)).toBe(true)
+  })
+
+  it('lieu_service_id_source prioritaire sur lieu_service_id (cas remappage parent)', () => {
+    // Cellule remappée vers parent JOIA mais source = LPRIVAT
+    const cell = {
+      jour_semaine: 2, service: 'dinner',
+      lieu_service_id: 'JOIA',
+      lieu_service_id_source: 'LPRIVAT',
+    }
+    expect(isCellElectedForDate(cell, '2026-05-12', 2026, 5, electedMap)).toBe(false)
+    expect(isCellElectedForDate(cell, '2026-05-26', 2026, 5, electedMap)).toBe(true)
+  })
+
+  it('map vide ou null → toujours true', () => {
+    const cell = { jour_semaine: 2, service: 'dinner', lieu_service_id: 'LPRIVAT' }
+    expect(isCellElectedForDate(cell, '2026-05-12', 2026, 5, new Map())).toBe(true)
+    expect(isCellElectedForDate(cell, '2026-05-12', 2026, 5, null)).toBe(true)
+  })
+})

--- a/lib/__tests__/rapportHebdo.test.ts
+++ b/lib/__tests__/rapportHebdo.test.ts
@@ -227,3 +227,93 @@ describe('formatters', () => {
     expect(formatPeriode('2026-05-05', '2026-05-05')).toBe('du 05 mai')
   })
 })
+
+// ── Cas Privat (1 mardi/mois) — overrides par lieu ────────────────────────
+//
+// Référence du bug : avant fix, periodBudget agrégeait un budget par jds×lieu
+// puis le multipliait par le nb calendaire d'occurrences du jds dans la
+// période. Pour un lieu "Privat" facturé 1 mardi/mois mais avec un budget
+// mensuel saisi en /budgets, le budget cumulé se voyait multiplié par 4 ou 5.
+//
+// Comportement attendu après fix : la cellule budgétée n'est comptée que pour
+// les N dernières occurrences du jour-de-semaine dans le mois (par défaut
+// "dernier mardi" pour Privat = 1).
+describe('overrides nb_jours par lieu (cas Privat 1 mardi/mois)', () => {
+  // Mai 2026 a 4 mardis : 05, 12, 19, 26
+  const budgetRowsPrivat = [
+    // Joia salle (L1) ouvert tous les mardis soir : budget 9 000 €
+    { annee: 2026, mois: 5, jour_semaine: 2, lieu_service_id: 'L1', service: 'dinner',
+      couverts_cible: 45, ca_food_cible: 7000, ca_bev_20_cible: 1500, ca_bev_10_cible: 500, ca_autre_cible: 0 },
+    // Joia Privat (LPRIVAT) ouvert 1 mardi soir/mois : budget 5 000 €
+    { annee: 2026, mois: 5, jour_semaine: 2, lieu_service_id: 'LPRIVAT', service: 'dinner',
+      couverts_cible: 30, ca_food_cible: 3500, ca_bev_20_cible: 1500, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+  ]
+  const overridesPrivat = [
+    { annee: 2026, mois: 5, jour_semaine: 2, service: 'dinner', lieu_service_id: 'LPRIVAT', nb_jours: 1 },
+  ]
+
+  it('periodBudget : sans override → toutes les cellules sont comptées chaque mardi (régression)', () => {
+    // Sans passer joursOverrideRows, le comportement historique : tous les
+    // mardis du mois reçoivent budget Salle + Privat → 4 × (9000 + 5000) = 56000.
+    const res = caTtcVsBudget([], budgetRowsPrivat, '2026-05-01', '2026-05-31')
+    expect(res.budget).toBe(56000)
+  })
+
+  it('periodBudget : avec override → Privat n\'est compté que le dernier mardi (26)', () => {
+    const res = caTtcVsBudget([], budgetRowsPrivat, '2026-05-01', '2026-05-31', null, overridesPrivat)
+    // Salle (L1) tous les mardis : 4 × 9000 = 36000
+    // Privat (LPRIVAT) seulement le 26 : 1 × 5000 = 5000
+    // Total = 41000
+    expect(res.budget).toBe(41000)
+  })
+
+  it('periodBudget : semaine SANS le dernier mardi → Privat à 0', () => {
+    // 5-11 mai (mardi 5) : pas le dernier mardi du mois.
+    const res = caTtcVsBudget([], budgetRowsPrivat, '2026-05-05', '2026-05-11', null, overridesPrivat)
+    // Seulement Salle ce mardi : 9000
+    expect(res.budget).toBe(9000)
+  })
+
+  it('periodBudget : semaine AVEC le dernier mardi (26 mai) → Privat compté', () => {
+    // 25-31 mai (mardi 26) : c'est le dernier mardi.
+    const res = caTtcVsBudget([], budgetRowsPrivat, '2026-05-25', '2026-05-31', null, overridesPrivat)
+    expect(res.budget).toBe(14000) // 9000 + 5000
+  })
+
+  it('couvertsJourParJour : Privat (30 cv) n\'est ajouté que le 26 mai', () => {
+    const jours = couvertsJourParJour([], budgetRowsPrivat, '2026-05-01', '2026-05-31', null, overridesPrivat)
+    const mardi05 = jours.find((j) => j.iso === '2026-05-05')
+    const mardi12 = jours.find((j) => j.iso === '2026-05-12')
+    const mardi19 = jours.find((j) => j.iso === '2026-05-19')
+    const mardi26 = jours.find((j) => j.iso === '2026-05-26')
+    // Mardis sans privat : seulement Salle (45 couv dinner)
+    expect(mardi05?.soir.budget).toBe(45)
+    expect(mardi12?.soir.budget).toBe(45)
+    expect(mardi19?.soir.budget).toBe(45)
+    // Mardi 26 : Salle 45 + Privat 30 = 75
+    expect(mardi26?.soir.budget).toBe(75)
+  })
+
+  it('tmParLieuService : Privat agrège uniquement le mardi élu', () => {
+    const lieuxMapPrivat = new Map([['L1', 'Salle'], ['LPRIVAT', 'Privat']])
+    const lignes = tmParLieuService([], budgetRowsPrivat, lieuxMapPrivat, '2026-05-01', '2026-05-31', null, overridesPrivat)
+    const privat = lignes.find((l) => l.lieu_id === 'LPRIVAT' && l.service === 'dinner')
+    // Privat compté 1 fois : 30 couverts × 1 mardi, ca 5000 × 1
+    expect(privat?.budget_couverts).toBe(30)
+    expect(privat?.budget_ca).toBe(5000)
+  })
+
+  it('respecte lieu_service_id_source (cas remappage parent du rapport hebdo)', () => {
+    // Cas réel : la page rapport-hebdo remap lieu_service_id vers le parent
+    // pour les agrégations. La cellule budget remappée perd son ID enfant
+    // mais conserve lieu_service_id_source pour matcher l'override.
+    const budgetRemap = budgetRowsPrivat.map((r) => ({
+      ...r,
+      lieu_service_id_source: r.lieu_service_id, // ID enfant conservé
+      lieu_service_id: r.lieu_service_id === 'LPRIVAT' ? 'JOIA' : r.lieu_service_id, // remap vers parent
+    }))
+    const res = caTtcVsBudget([], budgetRemap, '2026-05-01', '2026-05-31', null, overridesPrivat)
+    // Même résultat que sans remap : 41000
+    expect(res.budget).toBe(41000)
+  })
+})

--- a/lib/caJoursHelpers.js
+++ b/lib/caJoursHelpers.js
@@ -1,0 +1,101 @@
+// Helpers partagés pour la résolution des jours d'ouverture / d'événement
+// en fonction des overrides budgétaires par lieu (table ca_budget_jours_override).
+//
+// Cas d'usage type : "Privat" chez Joia n'est ouvert que 1 mardi par mois
+// (privatisations). L'override stocke `nb_jours = 1` pour (mardi, soir, Privat).
+// On veut alors que le budget de cette cellule soit AFFECTÉ à un seul mardi
+// du mois (par défaut le dernier), pas réparti sur tous les mardis.
+//
+// Pourquoi le "dernier" ? Faute de calendrier précis des évènements, on
+// choisit la convention qui rend la coloration jour-par-jour la moins
+// trompeuse : les mardis sans privat affichent 0 (et le CA réel ~0 → Δ ≈ 0),
+// le mardi élu porte le budget complet (et recevra le CA réel le moment venu).
+//
+// Note : ce module ne traite QUE les overrides par lieu. Les overrides
+// service ou globaux (lieu_service_id null) représentent des fermetures
+// exceptionnelles → comportement existant (ratio nb_jours/calendaire) conservé
+// dans les pages qui en ont besoin.
+
+// Compte le nombre d'occurrences d'un jour-de-semaine ISO (1=lun .. 7=dim)
+// dans le mois donné (mois 1-12).
+export function countIsoJdsInMonth(annee, mois, isoJds) {
+  const daysInMonth = new Date(annee, mois, 0).getDate()
+  let count = 0
+  for (let d = 1; d <= daysInMonth; d++) {
+    const dow = new Date(annee, mois - 1, d).getDay()
+    const iso = dow === 0 ? 7 : dow
+    if (iso === isoJds) count++
+  }
+  return count
+}
+
+// Retourne les ISO dates des N dernières occurrences d'un jour-de-semaine ISO
+// dans le mois (mois 1-12). Si n >= nb occurrences calendaires, retourne
+// toutes les occurrences. Tri chronologique croissant.
+//
+// Exemples (mai 2026 = jeudi 1er, donc 4 mardis : 05, 12, 19, 26) :
+//   pickLastNOccurrencesOfDow(2026, 5, 2, 1) → ['2026-05-26']
+//   pickLastNOccurrencesOfDow(2026, 5, 2, 2) → ['2026-05-19', '2026-05-26']
+//   pickLastNOccurrencesOfDow(2026, 5, 2, 4) → ['2026-05-05', '2026-05-12', '2026-05-19', '2026-05-26']
+//   pickLastNOccurrencesOfDow(2026, 5, 2, 10) → idem (cap à toutes les dates)
+export function pickLastNOccurrencesOfDow(annee, mois, isoJds, n) {
+  const daysInMonth = new Date(annee, mois, 0).getDate()
+  const moisStr = String(mois).padStart(2, '0')
+  const matches = []
+  for (let d = 1; d <= daysInMonth; d++) {
+    const dow = new Date(annee, mois - 1, d).getDay()
+    const iso = dow === 0 ? 7 : dow
+    if (iso === isoJds) {
+      matches.push(`${annee}-${moisStr}-${String(d).padStart(2, '0')}`)
+    }
+  }
+  if (n == null || n >= matches.length) return matches
+  if (n <= 0) return []
+  return matches.slice(-n)
+}
+
+// Construit un index "dates élues" à partir des overrides par lieu.
+// Retourne Map<`${annee}_${mois}_${jds}_${svc}_${lieuId}`, Set<isoDate>>.
+// Ne traite QUE les rows avec lieu_service_id défini. Les autres overrides
+// (lieu null) sont à gérer ailleurs (ratio).
+export function buildElectedDatesMap(joursOverrideRows) {
+  const out = new Map()
+  for (const o of (joursOverrideRows || [])) {
+    if (!o.lieu_service_id) continue
+    const annee = Number(o.annee)
+    const mois = Number(o.mois)
+    const jds = Number(o.jour_semaine)
+    const svc = o.service
+    const nb = Number(o.nb_jours)
+    if (!Number.isFinite(annee) || !Number.isFinite(mois) || !Number.isFinite(jds) || !Number.isFinite(nb)) continue
+    if (!svc) continue
+    const dates = pickLastNOccurrencesOfDow(annee, mois, jds, nb)
+    const key = `${annee}_${mois}_${jds}_${svc}_${o.lieu_service_id}`
+    out.set(key, new Set(dates))
+  }
+  return out
+}
+
+// Pour une cellule budget (jour_semaine, service, lieu_service_id) et une
+// date iso d'un mois donné, retourne true si la cellule doit être comptée
+// pour cette date.
+// - Cellule sans lieu_service_id ou sans override pour ce (mois, jds, svc, lieu)
+//   → toujours true (comportement calendaire classique conservé).
+// - Cellule avec override par lieu → true uniquement si la date fait partie
+//   des N dates élues du mois.
+//
+// `cell.lieu_service_id_source` est consulté en priorité s'il existe : la
+// page rapport-hebdo (et le panel comparaison) remappent lieu_service_id
+// vers le parent pour les agrégations analytiques, mais l'override est
+// stocké en DB avec le lieu enfant (ex : Privat sous Joia). Conserver
+// l'id source permet de matcher l'override sur le bon enfant.
+export function isCellElectedForDate(cell, isoDate, annee, mois, electedDatesMap) {
+  if (!cell) return true
+  if (!electedDatesMap || electedDatesMap.size === 0) return true
+  const lieuId = cell.lieu_service_id_source || cell.lieu_service_id
+  if (!lieuId) return true
+  const key = `${annee}_${mois}_${cell.jour_semaine}_${cell.service}_${lieuId}`
+  const elected = electedDatesMap.get(key)
+  if (!elected) return true
+  return elected.has(isoDate)
+}

--- a/lib/rapportHebdo.js
+++ b/lib/rapportHebdo.js
@@ -7,6 +7,7 @@
 // renvoie des objets dérivés (testable, réutilisable côté export HTML).
 
 import { TVA_FOOD, TVA_BEV_20, TVA_BEV_10, TVA_AUTRE } from './caAnalyses'
+import { buildElectedDatesMap, isCellElectedForDate } from './caJoursHelpers'
 
 // ── Constantes ─────────────────────────────────────────────────────────────
 
@@ -56,74 +57,74 @@ export function filterCaJournalier(rows, debut, fin) {
 
 // ── Section 1 : CA TTC réel vs budget ──────────────────────────────────────
 
-// Construit le budget journalier total par jour ISO pour le mois donné.
-// Override mensuel (mois = m) prioritaire sur le défaut (mois = NULL) au
-// niveau de la cellule (jds, lieu, service). Mêmes règles que PR 1.
-function budgetByIsoJdsForMonth(budgetRows, annee, mois) {
+// Construit le cache cellMap par mois (cellules résolues : override mensuel
+// prioritaire sur défaut mois=NULL, au niveau de chaque cellule jds/lieu/svc).
+// Réutilisé par toutes les fonctions ci-dessous pour éviter de re-parcourir
+// budgetRows à chaque appel.
+function buildMonthCellMap(budgetRows, annee, mois) {
   const cellMap = new Map() // key = `${jds}_${lieu}_${svc}`
   for (const b of (budgetRows || [])) {
     if (b.annee != null && Number(b.annee) !== Number(annee)) continue
     const key = `${b.jour_semaine}_${b.lieu_service_id}_${b.service}`
     const isOverride = b.mois === mois
     const existing = cellMap.get(key)
-    if (isOverride) {
-      cellMap.set(key, b)
-    } else if (!existing) {
-      cellMap.set(key, b)
-    }
+    if (isOverride) cellMap.set(key, b)
+    else if (!existing) cellMap.set(key, b)
   }
-  const out = new Map()
-  for (const cell of cellMap.values()) {
-    const total =
-      Number(cell.ca_food_cible || 0) +
-      Number(cell.ca_bev_20_cible || 0) +
-      Number(cell.ca_bev_10_cible || 0) +
-      Number(cell.ca_autre_cible || 0)
-    out.set(cell.jour_semaine, (out.get(cell.jour_semaine) || 0) + total)
-  }
-  return out
+  return cellMap
 }
 
 // Renvoie le budget cumulé sur [debut, fin].
-// `joursFermesIso` (optionnel) : Set<string> de dates ISO à exclure du
-// cumul budget (fermetures hebdo + dates spécifiques marquées sur Budgets).
-export function periodBudget(budgetRows, debut, fin, joursFermesIso = null) {
-  // Cache par mois pour éviter le calcul N fois
-  const cache = new Map()
-  const getMap = (annee, mois) => {
+// `joursFermesIso` (optionnel) : Set<string> de dates ISO à exclure.
+// `joursOverrideRows` (optionnel) : rows ca_budget_jours_override pour
+// respecter les overrides par lieu — une cellule avec override « 1 mardi/mois »
+// n'est comptée que pour le dernier mardi du mois (cf. caJoursHelpers).
+export function periodBudget(budgetRows, debut, fin, joursFermesIso = null, joursOverrideRows = null) {
+  const electedMap = buildElectedDatesMap(joursOverrideRows)
+  const cellCache = new Map()
+  const getCells = (annee, mois) => {
     const key = `${annee}_${mois}`
-    if (!cache.has(key)) cache.set(key, budgetByIsoJdsForMonth(budgetRows, annee, mois))
-    return cache.get(key)
+    if (!cellCache.has(key)) cellCache.set(key, buildMonthCellMap(budgetRows, annee, mois))
+    return cellCache.get(key)
   }
   let total = 0
   for (const d of eachDayIso(debut, fin)) {
     if (joursFermesIso && joursFermesIso.has(d.iso)) continue
     const date = fromIso(d.iso)
-    const map = getMap(date.getFullYear(), date.getMonth() + 1)
-    total += map.get(d.isoJds) || 0
+    const annee = date.getFullYear()
+    const mois = date.getMonth() + 1
+    const cells = getCells(annee, mois)
+    for (const cell of cells.values()) {
+      if (cell.jour_semaine !== d.isoJds) continue
+      if (!isCellElectedForDate(cell, d.iso, annee, mois, electedMap)) continue
+      total +=
+        Number(cell.ca_food_cible || 0) +
+        Number(cell.ca_bev_20_cible || 0) +
+        Number(cell.ca_bev_10_cible || 0) +
+        Number(cell.ca_autre_cible || 0)
+    }
   }
   return total
 }
 
 // Sommes réel et budget sur une période. Renvoie { real, budget, ratio }.
-// joursFermesIso exclut certaines dates du cumul budget.
-export function caTtcVsBudget(caRows, budgetRows, debut, fin, joursFermesIso = null) {
+export function caTtcVsBudget(caRows, budgetRows, debut, fin, joursFermesIso = null, joursOverrideRows = null) {
   const filtered = filterCaJournalier(caRows, debut, fin)
   let real = 0
   for (const r of filtered) {
     real += Number(r.ca_food || 0) + Number(r.ca_bev_20 || 0) + Number(r.ca_bev_10 || 0) + Number(r.ca_autre || 0)
   }
-  const budget = periodBudget(budgetRows, debut, fin, joursFermesIso)
+  const budget = periodBudget(budgetRows, debut, fin, joursFermesIso, joursOverrideRows)
   const delta = real - budget
   const ratio = budget > 0 ? (delta / budget) * 100 : null
   return { real, budget, delta, ratio }
 }
 
 // Cumul mois (1er du mois au jour de fin). Utilise le mois de `fin`.
-export function caTtcCumulMois(caRows, budgetRows, fin, joursFermesIso = null) {
+export function caTtcCumulMois(caRows, budgetRows, fin, joursFermesIso = null, joursOverrideRows = null) {
   const finDate = fromIso(fin)
   const debut = `${finDate.getFullYear()}-${String(finDate.getMonth() + 1).padStart(2, '0')}-01`
-  return caTtcVsBudget(caRows, budgetRows, debut, fin, joursFermesIso)
+  return caTtcVsBudget(caRows, budgetRows, debut, fin, joursFermesIso, joursOverrideRows)
 }
 
 // ── Section 2 : Tickets moyens par lieu × service ──────────────────────────
@@ -131,7 +132,7 @@ export function caTtcCumulMois(caRows, budgetRows, fin, joursFermesIso = null) {
 // Renvoie [{ lieu_label, service, real_tm, budget_tm, ratio }] trié.
 // `lieuxMap` : Map<lieu_service_id, label>
 // `joursFermesIso` (optionnel) : Set<string> de dates exclues du budget.
-export function tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin, joursFermesIso = null) {
+export function tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin, joursFermesIso = null, joursOverrideRows = null) {
   const filtered = filterCaJournalier(caRows, debut, fin)
   // Réel : agrège couverts et CA par (lieu, service)
   const realMap = new Map()
@@ -142,30 +143,25 @@ export function tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin, jours
     acc.couverts += Number(r.couverts || 0)
     acc.ca += Number(r.ca_food || 0) + Number(r.ca_bev_20 || 0) + Number(r.ca_bev_10 || 0) + Number(r.ca_autre || 0)
   }
-  // Budget : agrège sur chaque jour ouvré du période × jds matchant
+  // Budget : agrège sur chaque jour ouvré du période × jds matchant, en
+  // respectant les overrides par lieu (dates élues).
+  const electedMap = buildElectedDatesMap(joursOverrideRows)
   const budgetMap = new Map() // key = `${lieu}_${svc}` → { couverts_cible, ca_cible }
   const cacheBudgetByMonth = new Map()
   const getCellsForMonth = (annee, mois) => {
     const key = `${annee}_${mois}`
-    if (!cacheBudgetByMonth.has(key)) {
-      const cells = new Map() // key = `${jds}_${lieu}_${svc}`
-      for (const b of (budgetRows || [])) {
-        if (b.annee != null && Number(b.annee) !== Number(annee)) continue
-        const ck = `${b.jour_semaine}_${b.lieu_service_id}_${b.service}`
-        const isOverride = b.mois === mois
-        if (isOverride) cells.set(ck, b)
-        else if (!cells.has(ck)) cells.set(ck, b)
-      }
-      cacheBudgetByMonth.set(key, cells)
-    }
+    if (!cacheBudgetByMonth.has(key)) cacheBudgetByMonth.set(key, buildMonthCellMap(budgetRows, annee, mois))
     return cacheBudgetByMonth.get(key)
   }
   for (const d of eachDayIso(debut, fin)) {
     if (joursFermesIso && joursFermesIso.has(d.iso)) continue
     const date = fromIso(d.iso)
-    const cells = getCellsForMonth(date.getFullYear(), date.getMonth() + 1)
+    const annee = date.getFullYear()
+    const mois = date.getMonth() + 1
+    const cells = getCellsForMonth(annee, mois)
     for (const cell of cells.values()) {
       if (cell.jour_semaine !== d.isoJds) continue
+      if (!isCellElectedForDate(cell, d.iso, annee, mois, electedMap)) continue
       const key = `${cell.lieu_service_id}_${cell.service}`
       if (!budgetMap.has(key)) budgetMap.set(key, { couverts_cible: 0, ca_cible: 0 })
       const acc = budgetMap.get(key)
@@ -220,7 +216,7 @@ export function tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin, jours
 
 // Renvoie { midi: { food, bev, total }, soir: {...}, total: {...} }
 // où chaque objet contient { real_tm, budget_tm, ratio }
-export function tmFoodBevParService(caRows, budgetRows, debut, fin, joursFermesIso = null) {
+export function tmFoodBevParService(caRows, budgetRows, debut, fin, joursFermesIso = null, joursOverrideRows = null) {
   const filtered = filterCaJournalier(caRows, debut, fin)
   // Réel par service
   const real = {
@@ -233,7 +229,9 @@ export function tmFoodBevParService(caRows, budgetRows, debut, fin, joursFermesI
     real[svc].food += Number(r.ca_food || 0)
     real[svc].bev += Number(r.ca_bev_20 || 0) + Number(r.ca_bev_10 || 0)
   }
-  // Budget par service — on parcourt les jours du période et on agrège
+  // Budget par service — on parcourt les jours du période et on agrège,
+  // en respectant les overrides par lieu (dates élues).
+  const electedMap = buildElectedDatesMap(joursOverrideRows)
   const budget = {
     lunch: { couverts: 0, food: 0, bev: 0 },
     dinner: { couverts: 0, food: 0, bev: 0 },
@@ -247,18 +245,12 @@ export function tmFoodBevParService(caRows, budgetRows, debut, fin, joursFermesI
     const ck = `${annee}_${mois}`
     let cells = cache.get(ck)
     if (!cells) {
-      cells = new Map()
-      for (const b of (budgetRows || [])) {
-        if (b.annee != null && Number(b.annee) !== Number(annee)) continue
-        const k = `${b.jour_semaine}_${b.lieu_service_id}_${b.service}`
-        const isOverride = b.mois === mois
-        if (isOverride) cells.set(k, b)
-        else if (!cells.has(k)) cells.set(k, b)
-      }
+      cells = buildMonthCellMap(budgetRows, annee, mois)
       cache.set(ck, cells)
     }
     for (const cell of cells.values()) {
       if (cell.jour_semaine !== d.isoJds) continue
+      if (!isCellElectedForDate(cell, d.iso, annee, mois, electedMap)) continue
       const svc = cell.service === 'lunch' ? 'lunch' : 'dinner'
       budget[svc].couverts += Number(cell.couverts_cible || 0)
       budget[svc].food += Number(cell.ca_food_cible || 0)
@@ -312,7 +304,7 @@ export function mixFoodBev(tmFoodBev) {
 
 // ── Section 5 : Couverts midi/soir ─────────────────────────────────────────
 
-export function couvertsParService(caRows, budgetRows, debut, fin, joursFermesIso = null) {
+export function couvertsParService(caRows, budgetRows, debut, fin, joursFermesIso = null, joursOverrideRows = null) {
   const filtered = filterCaJournalier(caRows, debut, fin)
   let realLunch = 0
   let realDinner = 0
@@ -320,7 +312,9 @@ export function couvertsParService(caRows, budgetRows, debut, fin, joursFermesIs
     if (r.service === 'lunch') realLunch += Number(r.couverts || 0)
     else realDinner += Number(r.couverts || 0)
   }
-  // Budget : somme couverts_cible par service sur la période
+  // Budget : somme couverts_cible par service sur la période, en respectant
+  // les overrides par lieu (dates élues).
+  const electedMap = buildElectedDatesMap(joursOverrideRows)
   let budgetLunch = 0
   let budgetDinner = 0
   const cache = new Map()
@@ -332,18 +326,12 @@ export function couvertsParService(caRows, budgetRows, debut, fin, joursFermesIs
     const ck = `${annee}_${mois}`
     let cells = cache.get(ck)
     if (!cells) {
-      cells = new Map()
-      for (const b of (budgetRows || [])) {
-        if (b.annee != null && Number(b.annee) !== Number(annee)) continue
-        const k = `${b.jour_semaine}_${b.lieu_service_id}_${b.service}`
-        const isOverride = b.mois === mois
-        if (isOverride) cells.set(k, b)
-        else if (!cells.has(k)) cells.set(k, b)
-      }
+      cells = buildMonthCellMap(budgetRows, annee, mois)
       cache.set(ck, cells)
     }
     for (const cell of cells.values()) {
       if (cell.jour_semaine !== d.isoJds) continue
+      if (!isCellElectedForDate(cell, d.iso, annee, mois, electedMap)) continue
       if (cell.service === 'lunch') budgetLunch += Number(cell.couverts_cible || 0)
       else budgetDinner += Number(cell.couverts_cible || 0)
     }
@@ -366,7 +354,7 @@ export function couvertsParService(caRows, budgetRows, debut, fin, joursFermesIs
 // Renvoie [{ iso, jour_fr, midi: {real, budget, delta, ratio}, soir: {...} }, ...]
 // joursFermesIso : Set<string> de dates pour lesquelles on force budget=0
 // (fermeture hebdo ou date spécifique marquée sur Budgets CA).
-export function couvertsJourParJour(caRows, budgetRows, debut, fin, joursFermesIso = null) {
+export function couvertsJourParJour(caRows, budgetRows, debut, fin, joursFermesIso = null, joursOverrideRows = null) {
   const filtered = filterCaJournalier(caRows, debut, fin)
   // Par jour, par service : couverts réels
   const realByDay = new Map()
@@ -376,7 +364,9 @@ export function couvertsJourParJour(caRows, budgetRows, debut, fin, joursFermesI
     if (r.service === 'lunch') acc.lunch += Number(r.couverts || 0)
     else acc.dinner += Number(r.couverts || 0)
   }
-  // Budget par jour : agrège tous les lieux pour ce jour-de-semaine
+  // Budget par jour : agrège tous les lieux pour ce jour-de-semaine, en
+  // respectant les overrides par lieu (dates élues).
+  const electedMap = buildElectedDatesMap(joursOverrideRows)
   const out = []
   const cache = new Map()
   for (const d of eachDayIso(debut, fin)) {
@@ -386,14 +376,7 @@ export function couvertsJourParJour(caRows, budgetRows, debut, fin, joursFermesI
     const ck = `${annee}_${mois}`
     let cells = cache.get(ck)
     if (!cells) {
-      cells = new Map()
-      for (const b of (budgetRows || [])) {
-        if (b.annee != null && Number(b.annee) !== Number(annee)) continue
-        const k = `${b.jour_semaine}_${b.lieu_service_id}_${b.service}`
-        const isOverride = b.mois === mois
-        if (isOverride) cells.set(k, b)
-        else if (!cells.has(k)) cells.set(k, b)
-      }
+      cells = buildMonthCellMap(budgetRows, annee, mois)
       cache.set(ck, cells)
     }
     let budgetLunch = 0
@@ -404,6 +387,7 @@ export function couvertsJourParJour(caRows, budgetRows, debut, fin, joursFermesI
     if (!(joursFermesIso && joursFermesIso.has(d.iso))) {
       for (const cell of cells.values()) {
         if (cell.jour_semaine !== d.isoJds) continue
+        if (!isCellElectedForDate(cell, d.iso, annee, mois, electedMap)) continue
         if (cell.service === 'lunch') budgetLunch += Number(cell.couverts_cible || 0)
         else budgetDinner += Number(cell.couverts_cible || 0)
       }
@@ -486,14 +470,14 @@ export function autreCaParLieuService(caRows, lieuxMap, debut, fin) {
 
 // ── Agrégateur : construit tout le rapport en un appel ─────────────────────
 
-export function buildRapportData({ caRows, budgetRows, lieuxMap, debut, fin, joursFermesIso = null }) {
-  const ca = caTtcVsBudget(caRows, budgetRows, debut, fin, joursFermesIso)
-  const caMois = caTtcCumulMois(caRows, budgetRows, fin, joursFermesIso)
-  const tmLieux = tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin, joursFermesIso)
-  const tmFb = tmFoodBevParService(caRows, budgetRows, debut, fin, joursFermesIso)
+export function buildRapportData({ caRows, budgetRows, lieuxMap, debut, fin, joursFermesIso = null, joursOverrideRows = null }) {
+  const ca = caTtcVsBudget(caRows, budgetRows, debut, fin, joursFermesIso, joursOverrideRows)
+  const caMois = caTtcCumulMois(caRows, budgetRows, fin, joursFermesIso, joursOverrideRows)
+  const tmLieux = tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin, joursFermesIso, joursOverrideRows)
+  const tmFb = tmFoodBevParService(caRows, budgetRows, debut, fin, joursFermesIso, joursOverrideRows)
   const mix = mixFoodBev(tmFb)
-  const couverts = couvertsParService(caRows, budgetRows, debut, fin, joursFermesIso)
-  const couvertsJpJ = couvertsJourParJour(caRows, budgetRows, debut, fin, joursFermesIso)
+  const couverts = couvertsParService(caRows, budgetRows, debut, fin, joursFermesIso, joursOverrideRows)
+  const couvertsJpJ = couvertsJourParJour(caRows, budgetRows, debut, fin, joursFermesIso, joursOverrideRows)
   const autreCa = autreCaSurPeriode(caRows, debut, fin)
   const autreCaMois = autreCaCumulMois(caRows, fin)
   const autreCaDetail = autreCaParLieuService(caRows, lieuxMap, debut, fin)


### PR DESCRIPTION
## Le bug

Sur **Rapport hebdo** et **Suivi CA journalier**, un lieu comme « Privat » chez Joia configuré « 1 mardi/mois » voyait son budget mensuel **compté sur tous les mardis du mois (×4 ou ×5)**. Conséquences :

- CA réel vs budget gonflé sur la période (chaque mardi affiche le budget Privat complet)
- mtdBudget (cumul à date) systématiquement faux
- Coloration jour-par-jour trompeuse : seul le vrai mardi de privatisation aurait du budget, les autres devraient être à 0

## La cause

| Page | Fonction | Problème |
|---|---|---|
| Rapport hebdo | `periodBudget` + 4 autres dans `lib/rapportHebdo.js` | Aucun paramètre d'override reçu |
| Suivi CA | `budgetByIsoJds` dans `app/controle-gestion/ventes/page.js` | Ignorait `joursOverrideRows` (pourtant chargé en DB) |

Le commentaire ligne 244 de `ventes/page.js` reconnaissait déjà l'incohérence : *« Volontairement différent de la somme jour-par-jour de daysWithBudget »* — mais seul `monthlyBudgetAligned` avait été corrigé.

## Le fix

Pour les overrides **par lieu** uniquement (table `ca_budget_jours_override` avec `lieu_service_id` non null), le budget de la cellule est désormais affecté aux **N dernières occurrences** du jour-de-semaine dans le mois :

- `nb_jours = 1` → seul le dernier mardi reçoit le budget complet
- `nb_jours = 2` → avant-dernier + dernier
- Les autres mardis affichent 0 pour cette cellule

→ Le cumul mensuel devient cohérent : `1 × cellule` = budget mensuel exact, sans gonfler par 4-5.

**Pourquoi « les N derniers » ?** Faute de calendrier précis des évènements, c'est la convention qui rend la coloration jour-par-jour la moins trompeuse. Les privats tombent statistiquement plus souvent en fin de mois en restauration. Si la privat réelle tombe le 1er mardi, on aura un décalage temporaire le temps que le CA réel arrive — mais le total mensuel reste juste.

**Overrides global/service** (`lieu_service_id` null) : inchangés. Ils représentent des fermetures exceptionnelles → garder le ratio existant (qui devrait à terme passer par `ca_jours_fermes`).

**Page Analyses** : non touchée (l'utilisateur n'a pas signalé de bug visible dessus).

## Subtilité technique : remappage parent

`rapport-hebdo/page.js` et `ComparaisonPanel.js` remappent `lieu_service_id` vers le parent (Privat → Joia) pour les agrégations analytiques. Mais l'override est stocké en DB avec le **lieu enfant**. Solution : on conserve `lieu_service_id_source` (l'ID enfant d'origine) sur les rows remappées, et `isCellElectedForDate` le consulte en priorité.

## Test plan

- [ ] **Suivi CA journalier** sur le mois où Privat a une privat (ex. mai) : les mardis avant le dernier doivent afficher 0 € de budget Privat. Le dernier mardi affiche le budget complet.
- [ ] **mtdBudget** sur Suivi CA = `monthlyBudgetAligned` (les deux indicateurs cohérents)
- [ ] **Rapport hebdo** sur une semaine sans privat : budget Privat = 0
- [ ] **Rapport hebdo** sur la semaine de la privat (dernière du mois) : budget Privat = montant configuré
- [ ] **ComparaisonPanel** : mêmes valeurs cohérentes
- [ ] **Aucune régression** sur les ingrédients de Joia non concernés (Salle, etc.) qui sont ouverts tous les mardis : budget identique avant/après
- [ ] **228 tests Vitest** passent

## Changements

- `lib/caJoursHelpers.js` (nouveau) + tests (11 cas)
- `lib/rapportHebdo.js` : 5 fonctions + `buildRapportData` acceptent `joursOverrideRows`
- `lib/__tests__/rapportHebdo.test.ts` : 7 nouveaux cas (Privat 1 mardi/mois)
- `app/controle-gestion/ventes/rapport-hebdo/page.js` : charge override + `lieu_service_id_source`
- `components/rapport-hebdo/ComparaisonPanel.js` : pareil
- `app/controle-gestion/ventes/page.js` : `budgetByIsoJds` → `budgetByDateIso`

🤖 Generated with [Claude Code](https://claude.com/claude-code)