### PR TITLE
fix(inventaire): import xlsx tolère feuilles cachées

### DIFF
--- a/app/inventaire/import/page.js
+++ b/app/inventaire/import/page.js
@@ -43,18 +43,37 @@ export default function ImportInventairePage() {
     reader.onload = (evt) => {
       try {
         const wb = XLSX.read(evt.target.result, { type: 'binary' })
-        const sheet = wb.Sheets[wb.SheetNames[0]]
-        const rows = XLSX.utils.sheet_to_json(sheet, { header: 1 })
-        const parsed = []
-        for (let i = 1; i < rows.length; i++) {
-          const row = rows[i]
-          if (!row || row.length === 0) continue
-          const nom = String(row[0] || '').trim()
-          const qStr = String(row[1] || '').replace(',', '.').replace(/[^0-9.\-]/g, '')
-          const quantite = parseFloat(qStr)
-          if (!nom || isNaN(quantite)) continue
-          parsed.push({ nom, quantite })
+
+        const parseSheet = (sheet) => {
+          const rows = XLSX.utils.sheet_to_json(sheet, { header: 1 })
+          const out = []
+          for (let i = 1; i < rows.length; i++) {
+            const row = rows[i]
+            if (!row || row.length === 0) continue
+            const nom = String(row[0] || '').trim()
+            const qStr = String(row[1] || '').replace(',', '.').replace(/[^0-9.\-]/g, '')
+            const quantite = parseFloat(qStr)
+            if (!nom || isNaN(quantite)) continue
+            out.push({ nom, quantite })
+          }
+          return out
         }
+
+        // Excel peut masquer des feuilles vides en première position : on scanne
+        // d'abord les feuilles visibles, puis les masquées en fallback, et on prend
+        // la première qui contient au moins une ligne valide.
+        const sheetMeta = wb.Workbook?.Sheets || []
+        const isHidden = (i) => (sheetMeta[i]?.Hidden ?? 0) !== 0
+        const visible = wb.SheetNames.filter((_, i) => !isHidden(i))
+        const hidden = wb.SheetNames.filter((_, i) => isHidden(i))
+        const ordered = [...visible, ...hidden]
+
+        let parsed = []
+        for (const name of ordered) {
+          parsed = parseSheet(wb.Sheets[name])
+          if (parsed.length > 0) break
+        }
+
         if (parsed.length === 0) {
           setError('Aucune ligne valide trouvée. Vérifie le format : colonne A = Nom, colonne B = Quantité.')
           setLignes([])


### PR DESCRIPTION
## Summary

L'import xlsx d'inventaire échouait avec *« Aucune ligne valide trouvée »* sur des fichiers où Excel masque une feuille vide (`Transferts`, `Data`…) avant la feuille de données. Le parser prenait toujours `SheetNames[0]` — la feuille cachée vide — alors que l'utilisateur ne voit qu'un seul onglet dans Excel.

- Scan désormais les feuilles dans l'ordre **visibles → cachées**
- Retient la première feuille avec au moins une ligne `(Nom, Quantité)` valide
- Pas de changement de comportement pour les fichiers à une seule feuille

## Test plan

- [ ] Re-uploader le fichier *RATIO FOOD OFF MARSAN AVRIL 2026 OFFICIEL 2.xlsx* (3 feuilles dont 2 cachées) → 266 lignes détectées
- [ ] Uploader un fichier à une seule feuille → comportement inchangé
- [ ] Télécharger le modèle, le remplir, l'uploader → marche

🤖 Generated with [Claude Code](https://claude.com/claude-code)