### PR TITLE
refactor(fiches): helper estSousFiche partagé pour exclure les sous-fiches partout

### DIFF
--- a/app/bar/dashboard/page.js
+++ b/app/bar/dashboard/page.js
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation'
 import { useIsMobile } from '../../../lib/useIsMobile'
 import { useTheme } from '../../../lib/useTheme'
 import { useRole } from '../../../lib/useRole'
-import { calculerFoodCost, foodCostColor, getSeuilsFromParams } from '../../../lib/foodCost'
+import { calculerFoodCost, foodCostColor, getSeuilsFromParams, estSousFiche } from '../../../lib/foodCost'
 import Navbar from '../../../components/Navbar'
 import ChefLoader from '../../../components/ChefLoader'
 import { Badge } from '../../../components/ui'
@@ -51,7 +51,7 @@ export default function BarDashboardPage() {
       .not('prix_precedent', 'is', null)
       .order('prix_updated_at', { ascending: false })
       .limit(20)
-    setFiches(fichesData || [])
+    setFiches((fichesData || []).filter(f => !estSousFiche(f)))
     setIngredientsPrixHausse(prixData || [])
     setLoading(false)
   }

--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -7,7 +7,7 @@ import { useIsMobile } from '../../lib/useIsMobile'
 import { useTheme } from '../../lib/useTheme'
 import { useRole } from '../../lib/useRole'
 import { useTenant } from '../../lib/useTenant'
-import { calculerFoodCost, foodCostColor, getSeuilsFromParams } from '../../lib/foodCost'
+import { calculerFoodCost, foodCostColor, getSeuilsFromParams, estSousFiche } from '../../lib/foodCost'
 import { getDashboardLayout, WIDGET_BY_ID, isWidgetAvailable } from '../../lib/dashboardPreferences'
 import Navbar from '../../components/Navbar'
 import InventaireBanner from '../../components/InventaireBanner'
@@ -76,7 +76,8 @@ export default function DashboardPage() {
       supabase.from('categories_plats').select('id, nom, emoji').eq('client_id', clientId).eq('section', 'cuisine').order('ordre'),
       getDashboardLayout(),
     ])
-    setFiches(fichesData || [])
+    // Garde-fou robuste : exclure les sous-fiches (booléen ou catégorie « sous »)
+    setFiches((fichesData || []).filter(f => !estSousFiche(f)))
     setLieux(lieuxData || [])
     setMenus(menusData || [])
     setIngredientsPrixHausse(prixData || [])

--- a/components/FichesList.jsx
+++ b/components/FichesList.jsx
@@ -8,6 +8,7 @@ import { useIsMobile } from '../lib/useIsMobile'
 import { useTheme } from '../lib/useTheme'
 import { useRole } from '../lib/useRole'
 import { log } from '../lib/useLog'
+import { estSousFiche } from '../lib/foodCost'
 import Navbar from './Navbar'
 import Pagination from './Pagination'
 import { Badge } from './ui'
@@ -132,9 +133,7 @@ export default function FichesList({ section = 'cuisine' }) {
       // dans /sous-fiches). Le filtre `.or()` côté requête ne les écarte pas de
       // façon fiable (plusieurs `or=` non combinés en AND par PostgREST).
       let rows = fichesData || []
-      if (cfg.hasSousFicheFilter) {
-        rows = rows.filter(f => !(f.is_sub_fiche === true || (typeof f.categorie === 'string' && f.categorie.toLowerCase().includes('sous'))))
-      }
+      if (cfg.hasSousFicheFilter) rows = rows.filter(f => !estSousFiche(f))
       setFiches(rows)
       setLieux(lieuxData || [])
       setCategories(catsData || [])

--- a/components/RecapView.jsx
+++ b/components/RecapView.jsx
@@ -8,6 +8,7 @@ import { useIsMobile } from '../lib/useIsMobile'
 import { useTheme } from '../lib/useTheme'
 import { useRole } from '../lib/useRole'
 import { log } from '../lib/useLog'
+import { estSousFiche } from '../lib/foodCost'
 import * as XLSX from 'xlsx'
 import Navbar from './Navbar'
 import { Badge } from './ui'
@@ -128,7 +129,7 @@ export default function RecapView({ section = 'cuisine' }) {
 
   const fichesFiltrees = fiches.filter(f => {
     // Exclure les sous-fiches du récap food cost (elles vivent dans /sous-fiches)
-    if (f.is_sub_fiche === true || (typeof f.categorie === 'string' && f.categorie.toLowerCase().includes('sous'))) return false
+    if (estSousFiche(f)) return false
     if (saisonFiltree !== 'toutes' && f.saison !== saisonFiltree) return false
     if (anneeFiltree !== 'toutes' && f.annee !== parseInt(anneeFiltree, 10)) return false
     if (filtreLieu && f.lieu_id !== filtreLieu) return false

--- a/lib/foodCost.js
+++ b/lib/foodCost.js
@@ -60,3 +60,15 @@ export function isIngredientPossible(nomCategorie) {
 export function isSousFicheCategorie(nomCategorie) {
   return NOMS_SOUS_FICHE.includes(nomCategorie)
 }
+
+/**
+ * Vérifie si une fiche est une sous-fiche (à exclure des listes/récaps/stats food cost).
+ * Robuste : booléen is_sub_fiche OU catégorie contenant « sous » (compat legacy).
+ * @param {{ is_sub_fiche?: boolean, categorie?: string }} fiche
+ */
+export function estSousFiche(fiche) {
+  if (!fiche) return false
+  if (fiche.is_sub_fiche === true) return true
+  const cat = typeof fiche.categorie === 'string' ? fiche.categorie.toLowerCase() : ''
+  return cat.includes('sous')
+}


### PR DESCRIPTION
## Objectif
Bétonner et uniformiser l'exclusion des sous-fiches sur tous les écrans food cost (remplace l'ancien filtre fragile `.neq('categorie','Sous-fiche')` qui ratait les `is_sub_fiche=true` avec une autre catégorie).

## Changements
- `lib/foodCost.js` : nouveau helper `estSousFiche(fiche)` (booléen `is_sub_fiche` OU catégorie contenant « sous »).
- `dashboard` + `bar/dashboard` : exclusion des sous-fiches avant le calcul du **Food cost moyen**.
- `FichesList` + `RecapView` : utilisent le helper (remplacent le filtre inline déjà en place).

Analyses (marges) : non concerné — ne liste que les fiches **vendues**, où les sous-fiches n'apparaissent jamais.

## Vérifié (MARSAN)
Dashboard : « FOOD COST MOYEN 24.9% — Sur 5 fiches ». /recap, /fiches : 5 fiches, 0 sous-fiche. Toutes les routes compilent sans erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)