### PR TITLE
feat(fiches): sections étoilées réutilisables (promouvoir / importer) + coût fiabilisé

### DIFF
--- a/app/fiches/[id]/modifier/page.js
+++ b/app/fiches/[id]/modifier/page.js
@@ -18,6 +18,8 @@ import { Card, Alert } from '../../../../components/ui'
 
 import { isIngredientPossible } from '../../../../lib/foodCost'
 import { UNITES_PRODUCTION } from '../../../../lib/constants'
+import { coutLigneEditor } from '../../../../lib/cout'
+import { promoteSectionToSousFiche, loadSousFicheLignes } from '../../../../lib/sousFicheFromSection'
 
 export default function ModifierFiche() {
   const [nom, setNom] = useState('')
@@ -49,6 +51,7 @@ export default function ModifierFiche() {
   // un `section_temp_id` (string) qui pointe vers une section ; NULL = ligne
   // libre (brasserie).
   const [sections, setSections] = useState([])
+  const [sousFichesDispo, setSousFichesDispo] = useState([])
   const router = useRouter()
   const params_route = useParams()
   const { c, logoUrl, nomEtablissement } = useTheme()
@@ -113,6 +116,8 @@ export default function ModifierFiche() {
       est_sous_fiche: true
     }))
     setListeIngredients([...(liste || []), ...sousFichesFormatees])
+    // Sous-fiches importables (hors la fiche courante pour éviter un cycle direct).
+    setSousFichesDispo((sousFiches || []).filter(sf => sf.id !== params_route.id).map(sf => ({ id: sf.id, nom: sf.nom })))
 
     setPhotoPath(ficheData.photo_url || null)
     setNom(ficheData.nom)
@@ -152,7 +157,8 @@ export default function ModifierFiche() {
       tempId: s.id,
       dbId: s.id,
       nom: s.nom || '',
-      descriptif: s.descriptif || ''
+      descriptif: s.descriptif || '',
+      sous_fiche_id: s.sous_fiche_id || null
     }))
     setSections(sectionsLocales)
 
