### PR TITLE
fix(analyses): aligne sur le modèle dates élues comme Rapport hebdo

### DIFF
--- a/app/controle-gestion/analyses/page.js
+++ b/app/controle-gestion/analyses/page.js
@@ -26,6 +26,7 @@ import {
   perfByWeekdayMultiSeries,
   fromIsoDate,
 } from '../../../lib/caAnalyses'
+import { buildElectedDatesMap } from '../../../lib/caJoursHelpers'
 import {
   WIDGET_BY_ID,
   DEFAULT_LAYOUT,
@@ -106,6 +107,9 @@ export default function AnalysesPage() {
   // Overrides nb_jours (fermetures exceptionnelles) configurés sur /budgets.
   // Stockés en Map<`${annee}_${mois}_${jds}`, nb_jours> pour lookup O(1).
   const [overridesNbJours, setOverridesNbJours] = useState(new Map())
+  // Index des dates "élues" pour les overrides PAR LIEU (ex : Privat 1 mardi/mois
+  // = uniquement le dernier mardi). Construit depuis les rows brutes ci-dessous.
+  const [electedDatesMap, setElectedDatesMap] = useState(new Map())
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
@@ -259,12 +263,17 @@ export default function AnalysesPage() {
           Number(o.nb_jours)
         )
       }
+      // Index des dates élues pour les overrides PAR LIEU (lieu_service_id défini).
+      // Ex: « Privat 1 mardi/mois » → Set des dates du dernier mardi du mois.
+      // Le reste (overrides global/service) reste géré via ratio classique.
+      const elected = buildElectedDatesMap(overridesRes.data || [])
 
       setRawCa(caRes.data || [])
       setRawCaCompare(compareCaRes.data || [])
       setBudgetByYear(groupByYear(budgetRes.data || []))
       setBudgetByYearCompare(groupByYear(compareBudgetRes.data || []))
       setOverridesNbJours(overridesMap)
+      setElectedDatesMap(elected)
     } catch (e) {
       setError(e.message || 'Erreur de chargement')
     } finally {
@@ -428,8 +437,8 @@ export default function AnalysesPage() {
   }, [filteredRows, dateDebut, dateFin, filterJoursActive, joursSet])
 
   const periodBudget = useMemo(
-    () => periodBudgetTotal(filteredBudgetByYear, dateDebut, dateFin, filterJoursActive ? joursSet : null, overridesNbJours),
-    [filteredBudgetByYear, dateDebut, dateFin, filterJoursActive, joursSet, overridesNbJours]
+    () => periodBudgetTotal(filteredBudgetByYear, dateDebut, dateFin, filterJoursActive ? joursSet : null, overridesNbJours, electedDatesMap),
+    [filteredBudgetByYear, dateDebut, dateFin, filterJoursActive, joursSet, overridesNbJours, electedDatesMap]
   )
 
   const compareBudgetRange = useMemo(
@@ -439,8 +448,8 @@ export default function AnalysesPage() {
 
   const periodBudgetCompare = useMemo(() => {
     if (!compareBudgetRange) return 0
-    return periodBudgetTotal(filteredCompareBudgetByYear, compareBudgetRange.debut, compareBudgetRange.fin, filterJoursActive ? joursSet : null, overridesNbJours)
-  }, [filteredCompareBudgetByYear, compareBudgetRange, filterJoursActive, joursSet, overridesNbJours])
+    return periodBudgetTotal(filteredCompareBudgetByYear, compareBudgetRange.debut, compareBudgetRange.fin, filterJoursActive ? joursSet : null, overridesNbJours, electedDatesMap)
+  }, [filteredCompareBudgetByYear, compareBudgetRange, filterJoursActive, joursSet, overridesNbJours, electedDatesMap])
 
   // ── Comparison props injectés dans les KPIs ──────────────────────────────
   // - 'aucune' → pas de comparaison
