### PR TITLE
fix(recap): exclure les sous-fiches du récap food cost

### DIFF
--- a/components/RecapView.jsx
+++ b/components/RecapView.jsx
@@ -127,6 +127,8 @@ export default function RecapView({ section = 'cuisine' }) {
   }
 
   const fichesFiltrees = fiches.filter(f => {
+    // Exclure les sous-fiches du récap food cost (elles vivent dans /sous-fiches)
+    if (f.is_sub_fiche === true || (typeof f.categorie === 'string' && f.categorie.toLowerCase().includes('sous'))) return false
     if (saisonFiltree !== 'toutes' && f.saison !== saisonFiltree) return false
     if (anneeFiltree !== 'toutes' && f.annee !== parseInt(anneeFiltree, 10)) return false
     if (filtreLieu && f.lieu_id !== filtreLieu) return false


### PR DESCRIPTION
## Problème
Dans le **récap food cost** (route /recap, composant RecapView), les sous-fiches apparaissaient encore (groupe « Sans lieu ») et faussaient les moyennes food cost / bénéfice par groupe.

## Cause
Côté cuisine, `loadExtraFilter = null` → aucune exclusion des sous-fiches (ni à la requête, ni à l'affichage).

## Correctif
Exclusion robuste dans `fichesFiltrees` : on retire `is_sub_fiche === true` ou catégorie contenant « sous ». Les listes, groupes (par lieu/catégorie) et stats (FOOD COST MOY / BÉNÉFICE MOY) ne portent plus que sur les vraies fiches.

## Vérifié (MARSAN)
/recap : « 5 fiches » au lieu de 14, plus de groupe « Sans lieu », 0 sous-fiche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)