### PR TITLE
fix(fiches): exclure les sous-fiches de la liste principale

### DIFF
--- a/components/FichesList.jsx
+++ b/components/FichesList.jsx
@@ -128,7 +128,14 @@ export default function FichesList({ section = 'cuisine' }) {
         supabase.from('categories_plats').select('*').eq('client_id', clientId).eq('section', cfg.sectionFilter).order('ordre'),
       ])
       if (error) throw error
-      setFiches(fichesData || [])
+      // Garde-fou : exclure les sous-fiches de la liste principale (elles vivent
+      // dans /sous-fiches). Le filtre `.or()` côté requête ne les écarte pas de
+      // façon fiable (plusieurs `or=` non combinés en AND par PostgREST).
+      let rows = fichesData || []
+      if (cfg.hasSousFicheFilter) {
+        rows = rows.filter(f => !(f.is_sub_fiche === true || (typeof f.categorie === 'string' && f.categorie.toLowerCase().includes('sous'))))
+      }
+      setFiches(rows)
       setLieux(lieuxData || [])
       setCategories(catsData || [])
       setSelection([])


### PR DESCRIPTION
## Problème
Les sous-fiches (créées via « Rendre réutilisable ») apparaissaient dans la liste **Contenus → Fiches** sous un groupe « Sans lieu ». Elles devraient n'apparaître que dans **/sous-fiches**.

## Cause
La requête de liste enchaîne trois `.or()` (`is_sub_fiche`, `categorie`, `archive`). PostgREST ne les combine pas en AND comme attendu → les sous-fiches passent (14 fiches reçues = 5 vraies + 9 sous-fiches).

## Correctif
Filtrage côté client après le fetch (quand `cfg.hasSousFicheFilter`, donc cuisine uniquement) : on retire `is_sub_fiche === true` ou catégorie contenant « sous ». Comptes, groupes par lieu et pagination restent cohérents. Le bar (hasSousFicheFilter=false) n'est pas affecté.

## Vérifié (MARSAN)
Liste /fiches : ne montre plus que les 5 vraies fiches (Dessert aux herbes, Caviar/Wagyu/Baba/Homard Supp), plus de groupe « Sans lieu », 0 sous-fiche. /sous-fiches inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)