### PR TITLE
fix(analyses): match overrides par lieu_service_id (enfant), pas le parent

### DIFF
--- a/lib/__tests__/caAnalyses.test.ts
+++ b/lib/__tests__/caAnalyses.test.ts
@@ -332,6 +332,24 @@ describe('periodBudgetTotal', () => {
       expect(total).toBe(33195)
     })
 
+    it('cellule remappée avec lieu_parent_id ≠ lieu_service_id (cas page Analyses)', () => {
+      // Reproduction du bug constaté en prod : sur Analyses, filterBudgets
+      // ajoute `lieu_parent_id` aux rows budget (parent du lieu) MAIS garde
+      // `lieu_service_id` à sa valeur enfant. L'override est stocké en DB
+      // avec lieu_service_id = enfant. Le helper doit matcher sur l'enfant,
+      // pas le parent — sinon les overrides sur lieux enfants ratent.
+      const budgetAvecParent = [
+        { jour_semaine: 2, lieu_service_id: 'L1', lieu_parent_id: 'L1', service: 'dinner', mois: null,
+          ca_food_cible: 7000, ca_bev_20_cible: 1500, ca_bev_10_cible: 500, ca_autre_cible: 0 },
+        // Privat enfant de Joia : lieu_service_id = LPRIVAT, lieu_parent_id = JOIA
+        { jour_semaine: 2, lieu_service_id: 'LPRIVAT', lieu_parent_id: 'JOIA', service: 'dinner', mois: 5,
+          ca_food_cible: 6260, ca_bev_20_cible: 1500, ca_bev_10_cible: 500, ca_autre_cible: 0 },
+      ]
+      // Sur MTD 1-25 mai : 3 mardis × 9000 (Salle) + 0 (Privat car le 26 hors plage) = 27000
+      const total = periodBudgetTotal({ 2026: budgetAvecParent }, '2026-05-01', '2026-05-25', null, overridesMap, electedMap)
+      expect(total).toBe(27000)
+    })
+
     it('overrides global (lieu null) inchangés : ratio classique conservé', () => {
       // Override global (pas de lieu) ne doit PAS être affecté par electedMap.
       // Mai 2026 = 5 dimanches. Override "3 dim sur mois" → ratio 3/5.

--- a/lib/caAnalyses.js
+++ b/lib/caAnalyses.js
@@ -477,9 +477,17 @@ function ratioOverrideForCell(overridesMap, annee, mois, jds, lieu, service) {
 // pour les dates élues (cf. caJoursHelpers.isCellElectedForDate). C'est ce
 // qui aligne Analyses sur le modèle "1 mardi/mois = un seul mardi" de
 // rapportHebdo.js.
+//
+// IMPORTANT : on matche par `lieu_service_id` (l'ID ENFANT, tel que stocké
+// dans la table ca_budget_jours_override en DB), PAS par `lieu_parent_id`
+// (qui est seulement ajouté par filterBudgets pour le matching des filtres
+// utilisateur). Un override stocké sur "Privat" doit matcher la cellule
+// budget de Privat, pas celle du parent "Joia". Utiliser lieu_parent_id
+// ici raterait les overrides sur lieux enfants et garderait à tort le
+// ratio (= bug constaté : Analyses 189 145 vs Rapport hebdo 197 725).
 function cellHasLieuOverride(electedDatesMap, annee, mois, cell) {
   if (!electedDatesMap || electedDatesMap.size === 0) return false
-  const lieuId = cell.lieu_parent_id ?? cell.lieu_service_id
+  const lieuId = cell.lieu_service_id
   if (!lieuId) return false
   const key = `${annee}_${mois}_${cell.jour_semaine}_${cell.service}_${lieuId}`
   return electedDatesMap.has(key)


### PR DESCRIPTION
## Bug constaté

Après PR #129, l'utilisateur voit toujours un écart entre les deux pages :
- Rapport hebdo : 197 725 €
- Analyses : 189 145 €
- Écart restant : 8 580 €

Le fix PR #129 n'était que partiel — il marchait pour les lieux **top-level** mais pas pour les **lieux enfants** (cas Privat, enfant de Joia).

## Cause exacte

`filterBudgets` dans `app/controle-gestion/analyses/page.js` ajoute `lieu_parent_id` aux rows budget pour le matching des filtres utilisateur, mais **garde `lieu_service_id` à sa valeur enfant**.

Mon helper `cellHasLieuOverride` regardait `cell.lieu_parent_id ?? cell.lieu_service_id` :
- Pour la cellule Privat → `lieu_parent_id = JOIA`, `lieu_service_id = LPRIVAT`
- Helper cherchait `${...}_JOIA` dans `electedDatesMap`
- Or l'override est stocké en DB avec `lieu_service_id = LPRIVAT`
- Donc clé `${...}_LPRIVAT` dans `electedDatesMap` → MISS
- → Cellule NON skippée → ratio (1/4) appliqué quand même → bug pas corrigé pour les enfants

## Fix

Une ligne :
```js
const lieuId = cell.lieu_service_id  // au lieu de cell.lieu_parent_id ?? cell.lieu_service_id
```

C'est cohérent avec :
- La structure de la table `ca_budget_jours_override` (lieu_service_id = ID réel du lieu, enfant compris)
- Le helper `isCellElectedForDate` dans `caJoursHelpers.js` qui fait déjà ça (avec fallback `lieu_service_id_source` pour Rapport hebdo qui remap vers parent)

## Pourquoi mes tests précédents ne l'ont pas attrapé

Les 5 tests Privat de PR #129 utilisaient des rows budget sans `lieu_parent_id` défini. Le fallback `lieu_parent_id ?? lieu_service_id` retombait sur `lieu_service_id` (l'enfant) et tout marchait. Le bug n'apparaissait qu'en présence de `lieu_parent_id` (cas réel sur la page Analyses).

J'ajoute un nouveau test explicite qui simule ce cas : `it('cellule remappée avec lieu_parent_id ≠ lieu_service_id (cas page Analyses)')`.

## Test plan

- [ ] Recharger Analyses : le total doit maintenant matcher exactement Rapport hebdo (197 725 €)
- [ ] Vérifier les autres lieux enfants avec override (s'il y en a) : doivent être correctement comptés uniquement à leurs dates élues
- [ ] **480 tests Vitest** passent, dont le nouveau cas spécifique

🤖 Generated with [Claude Code](https://claude.com/claude-code)