### PR TITLE
feat(fiches): instructions à la création + impression portrait

### DIFF
--- a/app/bar/fiches/[id]/page.js
+++ b/app/bar/fiches/[id]/page.js
@@ -36,7 +36,7 @@ export default function BarFicheDetail() {
         .print-only { display: block !important; }
         .print-instructions { page-break-before: always; margin-top: 0 !important; }
         body { background: white !important; margin: 0; padding: 0; }
-        @page { margin: 15mm 15mm 15mm 15mm; }
+        @page { size: A4 portrait; margin: 15mm 15mm 15mm 15mm; }
       }
       @media screen {
         .print-only { display: none !important; }

--- a/app/bar/fiches/nouvelle/page.js
+++ b/app/bar/fiches/nouvelle/page.js
@@ -24,6 +24,7 @@ export default function NouvelleBarFiche() {
   const [prixTTC, setPrixTTC] = useState('')
   const [perte, setPerte] = useState(0)
   const [description, setDescription] = useState('')
+  const [instructions, setInstructions] = useState('')
   const [saison, setSaison] = useState('')
   const [annee, setAnnee] = useState(new Date().getFullYear())
   const [allergenes, setAllergenes] = useState([])
@@ -58,7 +59,7 @@ export default function NouvelleBarFiche() {
     }))
   ]
 
-  const autosaveData = { nom, categoriePlat, lieuId, nbPortions, prixTTC, perte, description, saison, annee, allergenes, ingredients }
+  const autosaveData = { nom, categoriePlat, lieuId, nbPortions, prixTTC, perte, description, instructions, saison, annee, allergenes, ingredients }
   const annees = getYearsRange()
   const { hasDraft, lastSaved, getDraft, clearDraft } = useAutosave('nouvelle-fiche-bar-draft', autosaveData, 60000)
 
