### PR TITLE
feat(fiches): dose par portion sur les sections — fiche dessert unifiée

### DIFF
--- a/app/fiches/[id]/modifier/page.js
+++ b/app/fiches/[id]/modifier/page.js
@@ -18,7 +18,7 @@ import { Card, Alert } from '../../../../components/ui'
 
 import { isIngredientPossible } from '../../../../lib/foodCost'
 import { UNITES_PRODUCTION } from '../../../../lib/constants'
-import { coutLigneEditor } from '../../../../lib/cout'
+import { coutLigneEditor, coutPortionEtoile } from '../../../../lib/cout'
 import { promoteSectionToSousFiche, loadSousFicheLignes } from '../../../../lib/sousFicheFromSection'
 
 export default function ModifierFiche() {
@@ -158,7 +158,9 @@ export default function ModifierFiche() {
       dbId: s.id,
       nom: s.nom || '',
       descriptif: s.descriptif || '',
-      sous_fiche_id: s.sous_fiche_id || null
+      sous_fiche_id: s.sous_fiche_id || null,
+      dose_portion: s.dose_portion != null ? String(s.dose_portion) : '',
+      dose_unite: s.dose_unite || 'g'
     }))
     setSections(sectionsLocales)
 
@@ -219,11 +221,20 @@ export default function ModifierFiche() {
     setIngredients(nouveaux)
   }
 
+  const coutLigne = (ing) => coutLigneEditor(listeIngredients.find(i => i.id === ing.ingredient_id), ing.quantite, ing.unite)
+  const unitCostFor = (sfId) => listeIngredients.find(i => i.est_sous_fiche && (i.fiche_id === sfId || i.id === sfId))?.prix_kg || null
+
   const calculerCout = () => {
-    return ingredients.reduce((total, ing) => {
-      const ingData = listeIngredients.find(i => i.id === ing.ingredient_id)
-      return total + coutLigneEditor(ingData, ing.quantite, ing.unite)
-    }, 0)
+    if (formatAffichage === 'etoile') {
+      const sectionsCout = sections.map(s => ({
+        sousFicheId: s.sous_fiche_id, dosePortion: s.dose_portion, doseUnite: s.dose_unite,
+        lineCost: ingredients.filter(i => i.section_temp_id === s.tempId).reduce((t, i) => t + coutLigne(i), 0),
+      }))
+      const freeLineCost = ingredients.filter(i => !i.section_temp_id).reduce((t, i) => t + coutLigne(i), 0)
+      const n = parseFloat(nbPortions) || 1
+      return coutPortionEtoile({ sections: sectionsCout, freeLineCost, nbPortions, unitCostFor }) * n
+    }
+    return ingredients.reduce((total, ing) => total + coutLigne(ing), 0)
   }
 
   // Sous-fiches importables comme section.
