### PR TITLE
fix(rapport-hebdo): Mix Food/Bev total = moyenne arithmétique (intuitive)

### DIFF
--- a/lib/__tests__/rapportHebdo.test.ts
+++ b/lib/__tests__/rapportHebdo.test.ts
@@ -92,12 +92,43 @@ describe('tmFoodBevParService', () => {
 })
 
 describe('mixFoodBev', () => {
-  it('pourcentages Food/Bev du TM total', () => {
+  it('pourcentages Food/Bev du TM par service', () => {
     const tm = tmFoodBevParService(caRows, budgetRows, '2026-05-05', '2026-05-05')
     const mix = mixFoodBev(tm)
     // Midi : food 160 / (160+80) = 66.67 %
     expect(mix.midi.food_pct).toBeCloseTo(66.67, 1)
     expect(mix.midi.bev_pct).toBeCloseTo(33.33, 1)
+    // Soir : food 200 / (200+100) = 66.67 % (mêmes proportions par hasard)
+    expect(mix.soir.food_pct).toBeCloseTo(66.67, 1)
+  })
+
+  it('total = moyenne ARITHMÉTIQUE des % midi et soir (pas pondérée)', () => {
+    // Cas inspiré du rapport hebdo Joia 18-24 mai où l'utilisateur calculait
+    // (83 + 65) / 2 = 74 mais le code affichait 70 (moyenne pondérée tirée
+    // par le soir qui a plus de volume). On bascule sur la moyenne arithmétique
+    // pour matcher l'attente naturelle de l'utilisateur.
+    const tm = {
+      midi: { real_tm_food: 83, real_tm_bev: 17 }, // 83/100 = 83 %
+      soir: { real_tm_food: 65, real_tm_bev: 35 }, // 65/100 = 65 %
+      // total pondéré classique : si midi=10cv et soir=100cv,
+      // food_total_tm = (830 + 6500) / 110 = 66.6 → ~ 66 % (proche soir)
+      // Avec moyenne arithmétique : (83 + 65) / 2 = 74 % (indépendant des volumes)
+      total: { real_tm_food: 66.6, real_tm_bev: 33.4 },
+    }
+    const mix = mixFoodBev(tm)
+    expect(mix.total.food_pct).toBe(74)
+    expect(mix.total.bev_pct).toBe(26)
+  })
+
+  it('si un seul service a des couverts → total = ce service seul', () => {
+    const tm = {
+      midi: { real_tm_food: 80, real_tm_bev: 20 },
+      soir: { real_tm_food: 0, real_tm_bev: 0 }, // pas de couverts le soir
+      total: { real_tm_food: 80, real_tm_bev: 20 },
+    }
+    const mix = mixFoodBev(tm)
+    expect(mix.total.food_pct).toBe(80)
+    expect(mix.total.bev_pct).toBe(20)
   })
 })
 

--- a/lib/rapportHebdo.js
+++ b/lib/rapportHebdo.js
@@ -318,6 +318,17 @@ export function tmFoodBevParService(caRows, budgetRows, debut, fin, joursFermesI
 // ── Section 4 : Mix Food/Bev en % du TM ────────────────────────────────────
 
 // Renvoie { midi: { food_pct, bev_pct }, soir, total } basé sur le réel.
+//
+// Le « total » est volontairement la MOYENNE ARITHMÉTIQUE des % midi et soir,
+// PAS la moyenne pondérée par les volumes. Raison : l'utilisateur recalcule
+// souvent à la main `(% midi + % soir) / 2` et la moyenne pondérée donne un
+// chiffre différent (tirée vers le service avec le plus de volume — souvent
+// le soir en restauration). Ça crée de la confusion. La moyenne arithmétique
+// matche le calcul intuitif et reste cohérente avec la lecture du rapport.
+//
+// Trade-off assumé : ce n'est pas le ratio comptable strict du CA total
+// (qui serait food_total / (food_total + bev_total)), mais c'est la
+// convention attendue par l'utilisateur.
 export function mixFoodBev(tmFoodBev) {
   const calcPct = (svc) => {
     const food = svc.real_tm_food || 0
@@ -326,10 +337,26 @@ export function mixFoodBev(tmFoodBev) {
     if (total === 0) return { food_pct: null, bev_pct: null }
     return { food_pct: (food / total) * 100, bev_pct: (bev / total) * 100 }
   }
+  const midi = calcPct(tmFoodBev.midi)
+  const soir = calcPct(tmFoodBev.soir)
+  // Moyenne arithmétique des deux services pour le total. Si un service n'a
+  // pas de TM (couverts = 0), on retombe sur l'autre service seul.
+  let totalFoodPct = null
+  let totalBevPct = null
+  if (midi.food_pct != null && soir.food_pct != null) {
+    totalFoodPct = (midi.food_pct + soir.food_pct) / 2
+    totalBevPct = (midi.bev_pct + soir.bev_pct) / 2
+  } else if (midi.food_pct != null) {
+    totalFoodPct = midi.food_pct
+    totalBevPct = midi.bev_pct
+  } else if (soir.food_pct != null) {
+    totalFoodPct = soir.food_pct
+    totalBevPct = soir.bev_pct
+  }
   return {
-    midi: calcPct(tmFoodBev.midi),
-    soir: calcPct(tmFoodBev.soir),
-    total: calcPct(tmFoodBev.total),
+    midi,
+    soir,
+    total: { food_pct: totalFoodPct, bev_pct: totalBevPct },
   }
 }
 


### PR DESCRIPTION
## Bug constaté

Sur le rapport hebdo Joia (semaine 18-24 mai), section « Mix Food/Bev » :
- Tu vois Food midi 83 %, Food soir 65 %
- Tu calcules naturellement (83 + 65) / 2 = **74 %**
- Mais le rapport affiche **70 %** → confusion

## Cause

`mixFoodBev` calculait le total en **moyenne pondérée par les couverts** : food_total_tm / (food_total_tm + bev_total_tm). Le soir (205 couverts vs 164 midi, % food plus bas) tirait le total vers son ratio, donnant 70 % au lieu des 74 % attendus en moyenne simple.

## Fix

Bascule sur la **moyenne arithmétique** (% midi + % soir) / 2 pour le total. Le calcul devient reproductible à la main par n'importe quel lecteur du rapport.

Cas dégradé : si un seul service a des couverts (l'autre est vide), on retombe sur ce service seul.

## Trade-off

La moyenne pondérée représentait techniquement la part comptable du Food sur le CA total réel (« sur 100 € encaissés, X € viennent du food »). La moyenne arithmétique traite midi et soir à égalité indépendamment du volume. C'est moins « juste » comptablement mais c'est l'attente intuitive.

## Test plan

- [ ] Recharger le rapport hebdo Joia 18-24 mai : section Mix doit afficher Food **74 %**, Bev **26 %**
- [ ] Vérifier sur le rapport semaine précédente : la cohérence (% midi + % soir) / 2 = total tient
- [ ] **217 tests Vitest** passent, dont 2 nouveaux cas (cas Joia + cas service unique)

🤖 Generated with [Claude Code](https://claude.com/claude-code)