### PR TITLE
fix(fiches): coût d'une section dosée calculé en direct depuis sa recette

### DIFF
--- a/app/fiches/[id]/modifier/page.js
+++ b/app/fiches/[id]/modifier/page.js
@@ -160,7 +160,9 @@ export default function ModifierFiche() {
       descriptif: s.descriptif || '',
       sous_fiche_id: s.sous_fiche_id || null,
       dose_portion: s.dose_portion != null ? String(s.dose_portion) : '',
-      dose_unite: s.dose_unite || 'g'
+      dose_unite: s.dose_unite || 'g',
+      rendement_portion: s.rendement_portion != null ? String(s.rendement_portion) : '',
+      rendement_unite: s.rendement_unite || 'g'
     }))
     setSections(sectionsLocales)
 
@@ -228,6 +230,7 @@ export default function ModifierFiche() {
     if (formatAffichage === 'etoile') {
       const sectionsCout = sections.map(s => ({
         sousFicheId: s.sous_fiche_id, dosePortion: s.dose_portion, doseUnite: s.dose_unite,
+        rendementPortion: s.rendement_portion, rendementUnite: s.rendement_unite,
         lineCost: ingredients.filter(i => i.section_temp_id === s.tempId).reduce((t, i) => t + coutLigne(i), 0),
       }))
       const freeLineCost = ingredients.filter(i => !i.section_temp_id).reduce((t, i) => t + coutLigne(i), 0)
@@ -260,7 +263,12 @@ export default function ModifierFiche() {
     const { ficheId, uniteBase } = await promoteSectionToSousFiche({
       supabase, clientId: cid, section, lignes, listeIngredients, rendement, categorieSousFiche,
     })
-    setSections(prev => prev.map(s => s.tempId === section.tempId ? { ...s, sous_fiche_id: ficheId, dose_unite: s.dose_unite || uniteBase } : s))
+    setSections(prev => prev.map(s => s.tempId === section.tempId ? {
+      ...s, sous_fiche_id: ficheId,
+      dose_unite: s.dose_unite || uniteBase,
+      rendement_portion: s.rendement_portion || String(rendement.qte),
+      rendement_unite: s.rendement_unite || rendement.unite,
+    } : s))
     await rechargerIngredients()
   }
 
@@ -275,7 +283,7 @@ export default function ModifierFiche() {
     }
     const tempId = `tmp_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`
     const doseUnite = listeIngredients.find(i => i.est_sous_fiche && (i.fiche_id === sf.id || i.id === sf.id))?.unite || 'g'
-    setSections(prev => [...prev, { tempId, nom: sfNom || sf.nom, descriptif: instructions || '', sous_fiche_id: sf.id, dose_portion: '', dose_unite: doseUnite }])
+    setSections(prev => [...prev, { tempId, nom: sfNom || sf.nom, descriptif: instructions || '', sous_fiche_id: sf.id, dose_portion: '', dose_unite: doseUnite, rendement_portion: '', rendement_unite: doseUnite }])
     setIngredients(prev => [
       ...prev,
       ...lignes.filter(l => l.ingredient_id).map(l => ({
@@ -376,7 +384,9 @@ export default function ModifierFiche() {
             descriptif: s.descriptif || null,
             sous_fiche_id: s.sous_fiche_id || null,
             dose_portion: s.dose_portion ? parseFloat(s.dose_portion) : null,
-            dose_unite: s.dose_portion ? (s.dose_unite || null) : null
+            dose_unite: s.dose_portion ? (s.dose_unite || null) : null,
+            rendement_portion: s.rendement_portion ? parseFloat(s.rendement_portion) : null,
+            rendement_unite: s.rendement_portion ? (s.rendement_unite || null) : null
           })
           .select('id')
           .single()

--- a/app/fiches/[id]/page.js
+++ b/app/fiches/[id]/page.js
@@ -9,7 +9,7 @@ import { useRole } from '../../../lib/useRole'
 import { log } from '../../../lib/useLog'
 import { ALLERGENES } from '../../../lib/allergenes'
 import { formatSaison } from '../../../lib/saison'
-import { coutLigneAffichage, coutDose, coutPortionEtoile } from '../../../lib/cout'
+import { coutLigneAffichage, coutDose, coutSectionDosee, coutPortionEtoile } from '../../../lib/cout'
 import FichePhoto, { FicheHeaderInfo, FicheHeaderInfoStyles } from '../../../components/FichePhoto'
 import { AllergenesBlock, FicheDetailNavbar } from '../../../components/FicheDetailShared'
 import ChefLoader from '../../../components/ChefLoader'
@@ -134,11 +134,16 @@ export default function FicheDetail() {
   const sectionUnitCostFor = (sfId) => sousFicheCout[sfId] || null
   // Coût d'une section : dose-based si dosée, sinon Σ de ses lignes.
   const coutSectionAffichage = (section) => {
-    if (section.sous_fiche_id) {
-      // Section liée : coût = dose (0 si non dosée — intermédiaire/référence, déjà compté ailleurs).
-      return section.dose_portion ? coutDose(sectionUnitCostFor(section.sous_fiche_id), section.dose_portion, section.dose_unite) : 0
+    const lineCost = ingredients.filter(i => i.section_id === section.id).reduce((t, i) => t + coutIngredient(i), 0)
+    if (section.sous_fiche_id || section.rendement_portion) {
+      if (!section.dose_portion) return 0 // liée non dosée (intermédiaire) → ne compte pas
+      // Live (recette ÷ rendement × dose) si rendement saisi, sinon coût figé sous-fiche.
+      const live = section.rendement_portion
+        ? coutSectionDosee(lineCost, section.rendement_portion, section.rendement_unite, section.dose_portion, section.dose_unite)
+        : null
+      return live != null ? live : coutDose(sectionUnitCostFor(section.sous_fiche_id), section.dose_portion, section.dose_unite)
     }
-    return ingredients.filter(i => i.section_id === section.id).reduce((t, i) => t + coutIngredient(i), 0)
+    return lineCost
   }
 
   // Coût "total" : en étoilé = coût/portion (dose-aware) × nb_portions (pour que
@@ -147,6 +152,7 @@ export default function FicheDetail() {
     if (formatAffichage === 'etoile') {
       const sectionsCout = sections.map(s => ({
         sousFicheId: s.sous_fiche_id, dosePortion: s.dose_portion, doseUnite: s.dose_unite,
+        rendementPortion: s.rendement_portion, rendementUnite: s.rendement_unite,
         lineCost: ingredients.filter(i => i.section_id === s.id).reduce((t, i) => t + coutIngredient(i), 0),
       }))
       const freeLineCost = ingredients.filter(i => !i.section_id).reduce((t, i) => t + coutIngredient(i), 0)
@@ -336,7 +342,7 @@ export default function FicheDetail() {
           <div className="fiche-ingredients-after-header" style={{ display: 'flex', flexDirection: 'column', gap: '12px', marginBottom: '12px' }}>
             {sections.map(section => {
               const ingsSection = ingredients.filter(i => i.section_id === section.id)
-              const estDosee = !!(section.sous_fiche_id && section.dose_portion)
+              const estDosee = !!(section.dose_portion && (section.sous_fiche_id || section.rendement_portion))
               const coutSection = coutSectionAffichage(section)
               return (
                 <div key={section.id} style={{ background: c.blanc, borderRadius: '12px', border: `0.5px solid ${c.bordure}`, overflow: 'hidden' }}>

--- a/app/fiches/nouvelle/page.js
+++ b/app/fiches/nouvelle/page.js
@@ -158,6 +158,7 @@ export default function NouvelleFiche() {
     if (formatAffichage === 'etoile') {
       const sectionsCout = sections.map(s => ({
         sousFicheId: s.sous_fiche_id, dosePortion: s.dose_portion, doseUnite: s.dose_unite,
+        rendementPortion: s.rendement_portion, rendementUnite: s.rendement_unite,
         lineCost: ingredients.filter(i => i.section_temp_id === s.tempId).reduce((t, i) => t + coutLigne(i), 0),
       }))
       const freeLineCost = ingredients.filter(i => !i.section_temp_id).reduce((t, i) => t + coutLigne(i), 0)
@@ -181,7 +182,13 @@ export default function NouvelleFiche() {
     const { ficheId, uniteBase } = await promoteSectionToSousFiche({
       supabase, clientId, section, lignes, listeIngredients, rendement, categorieSousFiche,
     })
-    setSections(prev => prev.map(s => s.tempId === section.tempId ? { ...s, sous_fiche_id: ficheId, dose_unite: s.dose_unite || uniteBase } : s))
+    setSections(prev => prev.map(s => s.tempId === section.tempId ? {
+      ...s, sous_fiche_id: ficheId,
+      dose_unite: s.dose_unite || uniteBase,
+      // mémorise le rendement saisi à la promotion → coût/assiette live
+      rendement_portion: s.rendement_portion || String(rendement.qte),
+      rendement_unite: s.rendement_unite || rendement.unite,
+    } : s))
     await loadIngredients() // le nouvel ingrédient miroir devient sélectionnable
   }
 
@@ -192,7 +199,7 @@ export default function NouvelleFiche() {
     const { nom: sfNom, instructions, lignes } = await loadSousFicheLignes({ supabase, clientId, sousFicheId: sf.id })
     const tempId = `tmp_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`
     const doseUnite = listeIngredients.find(i => i.est_sous_fiche && (i.fiche_id === sf.id || i.id === sf.id))?.unite || 'g'
-    setSections(prev => [...prev, { tempId, nom: sfNom || sf.nom, descriptif: instructions || '', sous_fiche_id: sf.id, dose_portion: '', dose_unite: doseUnite }])
+    setSections(prev => [...prev, { tempId, nom: sfNom || sf.nom, descriptif: instructions || '', sous_fiche_id: sf.id, dose_portion: '', dose_unite: doseUnite, rendement_portion: '', rendement_unite: doseUnite }])
     setIngredients(prev => [
       ...prev,
       ...lignes.filter(l => l.ingredient_id).map(l => ({
@@ -307,7 +314,9 @@ export default function NouvelleFiche() {
             descriptif: s.descriptif || null,
             sous_fiche_id: s.sous_fiche_id || null,
             dose_portion: s.dose_portion ? parseFloat(s.dose_portion) : null,
-            dose_unite: s.dose_portion ? (s.dose_unite || null) : null
+            dose_unite: s.dose_portion ? (s.dose_unite || null) : null,
+            rendement_portion: s.rendement_portion ? parseFloat(s.rendement_portion) : null,
+            rendement_unite: s.rendement_portion ? (s.rendement_unite || null) : null
           })
           .select('id')
           .single()

--- a/components/SectionsEditor.jsx
+++ b/components/SectionsEditor.jsx
@@ -2,7 +2,7 @@
 import { useState } from 'react'
 import IngredientSearch from './IngredientSearch'
 import { Card } from './ui'
-import { coutLigneEditor, coutDose } from '../lib/cout'
+import { coutLigneEditor, coutDose, coutSectionDosee } from '../lib/cout'
 
 const UNITES = ['kg', 'g', 'L', 'cl', 'ml', 'u', 'botte', 'pièce', 'portions']
 const UNITES_RENDEMENT = ['g', 'kg', 'ml', 'cl', 'L', 'u', 'portions']
@@ -32,7 +32,7 @@ export default function SectionsEditor({
 
   const ajouterSection = () => {
     const tempId = `tmp_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`
-    setSections([...sections, { tempId, nom: '', descriptif: '', sous_fiche_id: null, dose_portion: '', dose_unite: 'g' }])
+    setSections([...sections, { tempId, nom: '', descriptif: '', sous_fiche_id: null, dose_portion: '', dose_unite: 'g', rendement_portion: '', rendement_unite: 'g' }])
   }
 
   // Coût unitaire (€ / unité de base) d'une sous-fiche via son ingrédient miroir.
@@ -150,10 +150,15 @@ export default function SectionsEditor({
             return tot + coutLigneEditor(ingData, ing.quantite, ing.unite)
           }, 0)
           const estLiee = !!section.sous_fiche_id
-          const estDosee = estLiee && section.dose_portion
-          const coutSection = estDosee
-            ? coutDose(unitCostFor(section.sous_fiche_id), section.dose_portion, section.dose_unite || uniteFor(section.sous_fiche_id))
-            : coutLignes
+          const estDosee = !!(section.dose_portion && (estLiee || section.rendement_portion))
+          // Coût/assiette : live (recette ÷ rendement × dose) si rendement saisi,
+          // sinon fallback sur le coût figé de la sous-fiche.
+          const coutLive = section.rendement_portion
+            ? coutSectionDosee(coutLignes, section.rendement_portion, section.rendement_unite, section.dose_portion, section.dose_unite)
+            : null
+          const coutSection = !estDosee
+            ? coutLignes
+            : (coutLive != null ? coutLive : coutDose(unitCostFor(section.sous_fiche_id), section.dose_portion, section.dose_unite || uniteFor(section.sous_fiche_id)))
           return (
             <div key={section.tempId} style={{ background: c.fond, borderRadius: '10px', padding: '14px', border: `0.5px solid ${c.bordure}` }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '10px', flexWrap: 'wrap' }}>
@@ -206,19 +211,34 @@ export default function SectionsEditor({
                 </div>
               )}
 
-              {/* Dose par portion (assiette) — uniquement pour une section liée à une sous-fiche */}
+              {/* Rendement + dose par assiette — pour une section liée à une sous-fiche */}
               {estLiee && (
-                <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap', marginBottom: '10px', background: '#FBFBFE', border: `0.5px solid ${c.bordure}`, borderRadius: '8px', padding: '8px 10px' }}>
-                  <span style={{ fontSize: '12px', color: c.texteMuted }}>Dose par assiette :</span>
-                  <input type="number" step="0.01" value={section.dose_portion || ''} placeholder="ex. 4"
-                    onChange={e => modifierSection(section.tempId, 'dose_portion', e.target.value)}
-                    style={{ width: '90px', padding: '7px 9px', borderRadius: '6px', border: `0.5px solid ${c.bordure}`, fontSize: '13px', outline: 'none', color: c.texte, background: c.blanc }} />
-                  <select value={section.dose_unite || uniteFor(section.sous_fiche_id)} onChange={e => modifierSection(section.tempId, 'dose_unite', e.target.value)}
-                    style={{ padding: '7px 6px', borderRadius: '6px', border: `0.5px solid ${c.bordure}`, fontSize: '13px', background: c.blanc, outline: 'none', color: c.texte }}>
-                    {UNITES_DOSE.map(u => <option key={u}>{u}</option>)}
-                  </select>
-                  {estDosee && coutSection > 0 && (
-                    <span style={{ fontSize: '12px', color: c.texte, marginLeft: 'auto' }}>= <strong>{coutSection.toFixed(2)} €</strong> / assiette</span>
+                <div style={{ marginBottom: '10px', background: '#FBFBFE', border: `0.5px solid ${c.bordure}`, borderRadius: '8px', padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap' }}>
+                    <span style={{ fontSize: '12px', color: c.texteMuted, minWidth: '120px' }}>Cette recette produit :</span>
+                    <input type="number" step="0.01" value={section.rendement_portion || ''} placeholder="ex. 2800"
+                      onChange={e => modifierSection(section.tempId, 'rendement_portion', e.target.value)}
+                      style={{ width: '90px', padding: '7px 9px', borderRadius: '6px', border: `0.5px solid ${c.bordure}`, fontSize: '13px', outline: 'none', color: c.texte, background: c.blanc }} />
+                    <select value={section.rendement_unite || uniteFor(section.sous_fiche_id)} onChange={e => modifierSection(section.tempId, 'rendement_unite', e.target.value)}
+                      style={{ padding: '7px 6px', borderRadius: '6px', border: `0.5px solid ${c.bordure}`, fontSize: '13px', background: c.blanc, outline: 'none', color: c.texte }}>
+                      {UNITES_DOSE.map(u => <option key={u}>{u}</option>)}
+                    </select>
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap' }}>
+                    <span style={{ fontSize: '12px', color: c.texteMuted, minWidth: '120px' }}>Dose par assiette :</span>
+                    <input type="number" step="0.01" value={section.dose_portion || ''} placeholder="ex. 4"
+                      onChange={e => modifierSection(section.tempId, 'dose_portion', e.target.value)}
+                      style={{ width: '90px', padding: '7px 9px', borderRadius: '6px', border: `0.5px solid ${c.bordure}`, fontSize: '13px', outline: 'none', color: c.texte, background: c.blanc }} />
+                    <select value={section.dose_unite || uniteFor(section.sous_fiche_id)} onChange={e => modifierSection(section.tempId, 'dose_unite', e.target.value)}
+                      style={{ padding: '7px 6px', borderRadius: '6px', border: `0.5px solid ${c.bordure}`, fontSize: '13px', background: c.blanc, outline: 'none', color: c.texte }}>
+                      {UNITES_DOSE.map(u => <option key={u}>{u}</option>)}
+                    </select>
+                    {estDosee && coutSection > 0 && (
+                      <span style={{ fontSize: '12px', color: c.texte, marginLeft: 'auto' }}>= <strong>{coutSection.toFixed(2)} €</strong> / assiette</span>
+                    )}
+                  </div>
+                  {estDosee && !section.rendement_portion && (
+                    <span style={{ fontSize: '11px', color: '#B45309' }}>⚠ Renseigne le rendement pour que le coût suive la recette en direct.</span>
                   )}
                 </div>
               )}

--- a/lib/cout.js
+++ b/lib/cout.js
@@ -45,6 +45,16 @@ export function coutDose(unitCost, dosePortion, doseUnite) {
   return unitCost * parseFloat(dosePortion) * uniteCoefficient(doseUnite)
 }
 
+/** Coût/assiette d'une section dosée calculé EN DIRECT depuis sa recette :
+ *  coût unitaire = batchCost ÷ rendement (ramené à l'unité de base), puis × dose.
+ *  Retourne null si pas de rendement exploitable (→ fallback sous-fiche). */
+export function coutSectionDosee(batchCost, rendementPortion, rendementUnite, dosePortion, doseUnite) {
+  const rendBase = parseFloat(rendementPortion) * uniteCoefficient(rendementUnite)
+  if (!rendBase || !dosePortion) return null
+  const unitCost = batchCost / rendBase
+  return coutDose(unitCost, dosePortion, doseUnite)
+}
+
 /** Coût PAR PORTION d'une fiche étoilée tenant compte des sections dosées.
  *  - section dosée (sousFicheId + dosePortion) → coût/portion = coutDose(...), indépendant de nb_portions ;
  *  - section non dosée / lignes libres → batch réparti sur nb_portions (comportement historique).
@@ -54,11 +64,17 @@ export function coutPortionEtoile({ sections = [], freeLineCost = 0, nbPortions,
   const n = parseFloat(nbPortions) || 1
   let dosed = 0, batch = 0
   for (const s of sections) {
-    if (s.sousFicheId) {
-      // Section liée à une sous-fiche : compte uniquement via sa dose par assiette.
-      // Sans dose (intermédiaire/référence non dressé), elle ne compte pas — son
-      // coût est déjà porté par la sous-fiche qui la consomme. Pas de double comptage.
-      if (s.dosePortion) dosed += coutDose(unitCostFor ? unitCostFor(s.sousFicheId) : null, s.dosePortion, s.doseUnite)
+    if (s.dosePortion && (s.sousFicheId || s.rendementPortion)) {
+      // Section dosée. Priorité au calcul LIVE depuis la recette + rendement
+      // (ajouter un ingrédient met le coût à jour). Sinon fallback sur le coût
+      // figé de la sous-fiche (sections promues avant le rendement).
+      const live = s.rendementPortion
+        ? coutSectionDosee(s.lineCost || 0, s.rendementPortion, s.rendementUnite, s.dosePortion, s.doseUnite)
+        : null
+      dosed += (live != null) ? live : coutDose(unitCostFor ? unitCostFor(s.sousFicheId) : null, s.dosePortion, s.doseUnite)
+    } else if (s.sousFicheId) {
+      // Section liée mais non dosée (intermédiaire/référence) : ne compte pas —
+      // son coût est porté par la sous-fiche qui la consomme. Pas de double comptage.
     } else {
       // Section inline (recette propre, non promue) : batch réparti sur nb_portions.
       batch += (s.lineCost || 0)

--- a/supabase/migrations/20260608020000_fiche_sections_rendement.sql
+++ b/supabase/migrations/20260608020000_fiche_sections_rendement.sql
@@ -1,0 +1,16 @@
+-- Rendement (quantité produite) d'une section dosée, pour calculer son coût/assiette
+-- EN DIRECT depuis sa recette : coût/assiette = (Σ lignes ÷ rendement) × dose.
+-- Auparavant le coût d'une section dosée venait du coût figé de la sous-fiche
+-- (snapshot à la promotion) → les ingrédients ajoutés ensuite n'étaient pas pris
+-- en compte. Avec le rendement stocké sur la section, le coût devient live.
+--
+-- Colonnes additives/nullables → rétro-compatible.
+
+ALTER TABLE public.fiche_sections
+  ADD COLUMN IF NOT EXISTS rendement_portion numeric,
+  ADD COLUMN IF NOT EXISTS rendement_unite text;
+
+COMMENT ON COLUMN public.fiche_sections.rendement_portion IS
+  'Quantité totale produite par la recette de la section (rendement/batch). Sert à calculer le coût unitaire live : Σ lignes ÷ rendement. NULL = pas de calcul live (fallback sous-fiche).';
+COMMENT ON COLUMN public.fiche_sections.rendement_unite IS
+  'Unité du rendement (g, kg, ml, cl, L, u, portions).';


### PR DESCRIPTION
## Problème signalé
Sur une fiche étoilée : créer une section, la promouvoir (rendement), la doser, puis **ajouter des ingrédients** → les nouveaux ingrédients n'étaient **pas pris en compte** dans le coût de la section ni de la portion.

## Cause
Le coût/assiette d'une section dosée venait du **coût figé de la sous-fiche** (snapshot calculé à la promotion). Toute modification de la recette ensuite était ignorée.

## Correctif
La section porte désormais un **rendement** (quantité produite). Le coût/assiette est calculé **en direct** :
`(Σ coût recette ÷ rendement) × dose`. Ajouter un ingrédient → coût recette ↑ → coût/assiette ↑.

- Migration `fiche_sections.rendement_portion` + `rendement_unite` (nullables, rétro-compat — **déjà appliquée**).
- `lib/cout.js` : `coutSectionDosee()` ; `coutPortionEtoile()` privilégie le live, fallback sur le coût figé si pas de rendement (pas de régression sur les sections déjà dosées).
- Éditeur : champ « Cette recette produit » (rendement) au-dessus de la dose + avertissement si manquant ; pré-rempli depuis la modale de promotion.
- nouvelle + modifier + affichage : calcul live + save/charge du rendement.

## Vérifié (MARSAN, section MELANGE HERBES)
Rendement 40 portions, dose 1 portion. Ajout SUCRE CASSONADE 1 kg à la recette → Coût recette 2,8 → **5,32 €**, Coût/assiette **0,07 → 0,13 €** (5,32 ÷ 40). ✅ Les ingrédients sont pris en compte en direct. Non-régression : sections dosées sans rendement = coût inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)