@@ -246,10 +257,10 @@ export default function ModifierFiche() {
   const handlePromoteSection = async (section, lignes, rendement) => {
     const cid = await getClientId()
     if (!cid) throw new Error('Session expirée')
-    const { ficheId } = await promoteSectionToSousFiche({
+    const { ficheId, uniteBase } = await promoteSectionToSousFiche({
       supabase, clientId: cid, section, lignes, listeIngredients, rendement, categorieSousFiche,
     })
-    setSections(prev => prev.map(s => s.tempId === section.tempId ? { ...s, sous_fiche_id: ficheId } : s))
+    setSections(prev => prev.map(s => s.tempId === section.tempId ? { ...s, sous_fiche_id: ficheId, dose_unite: s.dose_unite || uniteBase } : s))
     await rechargerIngredients()
   }
 
@@ -263,7 +274,8 @@ export default function ModifierFiche() {
       throw new Error('Cycle détecté : cette sous-fiche utilise déjà la fiche courante.')
     }
     const tempId = `tmp_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`
-    setSections(prev => [...prev, { tempId, nom: sfNom || sf.nom, descriptif: instructions || '', sous_fiche_id: sf.id }])
+    const doseUnite = listeIngredients.find(i => i.est_sous_fiche && (i.fiche_id === sf.id || i.id === sf.id))?.unite || 'g'
+    setSections(prev => [...prev, { tempId, nom: sfNom || sf.nom, descriptif: instructions || '', sous_fiche_id: sf.id, dose_portion: '', dose_unite: doseUnite }])
     setIngredients(prev => [
       ...prev,
       ...lignes.filter(l => l.ingredient_id).map(l => ({
@@ -362,7 +374,9 @@ export default function ModifierFiche() {
             ordre: i,
             nom: (s.nom || '').trim() || `Préparation ${i + 1}`,
             descriptif: s.descriptif || null,
-            sous_fiche_id: s.sous_fiche_id || null
+            sous_fiche_id: s.sous_fiche_id || null,
+            dose_portion: s.dose_portion ? parseFloat(s.dose_portion) : null,
+            dose_unite: s.dose_portion ? (s.dose_unite || null) : null
           })
           .select('id')
           .single()

--- a/app/fiches/[id]/page.js
+++ b/app/fiches/[id]/page.js
@@ -9,7 +9,7 @@ import { useRole } from '../../../lib/useRole'
 import { log } from '../../../lib/useLog'
 import { ALLERGENES } from '../../../lib/allergenes'
 import { formatSaison } from '../../../lib/saison'
-import { coutLigneAffichage } from '../../../lib/cout'
+import { coutLigneAffichage, coutDose, coutPortionEtoile } from '../../../lib/cout'
 import FichePhoto, { FicheHeaderInfo, FicheHeaderInfoStyles } from '../../../components/FichePhoto'
 import { AllergenesBlock, FicheDetailNavbar } from '../../../components/FicheDetailShared'
 import ChefLoader from '../../../components/ChefLoader'
@@ -26,6 +26,7 @@ export default function FicheDetail() {
   const [signedUrl, setSignedUrl] = useState(null)
   const [allergenesCascade, setAllergenesCascade] = useState([])
   const [sections, setSections] = useState([])
+  const [sousFicheCout, setSousFicheCout] = useState({}) // { ficheId: cout_portion } pour les sections dosées
   const [formatAffichage, setFormatAffichage] = useState('brasserie')
   const [clientFormatDefaut, setClientFormatDefaut] = useState('brasserie')
   const router = useRouter()
@@ -102,17 +103,22 @@ export default function FicheDetail() {
       if (errIngs) console.error('Ingrédients error:', errIngs)
       setIngredients(ingsData || [])
 
-      const sousFicheIds = (ingsData || [])
-        .filter(ing => ing.ingredients?.est_sous_fiche && ing.ingredients?.fiche_id)
-        .map(ing => ing.ingredients.fiche_id)
+      // Sous-fiches référencées : via lignes d'ingrédients (miroir) ET via sections dosées (sous_fiche_id).
+      const sousFicheIds = [...new Set([
+        ...(ingsData || []).filter(ing => ing.ingredients?.est_sous_fiche && ing.ingredients?.fiche_id).map(ing => ing.ingredients.fiche_id),
+        ...(sectionsData || []).filter(s => s.sous_fiche_id).map(s => s.sous_fiche_id),
+      ])]
       if (sousFicheIds.length > 0) {
         const { data: sfFiches } = await supabase
           .from('fiches')
-          .select('allergenes')
+          .select('id, allergenes, cout_portion')
           .in('id', sousFicheIds)
           .eq('client_id', cId)
         const sfAllergs = (sfFiches || []).flatMap(sf => sf.allergenes || [])
         setAllergenesCascade([...new Set(sfAllergs)])
+        const coutMap = {}
+        ;(sfFiches || []).forEach(sf => { coutMap[sf.id] = sf.cout_portion })
+        setSousFicheCout(coutMap)
       }
     } catch (err) {
       console.error('Load fiche error:', err)
@@ -124,7 +130,31 @@ export default function FicheDetail() {
 
   const coutIngredient = (ing) => coutLigneAffichage(ing)
 
-  const calculerCout = () => ingredients.reduce((total, ing) => total + coutIngredient(ing), 0)
+  // Coût unitaire (€/unité de base) d'une sous-fiche liée à une section dosée.
+  const sectionUnitCostFor = (sfId) => sousFicheCout[sfId] || null
+  // Coût d'une section : dose-based si dosée, sinon Σ de ses lignes.
+  const coutSectionAffichage = (section) => {
+    if (section.sous_fiche_id) {
+      // Section liée : coût = dose (0 si non dosée — intermédiaire/référence, déjà compté ailleurs).
+      return section.dose_portion ? coutDose(sectionUnitCostFor(section.sous_fiche_id), section.dose_portion, section.dose_unite) : 0
+    }
+    return ingredients.filter(i => i.section_id === section.id).reduce((t, i) => t + coutIngredient(i), 0)
+  }
+
+  // Coût "total" : en étoilé = coût/portion (dose-aware) × nb_portions (pour que
+  // foodCost/prixIndicatif qui divisent par nb_portions restent justes).
+  const calculerCout = () => {
+    if (formatAffichage === 'etoile') {
+      const sectionsCout = sections.map(s => ({
+        sousFicheId: s.sous_fiche_id, dosePortion: s.dose_portion, doseUnite: s.dose_unite,
+        lineCost: ingredients.filter(i => i.section_id === s.id).reduce((t, i) => t + coutIngredient(i), 0),
+      }))
+      const freeLineCost = ingredients.filter(i => !i.section_id).reduce((t, i) => t + coutIngredient(i), 0)
+      const n = parseFloat(fiche?.nb_portions) || 1
+      return coutPortionEtoile({ sections: sectionsCout, freeLineCost, nbPortions: fiche?.nb_portions, unitCostFor: sectionUnitCostFor }) * n
+    }
+    return ingredients.reduce((total, ing) => total + coutIngredient(ing), 0)
+  }
 
   // Coût ventilé par section (clé = section_id ; '_libre' = ingrédients non rattachés)
   const coutParSection = () => {
@@ -306,7 +336,8 @@ export default function FicheDetail() {
           <div className="fiche-ingredients-after-header" style={{ display: 'flex', flexDirection: 'column', gap: '12px', marginBottom: '12px' }}>
             {sections.map(section => {
               const ingsSection = ingredients.filter(i => i.section_id === section.id)
-              const coutSection = ingsSection.reduce((tot, ing) => tot + coutIngredient(ing), 0)
+              const estDosee = !!(section.sous_fiche_id && section.dose_portion)
+              const coutSection = coutSectionAffichage(section)
               return (
                 <div key={section.id} style={{ background: c.blanc, borderRadius: '12px', border: `0.5px solid ${c.bordure}`, overflow: 'hidden' }}>
                   <div style={{ padding: '12px 18px', borderBottom: `0.5px solid ${c.bordure}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '8px', background: c.fond }}>
@@ -316,9 +347,14 @@ export default function FicheDetail() {
                         <a href={`/fiches/${section.sous_fiche_id}`} className="no-print" title="Voir la sous-fiche réutilisable" style={{ fontSize: '11px', fontWeight: '600', color: '#3C3489', background: '#EEEDFE', border: '0.5px solid #AFA9EC', borderRadius: '6px', padding: '3px 7px', textDecoration: 'none', whiteSpace: 'nowrap' }}>↗ réutilisable</a>
                       )}
                     </div>
-                    {peutVoirCosts && coutSection > 0 && (
-                      <div style={{ fontSize: '12px', color: c.texteMuted }}>Coût : <strong style={{ color: c.texte }}>{coutSection.toFixed(2)} €</strong></div>
-                    )}
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
+                      {estDosee && (
+                        <span style={{ fontSize: '12px', color: c.texteMuted }}>Par assiette : <strong style={{ color: c.texte }}>{section.dose_portion} {section.dose_unite}</strong></span>
+                      )}
+                      {peutVoirCosts && coutSection > 0 && (
+                        <div style={{ fontSize: '12px', color: c.texteMuted }}>Coût{estDosee ? '/assiette' : ''} : <strong style={{ color: c.texte }}>{coutSection.toFixed(2)} €</strong></div>
+                      )}
+                    </div>
                   </div>
                   <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr', gap: '0' }}>
                     {/* Colonne gauche : ingrédients */}
@@ -330,7 +366,7 @@ export default function FicheDetail() {
                           {ingsSection.map((ing, i) => (
                             <li key={i} style={{ fontSize: '13px', color: c.texte, lineHeight: '1.8', display: 'flex', justifyContent: 'space-between', gap: '8px' }}>
                               <span>{ing.quantite} {ing.unite} {ing.ingredients?.nom || '—'}</span>
-                              {peutVoirCosts && coutIngredient(ing) > 0 && (
+                              {peutVoirCosts && !estDosee && coutIngredient(ing) > 0 && (
                                 <span style={{ color: c.texteMuted, fontSize: '11px', whiteSpace: 'nowrap' }}>{coutIngredient(ing).toFixed(2)} €</span>
                               )}
                             </li>

--- a/app/fiches/nouvelle/page.js
+++ b/app/fiches/nouvelle/page.js
@@ -16,7 +16,7 @@ import { uploadFichePhoto } from '../../../lib/uploadPhoto'
 
 import { isIngredientPossible } from '../../../lib/foodCost'
 import { UNITES_PRODUCTION } from '../../../lib/constants'
-import { coutLigneEditor } from '../../../lib/cout'
+import { coutLigneEditor, coutPortionEtoile } from '../../../lib/cout'
 import { promoteSectionToSousFiche, loadSousFicheLignes } from '../../../lib/sousFicheFromSection'
 import { Alert, Card } from '../../../components/ui'
 
@@ -148,11 +148,23 @@ export default function NouvelleFiche() {
     setIngredients(nouveaux)
   }
 
+  const coutLigne = (ing) => coutLigneEditor(listeIngredients.find(i => i.id === ing.ingredient_id), ing.quantite, ing.unite)
+  const unitCostFor = (sfId) => listeIngredients.find(i => i.est_sous_fiche && (i.fiche_id === sfId || i.id === sfId))?.prix_kg || null
+
+  // Coût "total" : en étoilé = coût/portion (dose-aware) × nb_portions, pour que
+  // calculerCoutPortion/foodCost/prixIndicatif (qui divisent par nb_portions)
+  // restent justes sans modification.
   const calculerCout = () => {
-    return ingredients.reduce((total, ing) => {
-      const ingData = listeIngredients.find(i => i.id === ing.ingredient_id)
-      return total + coutLigneEditor(ingData, ing.quantite, ing.unite)
-    }, 0)
+    if (formatAffichage === 'etoile') {
+      const sectionsCout = sections.map(s => ({
+        sousFicheId: s.sous_fiche_id, dosePortion: s.dose_portion, doseUnite: s.dose_unite,
+        lineCost: ingredients.filter(i => i.section_temp_id === s.tempId).reduce((t, i) => t + coutLigne(i), 0),
+      }))
+      const freeLineCost = ingredients.filter(i => !i.section_temp_id).reduce((t, i) => t + coutLigne(i), 0)
+      const n = parseFloat(nbPortions) || 1
+      return coutPortionEtoile({ sections: sectionsCout, freeLineCost, nbPortions, unitCostFor }) * n
+    }
+    return ingredients.reduce((total, ing) => total + coutLigne(ing), 0)
   }
 
   // Sous-fiches disponibles (ingrédients miroirs) pour l'import en section.
@@ -166,10 +178,10 @@ export default function NouvelleFiche() {
   const handlePromoteSection = async (section, lignes, rendement) => {
     const clientId = await getClientId()
     if (!clientId) throw new Error('Session expirée')
-    const { ficheId } = await promoteSectionToSousFiche({
+    const { ficheId, uniteBase } = await promoteSectionToSousFiche({
       supabase, clientId, section, lignes, listeIngredients, rendement, categorieSousFiche,
     })
-    setSections(prev => prev.map(s => s.tempId === section.tempId ? { ...s, sous_fiche_id: ficheId } : s))
+    setSections(prev => prev.map(s => s.tempId === section.tempId ? { ...s, sous_fiche_id: ficheId, dose_unite: s.dose_unite || uniteBase } : s))
     await loadIngredients() // le nouvel ingrédient miroir devient sélectionnable
   }
 
@@ -179,7 +191,8 @@ export default function NouvelleFiche() {
     if (!clientId) throw new Error('Session expirée')
     const { nom: sfNom, instructions, lignes } = await loadSousFicheLignes({ supabase, clientId, sousFicheId: sf.id })
     const tempId = `tmp_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`
-    setSections(prev => [...prev, { tempId, nom: sfNom || sf.nom, descriptif: instructions || '', sous_fiche_id: sf.id }])
+    const doseUnite = listeIngredients.find(i => i.est_sous_fiche && (i.fiche_id === sf.id || i.id === sf.id))?.unite || 'g'
+    setSections(prev => [...prev, { tempId, nom: sfNom || sf.nom, descriptif: instructions || '', sous_fiche_id: sf.id, dose_portion: '', dose_unite: doseUnite }])
     setIngredients(prev => [
       ...prev,
       ...lignes.filter(l => l.ingredient_id).map(l => ({
@@ -292,7 +305,9 @@ export default function NouvelleFiche() {
             ordre: i,
             nom: (s.nom || '').trim() || `Préparation ${i + 1}`,
             descriptif: s.descriptif || null,
-            sous_fiche_id: s.sous_fiche_id || null
+            sous_fiche_id: s.sous_fiche_id || null,
+            dose_portion: s.dose_portion ? parseFloat(s.dose_portion) : null,
+            dose_unite: s.dose_portion ? (s.dose_unite || null) : null
           })
           .select('id')
           .single()

--- a/components/SectionsEditor.jsx
+++ b/components/SectionsEditor.jsx
@@ -2,10 +2,11 @@
 import { useState } from 'react'
 import IngredientSearch from './IngredientSearch'
 import { Card } from './ui'
-import { coutLigneEditor } from '../lib/cout'
+import { coutLigneEditor, coutDose } from '../lib/cout'
 
 const UNITES = ['kg', 'g', 'L', 'cl', 'ml', 'u', 'botte', 'pièce', 'portions']
 const UNITES_RENDEMENT = ['g', 'kg', 'ml', 'cl', 'L', 'u', 'portions']
+const UNITES_DOSE = ['g', 'kg', 'ml', 'cl', 'L', 'u', 'portions']
 
 export default function SectionsEditor({
   sections,
@@ -31,7 +32,17 @@ export default function SectionsEditor({
 
   const ajouterSection = () => {
     const tempId = `tmp_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`
-    setSections([...sections, { tempId, nom: '', descriptif: '', sous_fiche_id: null }])
+    setSections([...sections, { tempId, nom: '', descriptif: '', sous_fiche_id: null, dose_portion: '', dose_unite: 'g' }])
+  }
+
+  // Coût unitaire (€ / unité de base) d'une sous-fiche via son ingrédient miroir.
+  const unitCostFor = (sfId) => {
+    const m = listeIngredients.find(i => i.est_sous_fiche && (i.fiche_id === sfId || i.id === sfId))
+    return m?.prix_kg || null
+  }
+  const uniteFor = (sfId) => {
+    const m = listeIngredients.find(i => i.est_sous_fiche && (i.fiche_id === sfId || i.id === sfId))
+    return m?.unite || 'g'
   }
 
   const modifierSection = (tempId, champ, valeur) => {
@@ -134,11 +145,15 @@ export default function SectionsEditor({
           const ingsSection = ingredients
             .map((ing, gIdx) => ({ ing, gIdx }))
             .filter(({ ing }) => ing.section_temp_id === section.tempId)
-          const coutSection = ingsSection.reduce((tot, { ing }) => {
+          const coutLignes = ingsSection.reduce((tot, { ing }) => {
             const ingData = listeIngredients.find(i => i.id === ing.ingredient_id)
             return tot + coutLigneEditor(ingData, ing.quantite, ing.unite)
           }, 0)
           const estLiee = !!section.sous_fiche_id
+          const estDosee = estLiee && section.dose_portion
+          const coutSection = estDosee
+            ? coutDose(unitCostFor(section.sous_fiche_id), section.dose_portion, section.dose_unite || uniteFor(section.sous_fiche_id))
+            : coutLignes
           return (
             <div key={section.tempId} style={{ background: c.fond, borderRadius: '10px', padding: '14px', border: `0.5px solid ${c.bordure}` }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '10px', flexWrap: 'wrap' }}>
@@ -191,6 +206,23 @@ export default function SectionsEditor({
                 </div>
               )}
 
+              {/* Dose par portion (assiette) — uniquement pour une section liée à une sous-fiche */}
+              {estLiee && (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap', marginBottom: '10px', background: '#FBFBFE', border: `0.5px solid ${c.bordure}`, borderRadius: '8px', padding: '8px 10px' }}>
+                  <span style={{ fontSize: '12px', color: c.texteMuted }}>Dose par assiette :</span>
+                  <input type="number" step="0.01" value={section.dose_portion || ''} placeholder="ex. 4"
+                    onChange={e => modifierSection(section.tempId, 'dose_portion', e.target.value)}
+                    style={{ width: '90px', padding: '7px 9px', borderRadius: '6px', border: `0.5px solid ${c.bordure}`, fontSize: '13px', outline: 'none', color: c.texte, background: c.blanc }} />
+                  <select value={section.dose_unite || uniteFor(section.sous_fiche_id)} onChange={e => modifierSection(section.tempId, 'dose_unite', e.target.value)}
+                    style={{ padding: '7px 6px', borderRadius: '6px', border: `0.5px solid ${c.bordure}`, fontSize: '13px', background: c.blanc, outline: 'none', color: c.texte }}>
+                    {UNITES_DOSE.map(u => <option key={u}>{u}</option>)}
+                  </select>
+                  {estDosee && coutSection > 0 && (
+                    <span style={{ fontSize: '12px', color: c.texte, marginLeft: 'auto' }}>= <strong>{coutSection.toFixed(2)} €</strong> / assiette</span>
+                  )}
+                </div>
+              )}
+
               <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : 'minmax(0, 1.3fr) minmax(0, 1fr)', gap: '10px', alignItems: 'stretch' }}>
                 {/* Colonne gauche : ingrédients */}
                 <div style={{ background: c.blanc, borderRadius: '8px', padding: '10px', border: `0.5px solid ${c.bordure}` }}>
@@ -228,10 +260,10 @@ export default function SectionsEditor({
                   <button type="button" onClick={() => ajouterIngredientSection(section.tempId)} style={{ background: c.vertClair, color: c.vert, border: `0.5px solid ${c.vert}40`, borderRadius: '6px', padding: '6px 10px', fontSize: '12px', cursor: 'pointer', marginTop: '4px' }}>
                     + Ingrédient
                   </button>
-                  {coutSection > 0 && (
+                  {coutLignes > 0 && (
                     <div style={{ marginTop: '8px', paddingTop: '6px', borderTop: `0.5px solid ${c.bordure}`, fontSize: '11px', color: c.texteMuted, display: 'flex', justifyContent: 'space-between' }}>
-                      <span>Coût section</span>
-                      <strong style={{ color: c.texte }}>{coutSection.toFixed(2)} €</strong>
+                      <span>{estLiee ? 'Coût recette (batch)' : 'Coût section'}</span>
+                      <strong style={{ color: c.texte }}>{coutLignes.toFixed(2)} €</strong>
                     </div>
                   )}
                 </div>

--- a/lib/cout.js
+++ b/lib/cout.js
@@ -38,6 +38,35 @@ export function uniteBase(unite) {
   return unite || 'portions'
 }
 
+/** Coût d'une dose : coût unitaire (par kg/L/unité) × dose × coefficient d'unité.
+ *  Utilisé pour une section dosée liée à une sous-fiche. */
+export function coutDose(unitCost, dosePortion, doseUnite) {
+  if (!unitCost || !dosePortion) return 0
+  return unitCost * parseFloat(dosePortion) * uniteCoefficient(doseUnite)
+}
+
+/** Coût PAR PORTION d'une fiche étoilée tenant compte des sections dosées.
+ *  - section dosée (sousFicheId + dosePortion) → coût/portion = coutDose(...), indépendant de nb_portions ;
+ *  - section non dosée / lignes libres → batch réparti sur nb_portions (comportement historique).
+ *  sections: [{ sousFicheId, dosePortion, doseUnite, lineCost }] (lineCost = Σ coût des lignes de la section)
+ *  unitCostFor: (sousFicheId) => coût unitaire (€/unité de base) | null */
+export function coutPortionEtoile({ sections = [], freeLineCost = 0, nbPortions, unitCostFor }) {
+  const n = parseFloat(nbPortions) || 1
+  let dosed = 0, batch = 0
+  for (const s of sections) {
+    if (s.sousFicheId) {
+      // Section liée à une sous-fiche : compte uniquement via sa dose par assiette.
+      // Sans dose (intermédiaire/référence non dressé), elle ne compte pas — son
+      // coût est déjà porté par la sous-fiche qui la consomme. Pas de double comptage.
+      if (s.dosePortion) dosed += coutDose(unitCostFor ? unitCostFor(s.sousFicheId) : null, s.dosePortion, s.doseUnite)
+    } else {
+      // Section inline (recette propre, non promue) : batch réparti sur nb_portions.
+      batch += (s.lineCost || 0)
+    }
+  }
+  return dosed + (batch + freeLineCost) / n
+}
+
 /** Normalise un rendement (qté + unité produite) vers l'unité de base.
  *  Ex : (2800, 'g') → { qteBase: 2.8, uniteBase: 'kg' }.
  *  Permet de stocker un `prix_kg` au kg/L/unité pour que la cascade au gramme

--- a/supabase/migrations/20260608010000_fiche_sections_dose.sql
+++ b/supabase/migrations/20260608010000_fiche_sections_dose.sql
@@ -1,0 +1,18 @@
+-- Dose par portion sur les sections d'une fiche étoilée.
+-- Permet d'unifier « préparations » et « dressage » dans une seule fiche : une
+-- section liée à une sous-fiche peut indiquer la quantité utilisée par assiette,
+-- et le coût/portion du dessert = Σ (coût unitaire sous-fiche × dose).
+--
+-- Colonnes additives et nullables → rétro-compatible : dose NULL = section non
+-- dosée (coût = ses lignes, comportement actuel).
+
+ALTER TABLE public.fiche_sections
+  ADD COLUMN IF NOT EXISTS dose_portion numeric,
+  ADD COLUMN IF NOT EXISTS dose_unite text;
+
+COMMENT ON COLUMN public.fiche_sections.dose_portion IS
+  'Quantité de cette préparation utilisée par portion (assiette). NULL = section non dosée (coût = ses lignes). Voir dose_unite.';
+COMMENT ON COLUMN public.fiche_sections.dose_unite IS
+  'Unité de la dose par portion (g, kg, ml, cl, L, u, portions).';
+
+-- RLS : aucune nouvelle policy — fiche_sections_* filtrent déjà sur client_id.


### PR DESCRIPTION
## Contexte
Pour un dessert gastronomique, il fallait **deux fiches** (préparations + dressage) → double travail. Une section affichait la recette batch, sans pouvoir dire « j'en utilise 4 g par assiette ».

## Ce que fait cette PR
Chaque section liée à une sous-fiche gagne une **« dose par assiette »**. Le **coût/portion du dessert = Σ (coût unitaire sous-fiche × dose)**, indépendant de nb_portions. → préparations + assemblage dans **une seule fiche**.

- Migration `fiche_sections.dose_portion` + `dose_unite` (nullables, rétro-compat — **déjà appliquée**).
- `lib/cout.js` : `coutDose()` + `coutPortionEtoile()` (section-aware). Règle anti-double-comptage : une section liée compte via sa dose (0 si non dosée = intermédiaire, son coût est déjà dans la sous-fiche qui la consomme) ; sections inline non liées = batch/nb_portions.
- Éditeur : champ « Dose par assiette » sur les sections liées (unité pré-remplie depuis la sous-fiche), coût/assiette affiché.
- Affichage : par section dosée → « Par assiette : X » + coût/assiette ; recette affichée **sans coût** (livret) ; KPIs coût/portion & food cost dose-aware.

## Vérifié (MARSAN, fiche réelle PREPARATIONS DESSERT AUX HERBES)
Doses email saisies (Meringue 4 g, Glace 20 g, Sauce 20 ml, Citron 2 ml, Huile 1 ml, Siphon 25 ml ; Lait d'amande & Sorbet = intermédiaires non dosés).
- Éditeur : coût/portion calculé = **0,52 €/assiette** (prédiction indépendante = 0,520 €).
- Save : doses persistées, `cout_portion` = 0,5200 € enregistré.
- Affichage : « Par assiette » + coût/assiette par section, recette sans coût, KPI coût/portion 0,52 €.
- Non-régression : fiches sans dose inchangées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)