@@ -466,10 +475,10 @@ export default function AnalysesPage() {
   // passer joursSet ici : on est déjà filtré au niveau de `days`.
   const daysWithBudget = useMemo(() => {
     return days.map((d) => {
-      const budget = periodBudgetTotal(filteredBudgetByYear, d.iso, d.iso, null, overridesNbJours)
+      const budget = periodBudgetTotal(filteredBudgetByYear, d.iso, d.iso, null, overridesNbJours, electedDatesMap)
       return { ...d, budget }
     })
-  }, [days, filteredBudgetByYear, overridesNbJours])
+  }, [days, filteredBudgetByYear, overridesNbJours, electedDatesMap])
 
   const tableauTotals = useMemo(() => {
     let lunchCouverts = 0, dinnerCouverts = 0, budget = 0
@@ -648,7 +657,7 @@ export default function AnalysesPage() {
       case 'section-top-bottom-jours':
         return <SectionTopBottomJours c={c} isMobile={isMobile} topBottom={topBottom} />
       case 'section-tableau-jour-jour':
-        return <SectionTableauJourJour c={c} isMobile={isMobile} days={daysWithBudget} totals={tableauTotals} isSplit={isSplit} splitByLieu={splitByLieu} splitByService={splitByService} filteredRows={filteredRows} lieuxLabels={lieuxLabels} filteredBudgetByYear={filteredBudgetByYear} overridesNbJours={overridesNbJours} />
+        return <SectionTableauJourJour c={c} isMobile={isMobile} days={daysWithBudget} totals={tableauTotals} isSplit={isSplit} splitByLieu={splitByLieu} splitByService={splitByService} filteredRows={filteredRows} lieuxLabels={lieuxLabels} filteredBudgetByYear={filteredBudgetByYear} overridesNbJours={overridesNbJours} electedDatesMap={electedDatesMap} />
       case 'kpi-food-cost-moyen':
         return (
           <KpiFoodCostMoyen

--- a/components/analyses/widgets/SectionTableauJourJour.js
+++ b/components/analyses/widgets/SectionTableauJourJour.js
@@ -16,7 +16,7 @@ const JOURS_FR = ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi',
 export default function SectionTableauJourJour({
   c, isMobile, days, totals,
   isSplit, splitByLieu, splitByService, filteredRows, lieuxLabels,
-  filteredBudgetByYear, overridesNbJours,
+  filteredBudgetByYear, overridesNbJours, electedDatesMap,
 }) {
   if (isSplit) {
     return (
@@ -26,6 +26,7 @@ export default function SectionTableauJourJour({
         splitByLieu={splitByLieu} splitByService={splitByService}
         filteredBudgetByYear={filteredBudgetByYear}
         overridesNbJours={overridesNbJours}
+        electedDatesMap={electedDatesMap}
       />
     )
   }
@@ -127,7 +128,7 @@ function CumulatedTable({ c, isMobile, days, totals }) {
 
 function SplitTable({
   c, isMobile, filteredRows, lieuxLabels, splitByLieu, splitByService,
-  filteredBudgetByYear, overridesNbJours,
+  filteredBudgetByYear, overridesNbJours, electedDatesMap,
 }) {
   const splitDims = []
   if (splitByLieu) splitDims.push('lieu')
@@ -171,12 +172,12 @@ function SplitTable({
         const date = new Date(`${v.iso}T00:00:00`)
         // Budget cible pour cette cellule (jour × [lieu] × [service])
         const budget = filteredBudgetByYear
-          ? dailyBudgetForCell(filteredBudgetByYear, v.iso, v.lieu_service_id, v.service_key, overridesNbJours)
+          ? dailyBudgetForCell(filteredBudgetByYear, v.iso, v.lieu_service_id, v.service_key, overridesNbJours, electedDatesMap)
           : 0
         return { ...v, caTot, tm, budget, jsWeekday: date.getDay() }
       })
       .sort((a, b) => a.iso !== b.iso ? a.iso.localeCompare(b.iso) : a.serie.localeCompare(b.serie, 'fr'))
-  }, [filteredRows, lieuxLabels, splitByLieu, splitByService, filteredBudgetByYear, overridesNbJours])
+  }, [filteredRows, lieuxLabels, splitByLieu, splitByService, filteredBudgetByYear, overridesNbJours, electedDatesMap])
 
   const totals = useMemo(() => {
     const t = { couverts: 0, food: 0, bev_20: 0, bev_10: 0, autre: 0, budget: 0 }

--- a/lib/__tests__/caAnalyses.test.ts
+++ b/lib/__tests__/caAnalyses.test.ts
@@ -284,6 +284,69 @@ describe('periodBudgetTotal', () => {
     expect(avecMapVide).toBe(400)
   })
 
+  // Cas Privat 1 mardi/mois : budget affecté uniquement au dernier mardi
+  // (aligné sur rapportHebdo.js). Avant le fix, le ratio 1/4 répartissait
+  // le budget sur tous les mardis, ce qui surestimait le cumul MTD avant
+  // le dernier mardi du mois.
+  describe('overrides par lieu (cas Privat — dates élues)', () => {
+    // Mai 2026 a 4 mardis : 5, 12, 19, 26. Le 26 est le dernier.
+    const budgetPrivat = [
+      // Joia Salle (L1) ouvert tous les mardis soir : 9000 €/mardi
+      { jour_semaine: 2, lieu_service_id: 'L1', service: 'dinner', mois: null,
+        ca_food_cible: 7000, ca_bev_20_cible: 1500, ca_bev_10_cible: 500, ca_autre_cible: 0 },
+      // Privat (LPRIVAT) : budget mensuel = 8260 € avec override 1 mardi/mois
+      { jour_semaine: 2, lieu_service_id: 'LPRIVAT', service: 'dinner', mois: 5,
+        ca_food_cible: 6260, ca_bev_20_cible: 1500, ca_bev_10_cible: 500, ca_autre_cible: 0 },
+    ]
+    const overridesMap = new Map([
+      // Override par lieu : 1 mardi/mois pour Privat dinner
+      ['2026_5_2_dinner_LPRIVAT', 1],
+    ])
+    // electedDatesMap construit depuis les rows brutes : Privat élu uniquement le 26 mai
+    const electedMap = new Map([
+      ['2026_5_2_dinner_LPRIVAT', new Set(['2026-05-26'])],
+    ])
+
+    it('sur mois complet (1-31 mai) : Salle 4×9000 + Privat 1×8260 = 44260', () => {
+      const total = periodBudgetTotal({ 2026: budgetPrivat }, '2026-05-01', '2026-05-31', null, overridesMap, electedMap)
+      expect(total).toBe(44260)
+    })
+
+    it('sur MTD (1-25 mai, dernier mardi 26 EXCLU) : Salle 3×9000 + Privat 0 = 27000', () => {
+      // C'est le bug que le user a signalé : avant fix, Privat était compté
+      // 3 × 2065 = 6195 sur cette période. Maintenant Privat = 0 car le 26
+      // n'est pas dans la période.
+      const total = periodBudgetTotal({ 2026: budgetPrivat }, '2026-05-01', '2026-05-25', null, overridesMap, electedMap)
+      expect(total).toBe(27000)
+    })
+
+    it('semaine du 25-31 mai (contient le 26) : Salle 1×9000 + Privat 1×8260 = 17260', () => {
+      const total = periodBudgetTotal({ 2026: budgetPrivat }, '2026-05-25', '2026-05-31', null, overridesMap, electedMap)
+      expect(total).toBe(17260)
+    })
+
+    it('sans electedDatesMap : régression vers ratio (preuve du bug avant fix)', () => {
+      // Sur 1-25 mai sans electedDatesMap : Privat avec ratio 1/4
+      // = 3 mardis × 2065 = 6195. Salle = 3 × 9000 = 27000. Total = 33195.
+      const total = periodBudgetTotal({ 2026: budgetPrivat }, '2026-05-01', '2026-05-25', null, overridesMap)
+      expect(total).toBe(33195)
+    })
+
+    it('overrides global (lieu null) inchangés : ratio classique conservé', () => {
+      // Override global (pas de lieu) ne doit PAS être affecté par electedMap.
+      // Mai 2026 = 5 dimanches. Override "3 dim sur mois" → ratio 3/5.
+      const rowsDim = [
+        { jour_semaine: 7, lieu_service_id: 'L1', service: 'lunch', mois: null,
+          ca_food_cible: 100, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+      ]
+      const overrideGlobal = new Map([['2026_5_7___all_____all__', 3]])
+      // electedMap vide → pas d'élection, comportement = ratio
+      const total = periodBudgetTotal({ 2026: rowsDim }, '2026-05-01', '2026-05-31', null, overrideGlobal, new Map())
+      // 5 dim × 100 × (3/5) = 300
+      expect(total).toBe(300)
+    })
+  })
+
   it('cas Marsan : deux lieux enfants d\'un même parent ADDITIONNENT leurs budgets (ne s\'écrasent pas)', () => {
     // Marsan a "Table du chef" enfant de "Salle à manger", et "La cave" enfant
     // de "Table de partage". Avant le fix, le remap parent côté filterBudgets

--- a/lib/caAnalyses.js
+++ b/lib/caAnalyses.js
@@ -6,6 +6,8 @@
 // Tout est testable sans Supabase ni React : les fonctions prennent les rows
 // en entrée et renvoient des objets dérivés.
 
+import { isCellElectedForDate } from './caJoursHelpers'
+
 // ── Constantes ─────────────────────────────────────────────────────────────
 // Conversion TTC → HT par catégorie. TVA Food/Soft 10 %, TVA Alcool 20 %.
 // "Autre" : TVA inconnue → on assume 10 % (catégorie boutique/divers, le
@@ -469,6 +471,20 @@ function ratioOverrideForCell(overridesMap, annee, mois, jds, lieu, service) {
   return naturel > 0 ? nbJours / naturel : 1
 }
 
+// Détecte si une cellule a un override par lieu actif pour ce mois.
+// Si oui, on la SKIP du calcul "ratio par mois" : son budget sera ajouté
+// date par date dans periodBudgetTotal / dailyBudgetForCell uniquement
+// pour les dates élues (cf. caJoursHelpers.isCellElectedForDate). C'est ce
+// qui aligne Analyses sur le modèle "1 mardi/mois = un seul mardi" de
+// rapportHebdo.js.
+function cellHasLieuOverride(electedDatesMap, annee, mois, cell) {
+  if (!electedDatesMap || electedDatesMap.size === 0) return false
+  const lieuId = cell.lieu_parent_id ?? cell.lieu_service_id
+  if (!lieuId) return false
+  const key = `${annee}_${mois}_${cell.jour_semaine}_${cell.service}_${lieuId}`
+  return electedDatesMap.has(key)
+}
+
 // budgetRows : ca_budgets sur l'année concernée, filtrés (par lieu/service
 // côté SQL ou JS). Chaque row a soit `mois = null` (défaut annuel) soit
 // `mois ∈ 1..12` (override pour ce mois précis).
@@ -479,7 +495,11 @@ function ratioOverrideForCell(overridesMap, annee, mois, jds, lieu, service) {
 // `annee` et `overridesMap` (optionnels) servent à appliquer le ratio des
 // fermetures exceptionnelles AU NIVEAU CELLULE — un override "service=dinner
 // nb_jours=0" ne doit pas zéroter le budget du même jds en lunch.
-export function budgetByIsoJdsForMonth(budgetRows, monthNum, annee = null, overridesMap = null) {
+//
+// `electedDatesMap` (optionnel) : index des dates élues pour les overrides
+// par lieu (cf. caJoursHelpers.buildElectedDatesMap). Les cellules concernées
+// sont skippées ici et comptées séparément dans periodBudgetTotal.
+export function budgetByIsoJdsForMonth(budgetRows, monthNum, annee = null, overridesMap = null, electedDatesMap = null) {
   const cellMap = new Map() // key = `${jds}_${lieu}_${svc}` → row choisie
 
   // Pass 1 : défauts annuels (mois = null). Sert de base.
@@ -497,6 +517,8 @@ export function budgetByIsoJdsForMonth(budgetRows, monthNum, annee = null, overr
 
   const out = new Map()
   for (const cell of cellMap.values()) {
+    // Cellules avec override par lieu : skip ici, ajoutées date par date.
+    if (cellHasLieuOverride(electedDatesMap, annee, monthNum, cell)) continue
     const total =
       Number(cell.ca_food_cible || 0) +
       Number(cell.ca_bev_20_cible || 0) +
@@ -510,6 +532,34 @@ export function budgetByIsoJdsForMonth(budgetRows, monthNum, annee = null, overr
   return out
 }
 
+// Somme des cellules avec override par lieu qui sont ÉLUES pour cette date.
+// Itère uniquement sur les cellules pertinentes (même jds, même mois) qui
+// ont un override par lieu, et ne contribuent que si la date est dans le
+// Set des dates élues (typiquement le dernier mardi du mois pour Privat).
+function electedCellBudgetForDate(budgetRows, isoDate, annee, mois, isoJds, electedDatesMap) {
+  if (!electedDatesMap || electedDatesMap.size === 0) return 0
+  // Reconstruit le cellMap pour ce mois (Pass 1 + Pass 2 comme ci-dessus).
+  const cellMap = new Map()
+  for (const b of budgetRows) {
+    if (b.jour_semaine !== isoJds) continue
+    if (b.mois != null && b.mois !== mois) continue
+    const key = `${b.lieu_service_id}_${b.service}`
+    if (b.mois === mois) cellMap.set(key, b)
+    else if (!cellMap.has(key)) cellMap.set(key, b)
+  }
+  let total = 0
+  for (const cell of cellMap.values()) {
+    if (!cellHasLieuOverride(electedDatesMap, annee, mois, cell)) continue
+    if (!isCellElectedForDate(cell, isoDate, annee, mois, electedDatesMap)) continue
+    total +=
+      Number(cell.ca_food_cible || 0) +
+      Number(cell.ca_bev_20_cible || 0) +
+      Number(cell.ca_bev_10_cible || 0) +
+      Number(cell.ca_autre_cible || 0)
+  }
+  return total
+}
+
 // Budget journalier pour un (iso, [lieu_service_id], [service]). Si une des
 // dimensions est null, somme toutes les valeurs sur cette dimension.
 // Respecte la priorité override mensuel > défaut au niveau de chaque cellule
@@ -521,6 +571,7 @@ export function dailyBudgetForCell(
   lieuServiceId = null,
   service = null,
   overridesByYearMonth = null,
+  electedDatesMap = null,
 ) {
   const date = fromIsoDate(iso)
   const annee = date.getFullYear()
@@ -558,6 +609,8 @@ export function dailyBudgetForCell(
   // 3. Somme des cellules sélectionnées, avec ratio override par cellule.
   // Le ratio est appliqué cellule par cellule (et non globalement) pour
   // qu'un override "dim dinner = 0" ne zéroter pas aussi le dim lunch.
+  // Les cellules avec override par lieu sont gérées différemment :
+  // n'ajouter le budget que si la date courante est élue (cf. caJoursHelpers).
   let budgetParJour = 0
   for (const cell of cellMap.values()) {
     const total =
@@ -565,6 +618,12 @@ export function dailyBudgetForCell(
       Number(cell.ca_bev_20_cible || 0) +
       Number(cell.ca_bev_10_cible || 0) +
       Number(cell.ca_autre_cible || 0)
+    if (cellHasLieuOverride(electedDatesMap, annee, mois, cell)) {
+      if (isCellElectedForDate(cell, iso, annee, mois, electedDatesMap)) {
+        budgetParJour += total
+      }
+      continue
+    }
     const ratio = ratioOverrideForCell(
       overridesByYearMonth,
       annee, mois, isoJds,
@@ -598,12 +657,12 @@ export function countIsoJdsInMonth(annee, mois, isoJds) {
 //   priorité (lieu, svc) > (NULL, svc) > (NULL, NULL). Ça permet de fermer
 //   un service précis (ex: dimanche soir) sans impacter l'autre service du
 //   même jds.
-export function periodBudgetTotal(budgetRowsByYear, debut, fin, isoJdsFilter = null, overridesByYearMonth = null) {
+export function periodBudgetTotal(budgetRowsByYear, debut, fin, isoJdsFilter = null, overridesByYearMonth = null, electedDatesMap = null) {
   const cache = new Map()
   const getMap = (annee, mois) => {
     const key = `${annee}_${mois}`
     if (!cache.has(key)) {
-      cache.set(key, budgetByIsoJdsForMonth(budgetRowsByYear[annee] || [], mois, annee, overridesByYearMonth))
+      cache.set(key, budgetByIsoJdsForMonth(budgetRowsByYear[annee] || [], mois, annee, overridesByYearMonth, electedDatesMap))
     }
     return cache.get(key)
   }
@@ -611,7 +670,13 @@ export function periodBudgetTotal(budgetRowsByYear, debut, fin, isoJdsFilter = n
   for (const d of eachDayIso(debut, fin)) {
     if (isoJdsFilter && !isoJdsFilter.has(d.isoJds)) continue
     const date = fromIsoDate(d.iso)
-    total += getMap(date.getFullYear(), date.getMonth() + 1).get(d.isoJds) || 0
+    const annee = date.getFullYear()
+    const mois = date.getMonth() + 1
+    // Cellules "ratio" (sans override par lieu) : agrégées au niveau mois.
+    total += getMap(annee, mois).get(d.isoJds) || 0
+    // Cellules "elected" (override par lieu) : ajoutées uniquement pour les
+    // dates élues de la période (typiquement le dernier mardi pour Privat).
+    total += electedCellBudgetForDate(budgetRowsByYear[annee] || [], d.iso, annee, mois, d.isoJds, electedDatesMap)
   }
   return total
 }


### PR DESCRIPTION
## Bug constaté

L'utilisateur voit deux chiffres différents pour la **même métrique sur la même période** :

- **Analyses** (MTD 1-25 mai) : 203 920 € de budget
- **Rapport hebdo** (même période) : 197 725 € de budget
- **Écart : 6 195 €**

## Cause

Depuis PR #128, **Rapport hebdo** et **Suivi CA** utilisent le modèle « dates élues » pour les overrides par lieu : un Privat configuré « 1 mardi/mois » n'est compté qu'au dernier mardi du mois.

**Analyses** était resté sur le modèle « ratio » : la cellule Privat est étalée sur tous les mardis (× nb_jours/calendaire). Sur une période MTD qui n'inclut pas encore le dernier mardi, ça surestime.

Cas Joia mai 2026 :
- Budget mensuel Privat = 8 260 €
- 4 mardis dans le mois (5, 12, 19, 26)
- Sur 1-25 mai (3 mardis × ratio 1/4) : **Analyses comptait 6 195 €**
- Modèle correct (dates élues) : **0 € car le 26 mai n'est pas dans la période**

→ L'écart de 6 195 € est exactement cohérent avec cette divergence de modèle.

## Fix

`lib/caAnalyses.js`:
- `budgetByIsoJdsForMonth` accepte `electedDatesMap`. Les cellules avec override par lieu sont **skippées** (au lieu d'être multipliées par le ratio)
- Nouvelle fonction `electedCellBudgetForDate` qui ajoute la cellule **uniquement pour les dates élues** de la période
- `periodBudgetTotal` et `dailyBudgetForCell` consomment le nouveau param

`app/controle-gestion/analyses/page.js`:
- Construit `electedDatesMap` via `buildElectedDatesMap(overridesRes.data)`
- Le propage aux 3 appels de `periodBudgetTotal` + au widget `SectionTableauJourJour`

`components/analyses/widgets/SectionTableauJourJour.js`:
- Propage le param vers `SplitTable` → `dailyBudgetForCell`

## Overrides non touchés

Les overrides **global/service** (`lieu_service_id` null) gardent le modèle ratio. Ils représentent des fermetures exceptionnelles, pas des événements à date fixée. Ils continueront à se comporter comme avant.

## Test plan

- [ ] Recharger Analyses sur la même période MTD : le budget doit maintenant matcher celui du Rapport hebdo (197 725 €)
- [ ] Vérifier sur le mois COMPLET : les deux pages doivent donner la même valeur (sans changement vs avant le fix)
- [ ] Vérifier que la coloration jour-par-jour en mode split reste cohérente sur Analyses
- [ ] **707 tests Vitest** passent (5 nouveaux cas Privat dans `caAnalyses.test.ts`)
- [ ] Aucune régression sur les overrides global/service (les tests existants passent : `it('cas Joia : un override service=dinner ne zéroter pas le service=lunch du même jds')`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)