### PR TITLE
feat(inventaire): valeur de chaque inventaire dans la liste

### DIFF
--- a/app/inventaire/page.js
+++ b/app/inventaire/page.js
@@ -15,6 +15,7 @@ import {
 export default function InventairePage() {
   const [inventaires, setInventaires] = useState([])
   const [dernierLignes, setDernierLignes] = useState([])
+  const [valeurParInv, setValeurParInv] = useState({})
   const [loading, setLoading] = useState(true)
   const [filtre, setFiltre] = useState('tous')
   const [deleting, setDeleting] = useState(null)
@@ -61,6 +62,26 @@ export default function InventairePage() {
       setDernierLignes(lignes || [])
     } else {
       setDernierLignes([])
+    }
+
+    // Total par inventaire pour l'affichage en liste (somme valeur_stock).
+    // Une seule requête filtrée par client_id puis agrégation client-side —
+    // bien plus simple qu'un view SQL et largement OK pour ce volume.
+    const invIds = (data || []).map(i => i.id)
+    if (invIds.length > 0) {
+      const { data: allLignes } = await supabase
+        .from('inventaire_lignes')
+        .select('inventaire_id, valeur_stock')
+        .eq('client_id', clientId)
+        .in('inventaire_id', invIds)
+      const totals = {}
+      for (const l of allLignes || []) {
+        const v = Number(l.valeur_stock) || 0
+        totals[l.inventaire_id] = (totals[l.inventaire_id] || 0) + v
+      }
+      setValeurParInv(totals)
+    } else {
+      setValeurParInv({})
     }
 
     setLoading(false)
@@ -321,6 +342,14 @@ export default function InventairePage() {
                 </div>
 
                 <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                  {valeurParInv[inv.id] != null && (
+                    <div style={{ textAlign: 'right', minWidth: '70px' }}>
+                      <div style={{ fontSize: '14px', fontWeight: '600', color: c.texte, whiteSpace: 'nowrap' }}>
+                        {formatEur(valeurParInv[inv.id])}
+                      </div>
+                      <div style={{ fontSize: '10px', color: c.texteMuted, marginTop: '2px' }}>Valeur</div>
+                    </div>
+                  )}
                   {(role === 'admin' || role === 'cuisine' || role === 'bar') && inv.statut === 'brouillon' && (
                     <button
                       onClick={(e) => { e.stopPropagation(); router.push(`/inventaire/${inv.id}/saisie${queryString}`) }}


### PR DESCRIPTION
## Summary

Sur la page `/inventaire`, chaque ligne de la liste affiche désormais la valeur totale du stock (somme de `valeur_stock`) à droite, avant les boutons d'action. Plus besoin d'ouvrir le détail pour comparer les valorisations.

## Implémentation

Une requête supplémentaire dans `loadInventaires` qui charge `{inventaire_id, valeur_stock}` pour tous les inventaires du client (filtrés par `client_id` + `in(inventaire_ids)`), puis agrégation client-side dans un objet `{[id]: total}`. Pas de vue SQL ni de cache dénormalisé — simple, suffit largement pour le volume actuel.

## Test plan

- [ ] Liste affiche la valeur formatée en € à droite de chaque inventaire (brouillon + validé)
- [ ] Inventaires sans lignes saisies → bloc valeur absent (ou 0 €)
- [ ] Filtre Flash/Complets → les valeurs restent correctes
- [ ] Pas de régression sur les boutons "Modifier" / "Supprimer" / chevron

🤖 Generated with [Claude Code](https://claude.com/claude-code)