### PR TITLE
fix(rapport-hebdo): aligne sur Analyses pour les overrides global/service (cas Joia vendredi 4/5)

### DIFF
--- a/lib/__tests__/rapportHebdo.test.ts
+++ b/lib/__tests__/rapportHebdo.test.ts
@@ -303,6 +303,60 @@ describe('overrides nb_jours par lieu (cas Privat 1 mardi/mois)', () => {
     expect(privat?.budget_ca).toBe(5000)
   })
 
+  // Cas Joia mai 2026 : override global vendredi = 4 sur mois à 5 vendredis.
+  // Avant fix : Rapport hebdo comptait 5 vendredis × budget (ignorait l'override).
+  // Après fix : compte 5 × budget × (4/5) = 4 × budget équivalent (aligné Analyses).
+  // L'écart de 8 580 € constaté en prod chez Joia vient de là : budget vendredi
+  // Resto Joia = 10 725 €/vendredi, ratio 4/5 → 2 145 € de différence par vendredi
+  // × 4 vendredis sur 1-24 mai = 8 580 €.
+  describe('overrides global (cas Joia vendredi 4/5)', () => {
+    // Mai 2026 a 5 vendredis : 1, 8, 15, 22, 29
+    const budgetVen = [
+      { annee: 2026, mois: 5, jour_semaine: 5, lieu_service_id: 'L1', service: 'dinner',
+        couverts_cible: 50, ca_food_cible: 7000, ca_bev_20_cible: 700, ca_bev_10_cible: 0, ca_autre_cible: 0 }, // total 7 700
+      { annee: 2026, mois: 5, jour_semaine: 5, lieu_service_id: 'L1', service: 'lunch',
+        couverts_cible: 30, ca_food_cible: 2500, ca_bev_20_cible: 525, ca_bev_10_cible: 0, ca_autre_cible: 0 }, // total 3 025
+    ]
+    // Override global "vendredi=4" appliqué à dinner ET lunch
+    const overridesVen = [
+      { annee: 2026, mois: 5, jour_semaine: 5, service: 'dinner', lieu_service_id: null, nb_jours: 4 },
+      { annee: 2026, mois: 5, jour_semaine: 5, service: 'lunch',  lieu_service_id: null, nb_jours: 4 },
+    ]
+
+    it('sans override : 5 vendredis × 10 725 = 53 625 (comportement avant fix)', () => {
+      const res = caTtcVsBudget([], budgetVen, '2026-05-01', '2026-05-31')
+      expect(res.budget).toBe(53625)
+    })
+
+    it('avec override global vendredi=4 : 5 × 10 725 × (4/5) = 42 900 (mois complet)', () => {
+      const res = caTtcVsBudget([], budgetVen, '2026-05-01', '2026-05-31', null, overridesVen)
+      expect(res.budget).toBe(42900)
+    })
+
+    it('avec override sur 1-24 mai (4 vendredis dans la plage) : 4 × 10 725 × 0.8 = 34 320', () => {
+      // C'est exactement le bug constaté chez Joia : sans fix, Rapport hebdo
+      // donnerait 4 × 10 725 = 42 900. Avec fix, 34 320 = aligné avec Analyses.
+      const res = caTtcVsBudget([], budgetVen, '2026-05-01', '2026-05-24', null, overridesVen)
+      expect(res.budget).toBe(34320)
+    })
+
+    it('override global lieu null prioritaire sur priorité (lieu, svc) si pas trouvé', () => {
+      // Si l'override (lieu spécifique) n'existe pas, retombe sur (NULL, svc)
+      // puis (NULL, NULL). C'est la convention de ratioOverrideForCell.
+      const budgetSimple = [
+        { annee: 2026, mois: 5, jour_semaine: 5, lieu_service_id: 'L1', service: 'dinner',
+          couverts_cible: 0, ca_food_cible: 100, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+      ]
+      const overrideGlobalAll = [
+        // Pas de service ni lieu : override global "tous les vendredis = 4"
+        { annee: 2026, mois: 5, jour_semaine: 5, service: null, lieu_service_id: null, nb_jours: 4 },
+      ]
+      // Mai entier : 5 vendredis × 100 × (4/5) = 400
+      const res = caTtcVsBudget([], budgetSimple, '2026-05-01', '2026-05-31', null, overrideGlobalAll)
+      expect(res.budget).toBe(400)
+    })
+  })
+
   it('respecte lieu_service_id_source (cas remappage parent du rapport hebdo)', () => {
     // Cas réel : la page rapport-hebdo remap lieu_service_id vers le parent
     // pour les agrégations. La cellule budget remappée perd son ID enfant

--- a/lib/caJoursHelpers.js
+++ b/lib/caJoursHelpers.js
@@ -1,20 +1,29 @@
 // Helpers partagés pour la résolution des jours d'ouverture / d'événement
-// en fonction des overrides budgétaires par lieu (table ca_budget_jours_override).
+// en fonction des overrides budgétaires (table ca_budget_jours_override).
 //
-// Cas d'usage type : "Privat" chez Joia n'est ouvert que 1 mardi par mois
-// (privatisations). L'override stocke `nb_jours = 1` pour (mardi, soir, Privat).
-// On veut alors que le budget de cette cellule soit AFFECTÉ à un seul mardi
-// du mois (par défaut le dernier), pas réparti sur tous les mardis.
+// DEUX MÉCANISMES selon le type d'override :
 //
-// Pourquoi le "dernier" ? Faute de calendrier précis des évènements, on
-// choisit la convention qui rend la coloration jour-par-jour la moins
-// trompeuse : les mardis sans privat affichent 0 (et le CA réel ~0 → Δ ≈ 0),
-// le mardi élu porte le budget complet (et recevra le CA réel le moment venu).
+// 1. Override PAR LIEU (lieu_service_id défini) → modèle "dates élues"
+//    Cas d'usage : "Privat" chez Joia n'est ouvert que 1 mardi par mois
+//    (privatisations). L'override stocke `nb_jours = 1` pour (mardi, soir, Privat).
+//    Le budget est AFFECTÉ à un seul mardi du mois (par défaut le dernier),
+//    pas réparti sur tous les mardis. Les autres mardis affichent 0 pour cette
+//    cellule → le cumul mensuel reste juste et la coloration jour-par-jour
+//    reste fiable.
+//    Voir buildElectedDatesMap + isCellElectedForDate.
 //
-// Note : ce module ne traite QUE les overrides par lieu. Les overrides
-// service ou globaux (lieu_service_id null) représentent des fermetures
-// exceptionnelles → comportement existant (ratio nb_jours/calendaire) conservé
-// dans les pages qui en ont besoin.
+// 2. Override GLOBAL ou SERVICE (lieu_service_id null) → modèle "ratio"
+//    Cas d'usage : "ce mois j'ai 4 vendredis effectifs au lieu de 5 calendaires"
+//    (un vendredi férié, par exemple). L'override stocke nb_jours=4 pour
+//    (vendredi, service ou null, null). On applique un ratio nb_jours/naturel
+//    à TOUTES les cellules vendredi → leur somme totale donne 4 vendredis
+//    équivalents au lieu de 5. Le ratio est lissé, ce qui est l'approximation
+//    correcte sur un total mensuel quand on ne sait pas QUEL vendredi est fermé.
+//    Voir ratioOverrideForCell.
+//
+// Les deux mécanismes coexistent : pour une cellule donnée on applique l'un
+// OU l'autre, jamais les deux. Une cellule avec override par lieu (Privat)
+// est traitée en "dates élues" et N'EST PAS soumise au ratio (skip ratio).
 
 // Compte le nombre d'occurrences d'un jour-de-semaine ISO (1=lun .. 7=dim)
 // dans le mois donné (mois 1-12).
@@ -98,4 +107,59 @@ export function isCellElectedForDate(cell, isoDate, annee, mois, electedDatesMap
   const elected = electedDatesMap.get(key)
   if (!elected) return true
   return elected.has(isoDate)
+}
+
+// Compte le nombre d'occurrences naturel d'un jour-de-semaine ISO (1..7)
+// dans le mois calendaire entier. Utilisé pour calculer le ratio override.
+// Doublon de la fonction du même nom déjà exportée plus haut ? NON : la version
+// ci-dessus est appelée par pickLastNOccurrencesOfDow. On la garde unique.
+
+// ── Ratio override (mécanisme 2 : global / service) ────────────────────────
+//
+// Construit un Map<key, nb_jours> indexable par (annee, mois, jds, service,
+// lieu) avec priorité décroissante (lieu, svc) > (NULL, svc) > (NULL, NULL).
+// Pour les overrides PAR LIEU, on stocke aussi mais la valeur n'est lue que
+// si un caller appelle ratioOverrideForCell avec un lieu spécifique. En
+// pratique, les pages qui utilisent le ratio passent `null` comme lieu pour
+// les cellules dont l'override par lieu est déjà géré via dates élues.
+export function buildOverridesRatioMap(joursOverrideRows) {
+  const out = new Map()
+  for (const o of (joursOverrideRows || [])) {
+    const annee = Number(o.annee)
+    const mois = Number(o.mois)
+    const jds = Number(o.jour_semaine)
+    const nb = Number(o.nb_jours)
+    if (!Number.isFinite(annee) || !Number.isFinite(mois) || !Number.isFinite(jds) || !Number.isFinite(nb)) continue
+    const svcKey = o.service ?? '__all__'
+    const lieuKey = o.lieu_service_id ?? '__all__'
+    out.set(`${annee}_${mois}_${jds}_${svcKey}_${lieuKey}`, nb)
+  }
+  return out
+}
+
+// Lookup ratio nb_jours/naturel pour une cellule donnée. Priorité décroissante :
+//   1. override spécifique au lieu + service
+//   2. override service-only (lieu = null)
+//   3. override jds-only (service = null, lieu = null)
+//   4. ratio = 1 (pas d'override applicable)
+//
+// `lieu` peut être null pour ne pas tenter la priorité 1 (utile quand l'override
+// par lieu est déjà géré par dates élues ailleurs et qu'on veut juste appliquer
+// le ratio global/service ici).
+export function ratioOverrideForCell(overridesMap, annee, mois, jds, lieu, service) {
+  if (!overridesMap) return 1
+  const prefix = `${annee}_${mois}_${jds}_`
+  const lieuKey = lieu ?? '__all__'
+  const keys = [
+    `${prefix}${service}_${lieuKey}`,
+    `${prefix}${service}_${'__all__'}`,
+    `${prefix}${'__all__'}_${'__all__'}`,
+  ]
+  let nbJours = null
+  for (const k of keys) {
+    if (overridesMap.has(k)) { nbJours = overridesMap.get(k); break }
+  }
+  if (nbJours == null) return 1
+  const naturel = countIsoJdsInMonth(annee, mois, jds)
+  return naturel > 0 ? nbJours / naturel : 1
 }

--- a/lib/rapportHebdo.js
+++ b/lib/rapportHebdo.js
@@ -7,7 +7,12 @@
 // renvoie des objets dérivés (testable, réutilisable côté export HTML).
 
 import { TVA_FOOD, TVA_BEV_20, TVA_BEV_10, TVA_AUTRE } from './caAnalyses'
-import { buildElectedDatesMap, isCellElectedForDate } from './caJoursHelpers'
+import {
+  buildElectedDatesMap,
+  isCellElectedForDate,
+  buildOverridesRatioMap,
+  ratioOverrideForCell,
+} from './caJoursHelpers'
 
 // ── Constantes ─────────────────────────────────────────────────────────────
 
@@ -74,13 +79,33 @@ function buildMonthCellMap(budgetRows, annee, mois) {
   return cellMap
 }
 
+// Retourne le ratio (nb_jours/calendaire) à appliquer à une cellule pour
+// les overrides GLOBAL ou SERVICE uniquement. On passe `lieu=null` à
+// ratioOverrideForCell : les overrides PAR LIEU sont gérés séparément via
+// le mécanisme "dates élues" (isCellElectedForDate), pas via ratio. Ça évite
+// le double-comptage (skip pour cellule élue puis ajout via dates élues
+// uniquement).
+//
+// Cas type chez Joia : override vendredi nb_jours=4 (global) sur mois à 5
+// vendredis → ratio 4/5 = 0.8 appliqué à toutes les cellules vendredi
+// (Resto Joia midi + soir). Total mensuel = 4 vendredis équivalents au lieu
+// de 5 calendaires.
+function ratioGlobalServiceForCell(overridesMap, annee, mois, cell) {
+  if (!overridesMap || overridesMap.size === 0) return 1
+  return ratioOverrideForCell(overridesMap, annee, mois, cell.jour_semaine, null, cell.service)
+}
+
 // Renvoie le budget cumulé sur [debut, fin].
 // `joursFermesIso` (optionnel) : Set<string> de dates ISO à exclure.
-// `joursOverrideRows` (optionnel) : rows ca_budget_jours_override pour
-// respecter les overrides par lieu — une cellule avec override « 1 mardi/mois »
-// n'est comptée que pour le dernier mardi du mois (cf. caJoursHelpers).
+// `joursOverrideRows` (optionnel) : rows ca_budget_jours_override.
+//   - Overrides PAR LIEU : modèle "dates élues" (cellule comptée uniquement
+//     pour le N derniers jours-de-semaine du mois).
+//   - Overrides GLOBAL/SERVICE : ratio (nb_jours/calendaire) appliqué à toutes
+//     les cellules concernées. Ex : "vendredi=4 sur mois à 5 vendredis" → toutes
+//     les cellules vendredi multipliées par 4/5.
 export function periodBudget(budgetRows, debut, fin, joursFermesIso = null, joursOverrideRows = null) {
   const electedMap = buildElectedDatesMap(joursOverrideRows)
+  const overridesRatioMap = buildOverridesRatioMap(joursOverrideRows)
   const cellCache = new Map()
   const getCells = (annee, mois) => {
     const key = `${annee}_${mois}`
@@ -97,11 +122,12 @@ export function periodBudget(budgetRows, debut, fin, joursFermesIso = null, jour
     for (const cell of cells.values()) {
       if (cell.jour_semaine !== d.isoJds) continue
       if (!isCellElectedForDate(cell, d.iso, annee, mois, electedMap)) continue
-      total +=
+      const cellTotal =
         Number(cell.ca_food_cible || 0) +
         Number(cell.ca_bev_20_cible || 0) +
         Number(cell.ca_bev_10_cible || 0) +
         Number(cell.ca_autre_cible || 0)
+      total += cellTotal * ratioGlobalServiceForCell(overridesRatioMap, annee, mois, cell)
     }
   }
   return total
@@ -144,8 +170,9 @@ export function tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin, jours
     acc.ca += Number(r.ca_food || 0) + Number(r.ca_bev_20 || 0) + Number(r.ca_bev_10 || 0) + Number(r.ca_autre || 0)
   }
   // Budget : agrège sur chaque jour ouvré du période × jds matchant, en
-  // respectant les overrides par lieu (dates élues).
+  // respectant les overrides par lieu (dates élues) et global/service (ratio).
   const electedMap = buildElectedDatesMap(joursOverrideRows)
+  const overridesRatioMap = buildOverridesRatioMap(joursOverrideRows)
   const budgetMap = new Map() // key = `${lieu}_${svc}` → { couverts_cible, ca_cible }
   const cacheBudgetByMonth = new Map()
   const getCellsForMonth = (annee, mois) => {
@@ -162,15 +189,17 @@ export function tmParLieuService(caRows, budgetRows, lieuxMap, debut, fin, jours
     for (const cell of cells.values()) {
       if (cell.jour_semaine !== d.isoJds) continue
       if (!isCellElectedForDate(cell, d.iso, annee, mois, electedMap)) continue
+      const ratio = ratioGlobalServiceForCell(overridesRatioMap, annee, mois, cell)
       const key = `${cell.lieu_service_id}_${cell.service}`
       if (!budgetMap.has(key)) budgetMap.set(key, { couverts_cible: 0, ca_cible: 0 })
       const acc = budgetMap.get(key)
-      acc.couverts_cible += Number(cell.couverts_cible || 0)
-      acc.ca_cible +=
+      acc.couverts_cible += Number(cell.couverts_cible || 0) * ratio
+      acc.ca_cible += (
         Number(cell.ca_food_cible || 0) +
         Number(cell.ca_bev_20_cible || 0) +
         Number(cell.ca_bev_10_cible || 0) +
         Number(cell.ca_autre_cible || 0)
+      ) * ratio
     }
   }
   // Construit la sortie : 1 ligne par (lieu, service) qui apparaît dans
@@ -230,8 +259,9 @@ export function tmFoodBevParService(caRows, budgetRows, debut, fin, joursFermesI
     real[svc].bev += Number(r.ca_bev_20 || 0) + Number(r.ca_bev_10 || 0)
   }
   // Budget par service — on parcourt les jours du période et on agrège,
-  // en respectant les overrides par lieu (dates élues).
+  // en respectant les overrides par lieu (dates élues) et global/service (ratio).
   const electedMap = buildElectedDatesMap(joursOverrideRows)
+  const overridesRatioMap = buildOverridesRatioMap(joursOverrideRows)
   const budget = {
     lunch: { couverts: 0, food: 0, bev: 0 },
     dinner: { couverts: 0, food: 0, bev: 0 },
@@ -251,10 +281,11 @@ export function tmFoodBevParService(caRows, budgetRows, debut, fin, joursFermesI
     for (const cell of cells.values()) {
       if (cell.jour_semaine !== d.isoJds) continue
       if (!isCellElectedForDate(cell, d.iso, annee, mois, electedMap)) continue
+      const ratio = ratioGlobalServiceForCell(overridesRatioMap, annee, mois, cell)
       const svc = cell.service === 'lunch' ? 'lunch' : 'dinner'
-      budget[svc].couverts += Number(cell.couverts_cible || 0)
-      budget[svc].food += Number(cell.ca_food_cible || 0)
-      budget[svc].bev += Number(cell.ca_bev_20_cible || 0) + Number(cell.ca_bev_10_cible || 0)
+      budget[svc].couverts += Number(cell.couverts_cible || 0) * ratio
+      budget[svc].food += Number(cell.ca_food_cible || 0) * ratio
+      budget[svc].bev += (Number(cell.ca_bev_20_cible || 0) + Number(cell.ca_bev_10_cible || 0)) * ratio
     }
   }
   const make = (real, budget) => {
@@ -313,8 +344,9 @@ export function couvertsParService(caRows, budgetRows, debut, fin, joursFermesIs
     else realDinner += Number(r.couverts || 0)
   }
   // Budget : somme couverts_cible par service sur la période, en respectant
-  // les overrides par lieu (dates élues).
+  // les overrides par lieu (dates élues) et global/service (ratio).
   const electedMap = buildElectedDatesMap(joursOverrideRows)
+  const overridesRatioMap = buildOverridesRatioMap(joursOverrideRows)
   let budgetLunch = 0
   let budgetDinner = 0
   const cache = new Map()
@@ -332,8 +364,10 @@ export function couvertsParService(caRows, budgetRows, debut, fin, joursFermesIs
     for (const cell of cells.values()) {
       if (cell.jour_semaine !== d.isoJds) continue
       if (!isCellElectedForDate(cell, d.iso, annee, mois, electedMap)) continue
-      if (cell.service === 'lunch') budgetLunch += Number(cell.couverts_cible || 0)
-      else budgetDinner += Number(cell.couverts_cible || 0)
+      const ratio = ratioGlobalServiceForCell(overridesRatioMap, annee, mois, cell)
+      const couvertsValeur = Number(cell.couverts_cible || 0) * ratio
+      if (cell.service === 'lunch') budgetLunch += couvertsValeur
+      else budgetDinner += couvertsValeur
     }
   }
   const make = (real, budget) => ({
@@ -365,8 +399,9 @@ export function couvertsJourParJour(caRows, budgetRows, debut, fin, joursFermesI
     else acc.dinner += Number(r.couverts || 0)
   }
   // Budget par jour : agrège tous les lieux pour ce jour-de-semaine, en
-  // respectant les overrides par lieu (dates élues).
+  // respectant les overrides par lieu (dates élues) et global/service (ratio).
   const electedMap = buildElectedDatesMap(joursOverrideRows)
+  const overridesRatioMap = buildOverridesRatioMap(joursOverrideRows)
   const out = []
   const cache = new Map()
   for (const d of eachDayIso(debut, fin)) {
@@ -388,8 +423,10 @@ export function couvertsJourParJour(caRows, budgetRows, debut, fin, joursFermesI
       for (const cell of cells.values()) {
         if (cell.jour_semaine !== d.isoJds) continue
         if (!isCellElectedForDate(cell, d.iso, annee, mois, electedMap)) continue
-        if (cell.service === 'lunch') budgetLunch += Number(cell.couverts_cible || 0)
-        else budgetDinner += Number(cell.couverts_cible || 0)
+        const ratio = ratioGlobalServiceForCell(overridesRatioMap, annee, mois, cell)
+        const couvertsValeur = Number(cell.couverts_cible || 0) * ratio
+        if (cell.service === 'lunch') budgetLunch += couvertsValeur
+        else budgetDinner += couvertsValeur
       }
     }
     const real = realByDay.get(d.iso) || { lunch: 0, dinner: 0 }


### PR DESCRIPTION
## Bug constaté chez Joia mai 2026

- **Rapport hebdo** (cumul mois au 24 mai) : 197 725 €
- **Analyses** (MTD au 25 mai) : 189 145 €
- **Écart constant : 8 580 €**

L'utilisateur voyait deux chiffres différents pour la même métrique sur la même période, après mes 3 PR précédents (#128, #129, #130) qui ont aligné l'aspect « overrides par lieu » entre les pages.

## Cause exacte (investigation DB)

Vérification dans la table `ca_budget_jours_override` pour Joia mai 2026 :
- Override **vendredi nb_jours=4** (lieu_service_id = NULL, dinner ET lunch)
- Mai 2026 a **5 vendredis** calendaires (1, 8, 15, 22, 29)
- → Convention de l'utilisateur : « ce mois j'ai 4 vendredis effectifs (1 férié) »

Vérification dans `ca_budgets` :
- Budget vendredi Resto Joia dinner = 7 700 €
- Budget vendredi Resto Joia lunch = 3 025 €
- **Budget total vendredi = 10 725 €**

Calcul de l'écart :
- **Analyses** appliquait le ratio 4/5 → chaque vendredi compte 10 725 × 0.8 = 8 580 €
- **Rapport hebdo** ignorait l'override → chaque vendredi compte 10 725 €
- Sur 1-24 mai (4 vendredis) : diff = 4 × (10 725 - 8 580) = **8 580 €** ✓ exactement l'écart observé

Le bug est dans Rapport hebdo qui sur-comptait le vendredi férié.

## Fix

Les 5 fonctions de calcul de `lib/rapportHebdo.js` consomment désormais les overrides global/service via `ratioOverrideForCell` :

- `periodBudget` (CA TTC budget)
- `tmParLieuService` (tickets moyens par lieu)
- `tmFoodBevParService` (TM Food/Bev par service)
- `couvertsParService` (couverts midi/soir)
- `couvertsJourParJour` (couverts détaillés)

Pour chaque cellule budgétée, après le filtre dates élues (PR #128), on multiplie par `ratioGlobalServiceForCell` qui retourne :
- 1 si pas d'override global/service applicable
- nb_jours/calendaire sinon (ex : 4/5 pour vendredi)

Les overrides PAR LIEU restent gérés via dates élues (PR #128), pas via ratio. Pas de double comptage.

## Helpers factorisés

Nouveau dans `caJoursHelpers.js` :
- `buildOverridesRatioMap(rows)` : index Map<key, nb_jours>
- `ratioOverrideForCell(map, annee, mois, jds, lieu, svc)` : lookup avec priorité (lieu, svc) > (NULL, svc) > (NULL, NULL)

`caAnalyses.js` garde sa version locale pour limiter le risque de régression (unification possible ultérieurement).

## Validation

Calcul théorique attendu après fix sur Rapport hebdo Joia mai 2026 :
- Sur 1-24 mai : 197 725 - 8 580 = **189 145 €** = exactement Analyses MTD ✓

## Test plan

- [ ] Recharger Rapport hebdo Joia : le cumul mois doit afficher 189 145 € (cohérent avec Analyses)
- [ ] Aller sur la semaine en cours (18-24 mai) : le budget semaine doit avoir baissé proportionnellement (1 vendredi de moins compté à plein, soit 2 145 € en moins)
- [ ] Tableau couverts jour-par-jour : les vendredis affichent désormais leurs couverts × 0.8 (au lieu de 100 %)
- [ ] Tickets moyens par lieu : la cellule Resto Joia vendredi reflète aussi le ratio
- [ ] **708 tests Vitest** passent, dont 4 nouveaux cas reproduisant le scénario Joia exact
- [ ] Aucune régression sur les autres clients : les pages sans override global/service ne changent rien

🤖 Generated with [Claude Code](https://claude.com/claude-code)