@@ -216,9 +222,54 @@ export default function ModifierFiche() {
   const calculerCout = () => {
     return ingredients.reduce((total, ing) => {
       const ingData = listeIngredients.find(i => i.id === ing.ingredient_id)
-      if (ingData?.prix_kg && ing.quantite) return total + (ingData.prix_kg * parseFloat(ing.quantite))
-      return total
+      return total + coutLigneEditor(ingData, ing.quantite, ing.unite)
     }, 0)
+  }
+
+  // Sous-fiches importables comme section.
+  const listeSousFiches = sousFichesDispo
+  const categorieSousFiche = categoriesDyn.find(cat => cat.nom === 'Sous-fiches' || cat.nom === 'Sous-fiche') || null
+
+  // Recharge le catalogue d'ingrédients (après promotion d'une section).
+  const rechargerIngredients = async () => {
+    const cid = await getClientId()
+    if (!cid) return
+    const [{ data: liste }, { data: sousFiches }] = await Promise.all([
+      supabase.from('ingredients').select('*').eq('client_id', cid).order('nom').limit(5000),
+      supabase.from('fiches').select('id, nom, cout_portion').eq('client_id', cid).eq('is_sub_fiche', true).eq('archive', false).order('nom'),
+    ])
+    const sousFichesFormatees = (sousFiches || []).map(sf => ({ id: sf.id, nom: sf.nom, prix_kg: sf.cout_portion, unite: 'portion', est_sous_fiche: true }))
+    setListeIngredients([...(liste || []), ...sousFichesFormatees])
+    setSousFichesDispo((sousFiches || []).filter(sf => sf.id !== params_route.id).map(sf => ({ id: sf.id, nom: sf.nom })))
+  }
+
+  const handlePromoteSection = async (section, lignes, rendement) => {
+    const cid = await getClientId()
+    if (!cid) throw new Error('Session expirée')
+    const { ficheId } = await promoteSectionToSousFiche({
+      supabase, clientId: cid, section, lignes, listeIngredients, rendement, categorieSousFiche,
+    })
+    setSections(prev => prev.map(s => s.tempId === section.tempId ? { ...s, sous_fiche_id: ficheId } : s))
+    await rechargerIngredients()
+  }
+
+  const handleImportSousFiche = async (sf) => {
+    if (sf.id === params_route.id) throw new Error('Une fiche ne peut pas s\'importer elle-même.')
+    const cid = await getClientId()
+    if (!cid) throw new Error('Session expirée')
+    const { nom: sfNom, instructions, lignes } = await loadSousFicheLignes({ supabase, clientId: cid, sousFicheId: sf.id })
+    // Garde anti-cycle : refuser si la sous-fiche consomme déjà la fiche courante.
+    if (lignes.some(l => l.ingredientFicheId === params_route.id)) {
+      throw new Error('Cycle détecté : cette sous-fiche utilise déjà la fiche courante.')
+    }
+    const tempId = `tmp_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`
+    setSections(prev => [...prev, { tempId, nom: sfNom || sf.nom, descriptif: instructions || '', sous_fiche_id: sf.id }])
+    setIngredients(prev => [
+      ...prev,
+      ...lignes.filter(l => l.ingredient_id).map(l => ({
+        ingredient_id: l.ingredient_id, nom: l.nom, quantite: l.quantite, unite: l.unite, section_temp_id: tempId,
+      })),
+    ])
   }
 
   const calculerCoutAvecPerte = () => {
@@ -310,7 +361,8 @@ export default function ModifierFiche() {
             fiche_id: params_route.id,
             ordre: i,
             nom: (s.nom || '').trim() || `Préparation ${i + 1}`,
-            descriptif: s.descriptif || null
+            descriptif: s.descriptif || null,
+            sous_fiche_id: s.sous_fiche_id || null
           })
           .select('id')
           .single()
@@ -577,6 +629,9 @@ export default function ModifierFiche() {
             ingredients={ingredients}
             setIngredients={setIngredients}
             listeIngredients={listeIngredients}
+            listeSousFiches={listeSousFiches}
+            onPromoteSection={handlePromoteSection}
+            onImportSousFiche={handleImportSousFiche}
             c={c}
             isMobile={isMobile}
           />

--- a/app/fiches/[id]/page.js
+++ b/app/fiches/[id]/page.js
@@ -9,6 +9,7 @@ import { useRole } from '../../../lib/useRole'
 import { log } from '../../../lib/useLog'
 import { ALLERGENES } from '../../../lib/allergenes'
 import { formatSaison } from '../../../lib/saison'
+import { coutLigneAffichage } from '../../../lib/cout'
 import FichePhoto, { FicheHeaderInfo, FicheHeaderInfoStyles } from '../../../components/FichePhoto'
 import { AllergenesBlock, FicheDetailNavbar } from '../../../components/FicheDetailShared'
 import ChefLoader from '../../../components/ChefLoader'
@@ -121,11 +122,7 @@ export default function FicheDetail() {
     }
   }
 
-  const coutIngredient = (ing) => {
-    if (!ing.ingredients?.prix_kg || !ing.quantite) return 0
-    const coef = (ing.unite === 'g' || ing.unite === 'ml') ? 0.001 : (ing.unite === 'cl' ? 0.01 : 1)
-    return ing.ingredients.prix_kg * ing.quantite * coef
-  }
+  const coutIngredient = (ing) => coutLigneAffichage(ing)
 
   const calculerCout = () => ingredients.reduce((total, ing) => total + coutIngredient(ing), 0)
 
@@ -313,7 +310,12 @@ export default function FicheDetail() {
               return (
                 <div key={section.id} style={{ background: c.blanc, borderRadius: '12px', border: `0.5px solid ${c.bordure}`, overflow: 'hidden' }}>
                   <div style={{ padding: '12px 18px', borderBottom: `0.5px solid ${c.bordure}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '8px', background: c.fond }}>
-                    <div style={{ fontSize: '15px', fontWeight: '500', color: c.texte, textDecoration: 'underline', textUnderlineOffset: '3px' }}>{section.nom}</div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
+                      <span style={{ fontSize: '15px', fontWeight: '500', color: c.texte, textDecoration: 'underline', textUnderlineOffset: '3px' }}>{section.nom}</span>
+                      {section.sous_fiche_id && (
+                        <a href={`/fiches/${section.sous_fiche_id}`} className="no-print" title="Voir la sous-fiche réutilisable" style={{ fontSize: '11px', fontWeight: '600', color: '#3C3489', background: '#EEEDFE', border: '0.5px solid #AFA9EC', borderRadius: '6px', padding: '3px 7px', textDecoration: 'none', whiteSpace: 'nowrap' }}>↗ réutilisable</a>
+                      )}
+                    </div>
                     {peutVoirCosts && coutSection > 0 && (
                       <div style={{ fontSize: '12px', color: c.texteMuted }}>Coût : <strong style={{ color: c.texte }}>{coutSection.toFixed(2)} €</strong></div>
                     )}
@@ -371,8 +373,7 @@ export default function FicheDetail() {
           {isMobile ? (
             <div style={{ padding: '12px' }}>
               {ingredients.map((ing, i) => {
-                const coef = (ing.unite === 'g' || ing.unite === 'ml') ? 0.001 : (ing.unite === 'cl' ? 0.01 : 1)
-                const coutLigne = ing.ingredients?.prix_kg && ing.quantite ? ing.ingredients.prix_kg * ing.quantite * coef : null
+                const coutLigne = coutLigneAffichage(ing) || null
                 return (
                   <div key={i} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 0', borderBottom: i < ingredients.length - 1 ? `0.5px solid ${c.bordure}` : 'none' }}>
                     <div>
@@ -397,8 +398,7 @@ export default function FicheDetail() {
               </thead>
               <tbody>
                 {ingredients.map((ing, i) => {
-                  const coef = (ing.unite === 'g' || ing.unite === 'ml') ? 0.001 : (ing.unite === 'cl' ? 0.01 : 1)
-                  const coutLigne = ing.ingredients?.prix_kg && ing.quantite ? ing.ingredients.prix_kg * ing.quantite * coef : null
+                  const coutLigne = coutLigneAffichage(ing) || null
                   return (
                     <tr key={i} style={{ borderBottom: i < ingredients.length - 1 ? `0.5px solid ${c.bordure}` : 'none' }}>
                       <td style={{ padding: '12px 16px', fontSize: '14px', fontWeight: '500', color: c.texte }}>{ing.ingredients?.nom || '—'}</td>
@@ -555,8 +555,7 @@ export default function FicheDetail() {
             </thead>
             <tbody>
               {ingredients.map((ing, i) => {
-                const coef = (ing.unite === 'g' || ing.unite === 'ml') ? 0.001 : (ing.unite === 'cl' ? 0.01 : 1)
-                const coutLigne = ing.ingredients?.prix_kg && ing.quantite ? ing.ingredients.prix_kg * ing.quantite * coef : null
+                const coutLigne = coutLigneAffichage(ing) || null
                 return (
                   <tr key={i} style={{ background: i % 2 === 0 ? 'white' : '#FAF9F6' }}>
                     <td style={{ padding: '7px 12px', color: '#2C1810', fontWeight: '500', border: '0.5px solid #e8e4dc' }}>{ing.ingredients?.nom || '—'}</td>

--- a/app/fiches/nouvelle/page.js
+++ b/app/fiches/nouvelle/page.js
@@ -16,6 +16,8 @@ import { uploadFichePhoto } from '../../../lib/uploadPhoto'
 
 import { isIngredientPossible } from '../../../lib/foodCost'
 import { UNITES_PRODUCTION } from '../../../lib/constants'
+import { coutLigneEditor } from '../../../lib/cout'
+import { promoteSectionToSousFiche, loadSousFicheLignes } from '../../../lib/sousFicheFromSection'
 import { Alert, Card } from '../../../components/ui'
 
 export default function NouvelleFiche() {
@@ -149,9 +151,41 @@ export default function NouvelleFiche() {
   const calculerCout = () => {
     return ingredients.reduce((total, ing) => {
       const ingData = listeIngredients.find(i => i.id === ing.ingredient_id)
-      if (ingData?.prix_kg && ing.quantite) return total + (ingData.prix_kg * parseFloat(ing.quantite))
-      return total
+      return total + coutLigneEditor(ingData, ing.quantite, ing.unite)
     }, 0)
+  }
+
+  // Sous-fiches disponibles (ingrédients miroirs) pour l'import en section.
+  const listeSousFiches = listeIngredients
+    .filter(i => i.est_sous_fiche && i.fiche_id)
+    .map(i => ({ id: i.fiche_id, nom: i.nom }))
+
+  const categorieSousFiche = categoriesDyn.find(cat => cat.nom === 'Sous-fiches' || cat.nom === 'Sous-fiche') || null
+
+  // Promotion : crée une vraie sous-fiche depuis une section, puis lie la section.
+  const handlePromoteSection = async (section, lignes, rendement) => {
+    const clientId = await getClientId()
+    if (!clientId) throw new Error('Session expirée')
+    const { ficheId } = await promoteSectionToSousFiche({
+      supabase, clientId, section, lignes, listeIngredients, rendement, categorieSousFiche,
+    })
+    setSections(prev => prev.map(s => s.tempId === section.tempId ? { ...s, sous_fiche_id: ficheId } : s))
+    await loadIngredients() // le nouvel ingrédient miroir devient sélectionnable
+  }
+
+  // Import : ajoute une section pré-remplie depuis une sous-fiche existante.
+  const handleImportSousFiche = async (sf) => {
+    const clientId = await getClientId()
+    if (!clientId) throw new Error('Session expirée')
+    const { nom: sfNom, instructions, lignes } = await loadSousFicheLignes({ supabase, clientId, sousFicheId: sf.id })
+    const tempId = `tmp_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`
+    setSections(prev => [...prev, { tempId, nom: sfNom || sf.nom, descriptif: instructions || '', sous_fiche_id: sf.id }])
+    setIngredients(prev => [
+      ...prev,
+      ...lignes.filter(l => l.ingredient_id).map(l => ({
+        ingredient_id: l.ingredient_id, nom: l.nom, quantite: l.quantite, unite: l.unite, section_temp_id: tempId,
+      })),
+    ])
   }
 
   const calculerCoutAvecPerte = () => {
@@ -257,7 +291,8 @@ export default function NouvelleFiche() {
             fiche_id: fiche.id,
             ordre: i,
             nom: (s.nom || '').trim() || `Préparation ${i + 1}`,
-            descriptif: s.descriptif || null
+            descriptif: s.descriptif || null,
+            sous_fiche_id: s.sous_fiche_id || null
           })
           .select('id')
           .single()
@@ -629,6 +664,9 @@ export default function NouvelleFiche() {
             ingredients={ingredients}
             setIngredients={setIngredients}
             listeIngredients={listeIngredients}
+            listeSousFiches={listeSousFiches}
+            onPromoteSection={handlePromoteSection}
+            onImportSousFiche={handleImportSousFiche}
             c={c}
             isMobile={isMobile}
           />

--- a/components/SectionsEditor.jsx
+++ b/components/SectionsEditor.jsx
@@ -1,8 +1,11 @@
 'use client'
+import { useState } from 'react'
 import IngredientSearch from './IngredientSearch'
 import { Card } from './ui'
+import { coutLigneEditor } from '../lib/cout'
 
 const UNITES = ['kg', 'g', 'L', 'cl', 'ml', 'u', 'botte', 'pièce', 'portions']
+const UNITES_RENDEMENT = ['g', 'kg', 'ml', 'cl', 'L', 'u', 'portions']
 
 export default function SectionsEditor({
   sections,
@@ -10,12 +13,25 @@ export default function SectionsEditor({
   ingredients,
   setIngredients,
   listeIngredients,
+  listeSousFiches = [],
+  onPromoteSection,
+  onImportSousFiche,
   c,
   isMobile,
 }) {
+  // Modale "rendement" pour la promotion d'une section en sous-fiche.
+  const [promoteFor, setPromoteFor] = useState(null) // tempId de la section
+  const [rendQte, setRendQte] = useState('')
+  const [rendUnite, setRendUnite] = useState('g')
+  const [promoBusy, setPromoBusy] = useState(false)
+  // Picker d'import de sous-fiche existante.
+  const [importOpen, setImportOpen] = useState(false)
+  const [importSel, setImportSel] = useState('')
+  const [importBusy, setImportBusy] = useState(false)
+
   const ajouterSection = () => {
     const tempId = `tmp_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`
-    setSections([...sections, { tempId, nom: '', descriptif: '' }])
+    setSections([...sections, { tempId, nom: '', descriptif: '', sous_fiche_id: null }])
   }
 
   const modifierSection = (tempId, champ, valeur) => {
@@ -63,10 +79,49 @@ export default function SectionsEditor({
     setIngredients(ingredients.filter((_, i) => i !== gIdx))
   }
 
-  // Sur desktop, on rend l'ingrédient sur sa propre ligne (large) + qté/unité/suppr
-  // en dessous, pour que le nom long de l'ingrédient soit toujours visible.
-  // Sur mobile, tout en colonne unique.
-  const rowTemplate = isMobile ? '1fr' : 'minmax(0, 1fr)'
+  const lignesDeSection = (tempId) => ingredients.filter(i => i.section_temp_id === tempId)
+
+  const ouvrirPromotion = (section) => {
+    const lignes = lignesDeSection(section.tempId)
+    if (!(section.nom || '').trim()) { alert('Donnez d\'abord un nom à la préparation.'); return }
+    if (lignes.filter(l => l.ingredient_id && l.quantite).length === 0) { alert('Ajoutez au moins un ingrédient avant de créer une sous-fiche.'); return }
+    setPromoteFor(section.tempId)
+    setRendQte('')
+    setRendUnite('g')
+  }
+
+  const lancerPromotion = async (section) => {
+    if (!rendQte || parseFloat(rendQte) <= 0) { alert('Indiquez la quantité produite.'); return }
+    setPromoBusy(true)
+    try {
+      await onPromoteSection(section, lignesDeSection(section.tempId), { qte: rendQte, unite: rendUnite })
+      setPromoteFor(null)
+      setRendQte('')
+    } catch (e) {
+      alert('Erreur création sous-fiche : ' + (e?.message || e))
+    } finally {
+      setPromoBusy(false)
+    }
+  }
+
+  const lancerImport = async () => {
+    if (!importSel) return
+    const sf = listeSousFiches.find(s => String(s.id) === String(importSel))
+    if (!sf) return
+    setImportBusy(true)
+    try {
+      await onImportSousFiche(sf)
+      setImportOpen(false)
+      setImportSel('')
+    } catch (e) {
+      alert('Erreur import : ' + (e?.message || e))
+    } finally {
+      setImportBusy(false)
+    }
+  }
+
+  const peutPromouvoir = typeof onPromoteSection === 'function'
+  const peutImporter = typeof onImportSousFiche === 'function' && listeSousFiches.length > 0
 
   return (
     <Card c={c} style={{ marginBottom: '12px' }}>
@@ -81,18 +136,21 @@ export default function SectionsEditor({
             .filter(({ ing }) => ing.section_temp_id === section.tempId)
           const coutSection = ingsSection.reduce((tot, { ing }) => {
             const ingData = listeIngredients.find(i => i.id === ing.ingredient_id)
-            if (ingData?.prix_kg && ing.quantite) return tot + (ingData.prix_kg * parseFloat(ing.quantite))
-            return tot
+            return tot + coutLigneEditor(ingData, ing.quantite, ing.unite)
           }, 0)
+          const estLiee = !!section.sous_fiche_id
           return (
             <div key={section.tempId} style={{ background: c.fond, borderRadius: '10px', padding: '14px', border: `0.5px solid ${c.bordure}` }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '10px' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '10px', flexWrap: 'wrap' }}>
                 <input
                   type="text" value={section.nom}
                   onChange={e => modifierSection(section.tempId, 'nom', e.target.value)}
                   placeholder={`Préparation ${sIdx + 1} — ex : Garniture navet ail noir`}
-                  style={{ flex: 1, padding: '10px 12px', borderRadius: '8px', border: `0.5px solid ${c.bordure}`, fontSize: '14px', fontWeight: '500', outline: 'none', color: c.texte, background: c.blanc }}
+                  style={{ flex: 1, minWidth: '160px', padding: '10px 12px', borderRadius: '8px', border: `0.5px solid ${c.bordure}`, fontSize: '14px', fontWeight: '500', outline: 'none', color: c.texte, background: c.blanc }}
                 />
+                {estLiee && (
+                  <span title="Une sous-fiche réutilisable a été créée à partir de cette préparation." style={{ fontSize: '11px', fontWeight: '600', color: '#3C3489', background: '#EEEDFE', border: '0.5px solid #AFA9EC', borderRadius: '6px', padding: '5px 8px', whiteSpace: 'nowrap' }}>↗ réutilisable</span>
+                )}
                 <button type="button" onClick={() => monterSection(sIdx)} disabled={sIdx === 0}
                   style={{ width: '32px', height: '36px', borderRadius: '8px', border: `0.5px solid ${c.bordure}`, background: c.blanc, cursor: sIdx === 0 ? 'not-allowed' : 'pointer', color: c.texteMuted, opacity: sIdx === 0 ? 0.3 : 1 }}>↑</button>
                 <button type="button" onClick={() => descendreSection(sIdx)} disabled={sIdx === sections.length - 1}
@@ -100,6 +158,38 @@ export default function SectionsEditor({
                 <button type="button" onClick={() => supprimerSection(section.tempId)}
                   style={{ width: '36px', height: '36px', borderRadius: '8px', border: '0.5px solid #FECACA', background: c.blanc, cursor: 'pointer', color: '#DC2626', fontSize: '16px' }}>🗑</button>
               </div>
+
+              {/* Action : rendre la section réutilisable (promotion en sous-fiche) */}
+              {peutPromouvoir && !estLiee && promoteFor !== section.tempId && (
+                <button type="button" onClick={() => ouvrirPromotion(section)}
+                  style={{ background: '#EEEDFE', color: '#3C3489', border: '0.5px solid #AFA9EC', borderRadius: '6px', padding: '6px 10px', fontSize: '12px', cursor: 'pointer', marginBottom: '10px' }}>
+                  ↗ Rendre réutilisable
+                </button>
+              )}
+              {peutPromouvoir && promoteFor === section.tempId && (
+                <div style={{ background: '#F6F5FE', border: '0.5px solid #AFA9EC', borderRadius: '8px', padding: '10px', marginBottom: '10px' }}>
+                  <div style={{ fontSize: '12px', color: '#3C3489', marginBottom: '8px' }}>
+                    Cette préparation produit quelle quantité au total ? (pour calculer le coût par unité)
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap' }}>
+                    <input type="number" step="0.01" value={rendQte} placeholder="ex. 2800"
+                      onChange={e => setRendQte(e.target.value)}
+                      style={{ width: '110px', padding: '8px 10px', borderRadius: '6px', border: `0.5px solid ${c.bordure}`, fontSize: '13px', outline: 'none', color: c.texte, background: c.blanc }} />
+                    <select value={rendUnite} onChange={e => setRendUnite(e.target.value)}
+                      style={{ padding: '8px 6px', borderRadius: '6px', border: `0.5px solid ${c.bordure}`, fontSize: '13px', background: c.blanc, outline: 'none', color: c.texte }}>
+                      {UNITES_RENDEMENT.map(u => <option key={u}>{u}</option>)}
+                    </select>
+                    <button type="button" onClick={() => lancerPromotion(section)} disabled={promoBusy}
+                      style={{ background: '#3C3489', color: 'white', border: 'none', borderRadius: '6px', padding: '8px 12px', fontSize: '12px', cursor: promoBusy ? 'not-allowed' : 'pointer', fontWeight: '600', opacity: promoBusy ? 0.6 : 1 }}>
+                      {promoBusy ? '…' : 'Créer la sous-fiche'}
+                    </button>
+                    <button type="button" onClick={() => setPromoteFor(null)} disabled={promoBusy}
+                      style={{ background: 'transparent', color: c.texteMuted, border: `0.5px solid ${c.bordure}`, borderRadius: '6px', padding: '8px 12px', fontSize: '12px', cursor: 'pointer' }}>
+                      Annuler
+                    </button>
+                  </div>
+                </div>
+              )}
 
               <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : 'minmax(0, 1.3fr) minmax(0, 1fr)', gap: '10px', alignItems: 'stretch' }}>
                 {/* Colonne gauche : ingrédients */}
@@ -110,7 +200,7 @@ export default function SectionsEditor({
                   )}
                   {ingsSection.map(({ ing, gIdx }) => {
                     const ingData = listeIngredients.find(i => i.id === ing.ingredient_id)
-                    const coutLigne = ingData?.prix_kg && ing.quantite ? (ingData.prix_kg * parseFloat(ing.quantite)) : null
+                    const coutLigne = coutLigneEditor(ingData, ing.quantite, ing.unite) || null
                     return (
                       <div key={gIdx} style={{ marginBottom: '10px', paddingBottom: '10px', borderBottom: `0.5px solid ${c.bordure}` }}>
                         {/* Ligne 1 : nom ingrédient pleine largeur (lisibilité) */}
@@ -166,9 +256,35 @@ export default function SectionsEditor({
             Aucune préparation pour l'instant. Cliquez sur « Ajouter une préparation » pour démarrer.
           </div>
         )}
-        <button type="button" onClick={ajouterSection} style={{ background: c.accentClair, color: c.accent, border: `0.5px solid ${c.accent}40`, borderRadius: '8px', padding: '10px 16px', fontSize: '13px', cursor: 'pointer', fontWeight: '500' }}>
-          + Ajouter une préparation
-        </button>
+
+        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
+          <button type="button" onClick={ajouterSection} style={{ background: c.accentClair, color: c.accent, border: `0.5px solid ${c.accent}40`, borderRadius: '8px', padding: '10px 16px', fontSize: '13px', cursor: 'pointer', fontWeight: '500' }}>
+            + Ajouter une préparation
+          </button>
+          {peutImporter && !importOpen && (
+            <button type="button" onClick={() => setImportOpen(true)} style={{ background: '#EEEDFE', color: '#3C3489', border: '0.5px solid #AFA9EC', borderRadius: '8px', padding: '10px 16px', fontSize: '13px', cursor: 'pointer', fontWeight: '500' }}>
+              ⮈ Importer une sous-fiche
+            </button>
+          )}
+        </div>
+        {peutImporter && importOpen && (
+          <div style={{ background: '#F6F5FE', border: '0.5px solid #AFA9EC', borderRadius: '8px', padding: '10px', display: 'flex', gap: '6px', flexWrap: 'wrap', alignItems: 'center' }}>
+            <span style={{ fontSize: '12px', color: '#3C3489' }}>Importer :</span>
+            <select value={importSel} onChange={e => setImportSel(e.target.value)}
+              style={{ flex: 1, minWidth: '180px', padding: '8px 10px', borderRadius: '6px', border: `0.5px solid ${c.bordure}`, fontSize: '13px', background: c.blanc, outline: 'none', color: c.texte }}>
+              <option value="">— Choisir une sous-fiche —</option>
+              {listeSousFiches.map(sf => <option key={sf.id} value={sf.id}>{sf.nom}</option>)}
+            </select>
+            <button type="button" onClick={lancerImport} disabled={importBusy || !importSel}
+              style={{ background: '#3C3489', color: 'white', border: 'none', borderRadius: '6px', padding: '8px 12px', fontSize: '12px', cursor: (importBusy || !importSel) ? 'not-allowed' : 'pointer', fontWeight: '600', opacity: (importBusy || !importSel) ? 0.6 : 1 }}>
+              {importBusy ? '…' : 'Importer'}
+            </button>
+            <button type="button" onClick={() => { setImportOpen(false); setImportSel('') }} disabled={importBusy}
+              style={{ background: 'transparent', color: c.texteMuted, border: `0.5px solid ${c.bordure}`, borderRadius: '6px', padding: '8px 12px', fontSize: '12px', cursor: 'pointer' }}>
+              Annuler
+            </button>
+          </div>
+        )}
       </div>
     </Card>
   )

--- a/lib/cout.js
+++ b/lib/cout.js
@@ -1,0 +1,50 @@
+// Helpers de coût partagés entre les éditeurs de fiche et l'affichage.
+//
+// Historique : l'affichage (app/fiches/[id]/page.js) appliquait un coefficient
+// d'unité (g/ml → 0,001, cl → 0,01) tandis que les éditeurs (nouvelle, modifier,
+// SectionsEditor) faisaient `prix_kg * quantite` SANS coefficient. Résultat :
+// pour une ligne en grammes le coût éditeur était ~1000× trop élevé, et le coût
+// des sous-fiches imbriquées consommées au gramme était faux. On centralise ici
+// la logique correcte (celle de l'affichage) pour que tous les sites l'utilisent.
+
+/** Coefficient pour ramener une quantité exprimée en `unite` vers l'unité de
+ *  base à laquelle `prix_kg` est rattaché (kg pour les masses, L pour les
+ *  volumes, l'unité elle-même pour le reste). */
+export function uniteCoefficient(unite) {
+  if (unite === 'g' || unite === 'ml') return 0.001
+  if (unite === 'cl') return 0.01
+  return 1 // kg, L, u, botte, pièce, portions, portion…
+}
+
+/** Coût d'une ligne côté éditeur : on a l'entrée catalogue (ingData.prix_kg) +
+ *  la quantité/l'unité saisies. */
+export function coutLigneEditor(ingData, quantite, unite) {
+  if (!ingData?.prix_kg || !quantite) return 0
+  return ingData.prix_kg * parseFloat(quantite) * uniteCoefficient(unite)
+}
+
+/** Coût d'une ligne côté affichage : la ligne `fiche_ingredients` jointe à
+ *  `ingredients` ({ quantite, unite, ingredients: { prix_kg } }). */
+export function coutLigneAffichage(ing) {
+  if (!ing?.ingredients?.prix_kg || !ing.quantite) return 0
+  return ing.ingredients.prix_kg * ing.quantite * uniteCoefficient(ing.unite)
+}
+
+/** Unité de base de la famille d'une unité (masse → kg, volume → L, sinon
+ *  l'unité telle quelle). Sert à fixer l'unité d'un ingrédient miroir. */
+export function uniteBase(unite) {
+  if (unite === 'g' || unite === 'kg') return 'kg'
+  if (unite === 'ml' || unite === 'cl' || unite === 'L') return 'L'
+  return unite || 'portions'
+}
+
+/** Normalise un rendement (qté + unité produite) vers l'unité de base.
+ *  Ex : (2800, 'g') → { qteBase: 2.8, uniteBase: 'kg' }.
+ *  Permet de stocker un `prix_kg` au kg/L/unité pour que la cascade au gramme
+ *  via `uniteCoefficient` soit exacte. */
+export function normaliserRendement(qte, unite) {
+  const q = parseFloat(qte) || 0
+  const base = uniteBase(unite)
+  const qteBase = (base === 'kg' || base === 'L') ? q * uniteCoefficient(unite) : q
+  return { qteBase, uniteBase: base }
+}

--- a/lib/sousFicheFromSection.js
+++ b/lib/sousFicheFromSection.js
@@ -1,0 +1,107 @@
+// Logique partagée (création + modification de fiche) pour relier une section
+// d'une fiche étoilée à une vraie sous-fiche réutilisable :
+//   - promoteSectionToSousFiche : crée une sous-fiche à partir d'une section
+//     (fiche is_sub_fiche + copie des ingrédients + ingrédient miroir) ;
+//   - loadSousFicheLignes : charge les lignes d'une sous-fiche existante pour
+//     l'importer comme section.
+//
+// L'ingrédient miroir est prix par unité de BASE (kg/L/unité) — voir
+// normaliserRendement — pour que la consommation au gramme cascade juste.
+
+import { coutLigneEditor, normaliserRendement } from './cout'
+
+/**
+ * Promeut une section en sous-fiche réutilisable.
+ * @returns { ficheId, coutUnite, uniteBase }
+ */
+export async function promoteSectionToSousFiche({
+  supabase, clientId, section, lignes, listeIngredients, rendement, categorieSousFiche,
+}) {
+  // Coût total de la section (avec coefficient d'unité correct).
+  const coutSection = lignes.reduce((tot, l) => {
+    const ingData = listeIngredients.find(i => i.id === l.ingredient_id)
+    return tot + coutLigneEditor(ingData, l.quantite, l.unite)
+  }, 0)
+
+  const { qteBase, uniteBase } = normaliserRendement(rendement.qte, rendement.unite)
+  const coutUnite = qteBase > 0 ? coutSection / qteBase : coutSection
+
+  // 1. Fiche sous-fiche
+  const { data: fiche, error: errFiche } = await supabase
+    .from('fiches')
+    .insert([{
+      nom: section.nom,
+      categorie: categorieSousFiche?.nom || 'Sous-fiches',
+      categorie_plat_id: categorieSousFiche?.id || null,
+      is_sub_fiche: true,
+      nb_portions: 1,
+      unite_production: uniteBase,
+      prix_ttc: null,
+      instructions: section.descriptif || null,
+      cout_portion: coutUnite,
+      perte: 0,
+      format_affichage: 'brasserie',
+      // Explicite pour éviter le DEFAULT invalide de la colonne saison
+      // ('Printemps 2026' viole fiches_saison_check via le param columns= de PostgREST).
+      saison: null,
+      annee: null,
+      client_id: clientId,
+    }])
+    .select()
+    .single()
+  if (errFiche || !fiche) throw new Error(errFiche?.message || 'Création de la sous-fiche échouée')
+
+  // 2. Copie des lignes d'ingrédients dans la sous-fiche
+  const lignesAInserer = lignes
+    .filter(l => l.ingredient_id && l.quantite)
+    .map(l => ({
+      fiche_id: fiche.id,
+      ingredient_id: l.ingredient_id,
+      quantite: parseFloat(l.quantite),
+      unite: l.unite,
+      client_id: clientId,
+      section_id: null,
+    }))
+  if (lignesAInserer.length > 0) {
+    const { error: errLignes } = await supabase.from('fiche_ingredients').insert(lignesAInserer)
+    if (errLignes) throw new Error(errLignes.message)
+  }
+
+  // 3. Ingrédient miroir (rend la sous-fiche sélectionnable ailleurs)
+  const { error: errMiroir } = await supabase.from('ingredients').insert([{
+    nom: section.nom,
+    prix_kg: coutUnite,
+    unite: uniteBase,
+    est_sous_fiche: true,
+    fiche_id: fiche.id,
+    client_id: clientId,
+  }])
+  if (errMiroir) throw new Error(errMiroir.message)
+
+  return { ficheId: fiche.id, coutUnite, uniteBase }
+}
+
+/**
+ * Charge le descriptif + les lignes d'une sous-fiche existante, pour l'importer
+ * comme section. Inclut `fiche_id` de chaque ingrédient pour la garde anti-cycle.
+ * @returns { nom, instructions, lignes: [{ ingredient_id, nom, quantite, unite, ingredientFicheId }] }
+ */
+export async function loadSousFicheLignes({ supabase, clientId, sousFicheId }) {
+  const [{ data: fiche }, { data: lignes }] = await Promise.all([
+    supabase.from('fiches').select('nom, instructions').eq('id', sousFicheId).eq('client_id', clientId).single(),
+    supabase.from('fiche_ingredients')
+      .select('ingredient_id, quantite, unite, ingredients(nom, fiche_id, est_sous_fiche)')
+      .eq('fiche_id', sousFicheId).eq('client_id', clientId),
+  ])
+  return {
+    nom: fiche?.nom || '',
+    instructions: fiche?.instructions || '',
+    lignes: (lignes || []).map(l => ({
+      ingredient_id: l.ingredient_id,
+      nom: l.ingredients?.nom || '',
+      quantite: l.quantite,
+      unite: l.unite,
+      ingredientFicheId: l.ingredients?.fiche_id || null,
+    })),
+  }
+}

--- a/supabase/migrations/20260608000000_fiche_sections_sous_fiche_link.sql
+++ b/supabase/migrations/20260608000000_fiche_sections_sous_fiche_link.sql
@@ -1,0 +1,23 @@
+-- Lien optionnel d'une section de fiche étoilée vers une vraie sous-fiche
+-- réutilisable. Une section peut être « promue » (transformée en sous-fiche) ou
+-- « importée » (créée à partir d'une sous-fiche existante). Le lien permet
+-- d'afficher un badge « réutilisable » et de retrouver la sous-fiche source.
+--
+-- ON DELETE SET NULL : supprimer la sous-fiche déliera la section sans casser la
+-- fiche consommatrice (la section garde sa copie d'ingrédients pour le livret).
+--
+-- Colonne additive et nullable → rétro-compatible : l'ancien code l'ignore.
+
+ALTER TABLE public.fiche_sections
+  ADD COLUMN IF NOT EXISTS sous_fiche_id uuid
+    REFERENCES public.fiches(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.fiche_sections.sous_fiche_id IS
+  'Sous-fiche réutilisable liée à cette section (promue depuis la section ou importée). NULL = section autonome. ON DELETE SET NULL.';
+
+CREATE INDEX IF NOT EXISTS fiche_sections_sous_fiche_idx
+  ON public.fiche_sections (sous_fiche_id);
+
+-- RLS : aucune nouvelle policy. Les policies fiche_sections_* (migration
+-- 20260527150000) filtrent déjà sur client_id via user_has_client_access, et
+-- toutes les écritures passent par des requêtes tenant-scoped.


### PR DESCRIPTION
## Contexte
Sur les fiches étoilées, les **sections** n'étaient qu'un regroupement visuel : une préparation (ex. *lait d'amandes*) ne pouvait pas être réutilisée comme ingrédient ailleurs. Cas déclencheur : le dessert « Herbes chartreuse » où le lait d'amandes sert dans la glace ET la sauce.

## Ce que fait cette PR
- **Promouvoir une section** en vraie sous-fiche réutilisable (bouton « ↗ Rendre réutilisable » → modale rendement qté+unité → crée la fiche `is_sub_fiche`, copie les lignes, crée l'ingrédient miroir). La section affiche un badge « réutilisable ».
- **Importer une sous-fiche** existante comme section (pré-remplit nom + descriptif + ingrédients).
- **Fiabilisation du coût** : nouveau `lib/cout.js` centralise le coefficient d'unité (g/ml→0,001, cl→0,01) utilisé partout. Corrige l'incohérence où les éditeurs calculaient `prix_kg*qté` **sans** coefficient (≈ ×1000 sur les lignes en g), ce qui faussait le coût des sous-fiches imbriquées consommées au gramme.

## Détails techniques
- Migration `fiche_sections.sous_fiche_id` (FK → fiches, `ON DELETE SET NULL`) — **déjà appliquée** (additive, nullable, rétro-compatible).
- Helper `lib/sousFicheFromSection.js` : `promoteSectionToSousFiche` (prix normalisé par unité de base kg/L/unité → cascade au gramme correcte) + `loadSousFicheLignes`.
- Garde anti-cycle (un niveau) à l'import ; idempotence de la promotion.
- Décision v1 : après promotion, la section garde sa copie d'ingrédients (snapshot découplé, pas de re-sync live).

## Vérifié (MARSAN, localhost)
- Non-régression coût sur la fiche réelle « HERBES FRAICHE, CREME AMANDE » (lignes en kg → coûts identiques).
- Promote end-to-end : sous-fiche créée, coût normalisé correct (EAU DE COCO 5,60 €/L × 2 ÷ 2 kg = **5,60 €/kg**), badge, idempotence, cross-référence `[SF]` dans une autre section.
- Import end-to-end : section pré-remplie + badge.
- Donnée de test nettoyée.

## À noter
Bug de schéma préexistant découvert : `fiches.saison` a un DEFAULT invalide (`'Printemps 2026'`) qui viole sa contrainte CHECK → fait échouer toute insertion omettant `saison`. Contourné ici (saison passée explicitement) ; fix séparé recommandé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)