@@ -119,6 +120,7 @@ export default function NouvelleBarFiche() {
     setPrixTTC(draft.prixTTC || '')
     setPerte(draft.perte || 0)
     setDescription(draft.description || '')
+    setInstructions(draft.instructions || '')
     setSaison(draft.saison || '')
     setAnnee(draft.annee || new Date().getFullYear())
     setAllergenes(draft.allergenes || [])
@@ -217,7 +219,8 @@ export default function NouvelleBarFiche() {
         lieu_id: lieuId || null,
         nb_portions: parseInt(nbPortions),
         prix_ttc: isSousFiche ? null : (prixTTC ? parseFloat(prixTTC) : null),
-        description, saison: saison || null, annee: annee || null, allergenes,
+        description, instructions: instructions || null,
+        saison: saison || null, annee: annee || null, allergenes,
         cout_portion: coutPortion ? parseFloat(coutPortion) : null,
         unite_production: uniteProduction,
         perte: perte ? parseFloat(perte) : 0,
@@ -434,6 +437,21 @@ export default function NouvelleBarFiche() {
               />
             </div>
           </div>
+        </Card>
+
+        {/* Instructions de préparation */}
+        <Card c={c} style={{ marginBottom: '12px' }}>
+          <div className="sk-label-muted" style={{ fontSize: '13px', color: c.texteMuted, marginBottom: '6px' }}>📋 Instructions de préparation</div>
+          <div style={{ fontSize: '12px', color: c.texteMuted, marginBottom: '12px' }}>Les sauts de ligne seront respectés à l'écran et à l'impression.</div>
+          <textarea value={instructions} onChange={e => setInstructions(e.target.value)} rows={8}
+            placeholder={`1. Givrer le verre au sucre...\n2. Frapper au shaker...\n\nDressage :\n- Zeste de citron...`}
+            style={{ width: '100%', padding: '12px', borderRadius: '8px', border: `0.5px solid ${c.bordure}`, fontSize: '14px', outline: 'none', resize: 'vertical', fontFamily: 'inherit', color: c.texte, background: c.blanc, lineHeight: '1.7', minHeight: '180px' }}
+          />
+          {instructions && (
+            <div style={{ marginTop: '8px', fontSize: '12px', color: c.texteMuted }}>
+              {instructions.split('\n').length} ligne{instructions.split('\n').length > 1 ? 's' : ''} — {instructions.length} caractères
+            </div>
+          )}
         </Card>
 
         {/* Ingrédients */}

--- a/app/fiches/[id]/page.js
+++ b/app/fiches/[id]/page.js
@@ -40,7 +40,7 @@ export default function FicheDetail() {
         .print-only { display: block !important; }
         .print-instructions { page-break-before: always; margin-top: 0 !important; }
         body { background: white !important; margin: 0; padding: 0; }
-        @page { margin: 15mm 15mm 15mm 15mm; }
+        @page { size: A4 portrait; margin: 15mm 15mm 15mm 15mm; }
       }
       @media screen {
         .print-only { display: none !important; }

--- a/app/fiches/nouvelle/page.js
+++ b/app/fiches/nouvelle/page.js
@@ -26,6 +26,7 @@ export default function NouvelleFiche() {
   const [prixTTC, setPrixTTC] = useState('')
   const [perte, setPerte] = useState(0)
   const [description, setDescription] = useState('')
+  const [instructions, setInstructions] = useState('')
   const [saison, setSaison] = useState('')
   const [annee, setAnnee] = useState(new Date().getFullYear())
   const [allergenes, setAllergenes] = useState([])
@@ -50,7 +51,7 @@ export default function NouvelleFiche() {
   const catSelectionnee = categoriesDyn.find(cat => cat.id === categoriePlat)
   const isSousFiche = catSelectionnee?.nom === 'Sous-fiches' || catSelectionnee?.nom === 'Sous-fiche'
 
-  const autosaveData = { nom, categoriePlat, lieuId, nbPortions, unitePortions, prixTTC, perte, description, saison, annee, allergenes, ingredients }
+  const autosaveData = { nom, categoriePlat, lieuId, nbPortions, unitePortions, prixTTC, perte, description, instructions, saison, annee, allergenes, ingredients }
   const { hasDraft, lastSaved, getDraft, clearDraft } = useAutosave('nouvelle-fiche-draft', autosaveData, 60000)
 
   useEffect(() => {
@@ -100,6 +101,7 @@ export default function NouvelleFiche() {
     setPrixTTC(draft.prixTTC || '')
     setPerte(draft.perte || 0)
     setDescription(draft.description || '')
+    setInstructions(draft.instructions || '')
     setSaison(draft.saison || '')
     setAnnee(draft.annee || new Date().getFullYear())
     setAllergenes(draft.allergenes || [])
@@ -191,7 +193,8 @@ export default function NouvelleFiche() {
       is_sub_fiche: !!isSousFiche,
       nb_portions: parseInt(nbPortions),
       prix_ttc: isSousFiche ? null : (prixTTC ? parseFloat(prixTTC) : null),
-      description, saison: saison || null, annee: annee || null, allergenes,
+      description, instructions: instructions || null,
+      saison: saison || null, annee: annee || null, allergenes,
       cout_portion: coutPortion ? parseFloat(coutPortion) : null,
       perte: perte ? parseFloat(perte) : 0,
       client_id: clientId
@@ -440,6 +443,21 @@ export default function NouvelleFiche() {
             </div>
           </div>
         </div>
+
+        {/* Instructions de préparation */}
+        <Card c={c} style={{ marginBottom: '12px' }}>
+          <div className="sk-label-muted" style={{ fontSize: '13px', color: c.texteMuted, marginBottom: '6px' }}>📋 Instructions de préparation</div>
+          <div style={{ fontSize: '12px', color: c.texteMuted, marginBottom: '12px' }}>Les sauts de ligne seront respectés à l'écran et à l'impression.</div>
+          <textarea value={instructions} onChange={e => setInstructions(e.target.value)} rows={8}
+            placeholder={`1. Préparer la marinade...\n2. Saisir la viande à feu vif...\n\nDressage :\n- Disposer les légumes...`}
+            style={{ width: '100%', padding: '12px', borderRadius: '8px', border: `0.5px solid ${c.bordure}`, fontSize: '14px', outline: 'none', resize: 'vertical', fontFamily: 'inherit', color: c.texte, background: c.blanc, lineHeight: '1.7', minHeight: '180px' }}
+          />
+          {instructions && (
+            <div style={{ marginTop: '8px', fontSize: '12px', color: c.texteMuted }}>
+              {instructions.split('\n').length} ligne{instructions.split('\n').length > 1 ? 's' : ''} — {instructions.length} caractères
+            </div>
+          )}
+        </Card>
 
         {/* Ingrédients */}
         <Card c={c} style={{ marginBottom: '12px' }}>


### PR DESCRIPTION
## Summary

- Ajoute le champ **📋 Instructions de préparation** sur les pages de **création** de fiche (cuisine + bar) — il n'existait qu'en édition, du coup il fallait créer puis rouvrir pour le saisir.
- Force l'orientation **portrait** à l'impression des fiches techniques (cuisine + bar). Le défaut `landscape` venait de `app/globals.css` (probablement voulu pour la carte), donc on l'override uniquement sur les pages détail fiche.

## Fichiers touchés

- `app/fiches/nouvelle/page.js` — state, autosave, insert, UI Card avec textarea identique à la page modifier
- `app/bar/fiches/nouvelle/page.js` — idem, placeholder cocktail
- `app/fiches/[id]/page.js` — `@page { size: A4 portrait; … }`
- `app/bar/fiches/[id]/page.js` — idem

## Test plan

- [ ] Aller sur `/fiches/nouvelle` → le bloc "Instructions de préparation" apparaît sous Description
- [ ] Remplir + Enregistrer → la fiche s'affiche avec les instructions à l'écran
- [ ] Imprimer la fiche → A4 portrait, instructions sur la dernière page séparée (`page-break-before: always`)
- [ ] Idem côté bar : `/bar/fiches/nouvelle` + détail
- [ ] L'autosave brouillon restaure aussi les instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)