### PR TITLE
fix(fiches): coût de revient identique en vue brasserie et étoilé

### DIFF
--- a/app/fiches/[id]/modifier/page.js
+++ b/app/fiches/[id]/modifier/page.js
@@ -227,7 +227,8 @@ export default function ModifierFiche() {
   const unitCostFor = (sfId) => listeIngredients.find(i => i.est_sous_fiche && (i.fiche_id === sfId || i.id === sfId))?.prix_kg || null
 
   const calculerCout = () => {
-    if (formatAffichage === 'etoile') {
+    // Coût indépendant du toggle d'affichage : dose-aware dès qu'il y a des sections.
+    if (sections.length > 0) {
       const sectionsCout = sections.map(s => ({
         sousFicheId: s.sous_fiche_id, dosePortion: s.dose_portion, doseUnite: s.dose_unite,
         rendementPortion: s.rendement_portion, rendementUnite: s.rendement_unite,

--- a/app/fiches/[id]/page.js
+++ b/app/fiches/[id]/page.js
@@ -149,7 +149,8 @@ export default function FicheDetail() {
   // Coût "total" : en étoilé = coût/portion (dose-aware) × nb_portions (pour que
   // foodCost/prixIndicatif qui divisent par nb_portions restent justes).
   const calculerCout = () => {
-    if (formatAffichage === 'etoile') {
+    // Coût indépendant du toggle d'affichage : dose-aware dès qu'il y a des sections.
+    if (sections.length > 0) {
       const sectionsCout = sections.map(s => ({
         sousFicheId: s.sous_fiche_id, dosePortion: s.dose_portion, doseUnite: s.dose_unite,
         rendementPortion: s.rendement_portion, rendementUnite: s.rendement_unite,

--- a/app/fiches/nouvelle/page.js
+++ b/app/fiches/nouvelle/page.js
@@ -155,7 +155,8 @@ export default function NouvelleFiche() {
   // calculerCoutPortion/foodCost/prixIndicatif (qui divisent par nb_portions)
   // restent justes sans modification.
   const calculerCout = () => {
-    if (formatAffichage === 'etoile') {
+    // Coût indépendant du toggle d'affichage : dose-aware dès qu'il y a des sections.
+    if (sections.length > 0) {
       const sectionsCout = sections.map(s => ({
         sousFicheId: s.sous_fiche_id, dosePortion: s.dose_portion, doseUnite: s.dose_unite,
         rendementPortion: s.rendement_portion, rendementUnite: s.rendement_unite,


### PR DESCRIPTION
## Problème
Sur la page d'une fiche, basculer entre vue **Brasserie** et **Étoilé** changeait le **coût de revient affiché**.

## Cause
`calculerCout` branchait sur `formatAffichage` (le toggle d'affichage) : en brasserie il sommait toutes les lignes (les batchs complets), en étoilé il sommait les doses par assiette → deux résultats différents pour la même fiche.

## Correctif
Le coût de revient est une propriété de la **fiche**, pas de la **vue**. `calculerCout` branche désormais sur `sections.length > 0` (la structure réelle) → calcul dose-aware identique quelle que soit la vue. (3 fichiers : nouvelle, modifier, affichage.)

## Vérifié (MARSAN)
Fiche PREPARATIONS DESSERT AUX HERBES : Étoilé **3,64 €** = Brasserie **3,64 €** (coût/portion et total). Avant, les deux différaient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)