### PR TITLE
feat(fiches): extraction Excel des ingrédients pour commande

### DIFF
--- a/components/FichesList.jsx
+++ b/components/FichesList.jsx
@@ -9,6 +9,7 @@ import { useTheme } from '../lib/useTheme'
 import { useRole } from '../lib/useRole'
 import { log } from '../lib/useLog'
 import { estSousFiche } from '../lib/foodCost'
+import { buildCommandeWorkbook, downloadXlsx } from '../lib/fichesExport'
 import Navbar from './Navbar'
 import Pagination from './Pagination'
 import { Badge } from './ui'
@@ -78,6 +79,10 @@ export default function FichesList({ section = 'cuisine' }) {
   const [saving, setSaving] = useState(false)
   const [showArchives, setShowArchives] = useState(false)
   const [page, setPage] = useState(1)
+  const [modeExtraire, setModeExtraire] = useState(false)
+  const [selectionExtraire, setSelectionExtraire] = useState([])
+  const [rechercheExtraire, setRechercheExtraire] = useState('')
+  const [extracting, setExtracting] = useState(false)
   const router = useRouter()
   const isMobile = useIsMobile()
   const { c } = useTheme()
@@ -168,6 +173,39 @@ export default function FichesList({ section = 'cuisine' }) {
     finally { setSaving(false) }
   }
 
+  const toggleSelectionExtraire = (id) => setSelectionExtraire(prev => prev.includes(id) ? prev.filter(i => i !== id) : [...prev, id])
+
+  const extraireSelection = async () => {
+    if (selectionExtraire.length === 0) return
+    setExtracting(true)
+    try {
+      const clientId = await getClientId()
+      if (!clientId) return
+      const { data: ingsData, error } = await supabase
+        .from('fiche_ingredients')
+        .select('fiche_id, quantite, unite, ingredients (nom, unite)')
+        .in('fiche_id', selectionExtraire)
+        .eq('client_id', clientId)
+      if (error) throw error
+      // Regroupe les ingrédients par fiche, en respectant l'ordre d'affichage des fiches.
+      const parFiche = new Map()
+      for (const ligne of ingsData || []) {
+        if (!parFiche.has(ligne.fiche_id)) parFiche.set(ligne.fiche_id, [])
+        parFiche.get(ligne.fiche_id).push(ligne)
+      }
+      const fichesPourExport = fiches
+        .filter(f => selectionExtraire.includes(f.id))
+        .map(f => ({ nom: f.nom, ingredients: parFiche.get(f.id) || [] }))
+      const wb = await buildCommandeWorkbook(fichesPourExport)
+      const dateStr = new Date().toISOString().slice(0, 10)
+      await downloadXlsx(wb, `commande_fiches_${dateStr}.xlsx`)
+      setModeExtraire(false); setSelectionExtraire([]); setRechercheExtraire('')
+    } catch (err) { console.error('Extract error:', err); alert('Erreur lors de l\'extraction Excel') }
+    finally { setExtracting(false) }
+  }
+
+  const fichesExtraireFiltrees = fiches.filter(f => f.nom.toLowerCase().includes(rechercheExtraire.toLowerCase()))
+
   return (
     <div style={{ minHeight: '100vh', background: c.fond }}>
       <Navbar section={section} />
@@ -214,6 +252,12 @@ export default function FichesList({ section = 'cuisine' }) {
               border: `0.5px solid ${modeArchive ? '#DC2626' : c.bordure}`, background: modeArchive ? '#FEE2E2' : c.blanc,
               color: modeArchive ? '#DC2626' : c.texteMuted, fontWeight: modeArchive ? '500' : '400', whiteSpace: 'nowrap'
             }}>{modeArchive ? '✕ Annuler' : showArchives ? '📤 Désarchiver' : '📥 Archiver'}</button>
+          )}
+          {fiches.length > 0 && (
+            <button onClick={() => { setModeExtraire(true); setSelectionExtraire([]); setRechercheExtraire('') }} style={{
+              padding: '10px 14px', borderRadius: '8px', fontSize: '13px', cursor: 'pointer',
+              border: `0.5px solid ${c.bordure}`, background: c.blanc, color: c.texteMuted, whiteSpace: 'nowrap'
+            }}>📤 Extraire</button>
           )}
         </div>
 
@@ -321,6 +365,70 @@ export default function FichesList({ section = 'cuisine' }) {
         )}
         {cfg.hasPagination && <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />}
       </div>
+
+      {/* Modale d'extraction Excel */}
+      {modeExtraire && (
+        <div onClick={() => !extracting && setModeExtraire(false)} style={{
+          position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.4)', zIndex: 1000,
+          display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '16px'
+        }}>
+          <div onClick={e => e.stopPropagation()} style={{
+            background: c.blanc, borderRadius: '14px', width: '100%', maxWidth: '480px',
+            maxHeight: '85vh', display: 'flex', flexDirection: 'column', overflow: 'hidden'
+          }}>
+            <div style={{ padding: '18px 20px', borderBottom: `0.5px solid ${c.bordure}` }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px' }}>
+                <div style={{ fontSize: '16px', fontWeight: '600', color: c.texte }}>📤 Extraire les ingrédients</div>
+                <button onClick={() => !extracting && setModeExtraire(false)} style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '20px', color: c.texteMuted, lineHeight: 1 }}>×</button>
+              </div>
+              <div style={{ fontSize: '12px', color: c.texteMuted, marginTop: '4px' }}>
+                Sélectionnez les fiches à inclure dans le fichier Excel de commande.
+              </div>
+            </div>
+
+            <div style={{ padding: '12px 20px', borderBottom: `0.5px solid ${c.bordure}`, display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
+              <input type="text" placeholder="Rechercher une fiche..." value={rechercheExtraire} onChange={e => setRechercheExtraire(e.target.value)}
+                style={{ flex: 1, minWidth: '160px', padding: '8px 10px', borderRadius: '8px', border: `0.5px solid ${c.bordure}`, background: c.blanc, outline: 'none', fontSize: '13px', color: c.texte }} />
+              <button onClick={() => setSelectionExtraire(
+                selectionExtraire.length === fichesExtraireFiltrees.length ? [] : fichesExtraireFiltrees.map(f => f.id)
+              )} style={{ padding: '8px 12px', borderRadius: '8px', fontSize: '12px', cursor: 'pointer', border: `0.5px solid ${c.bordure}`, background: c.blanc, color: c.texteMuted, whiteSpace: 'nowrap' }}>
+                {selectionExtraire.length === fichesExtraireFiltrees.length && fichesExtraireFiltrees.length > 0 ? 'Tout désélectionner' : 'Tout sélectionner'}
+              </button>
+            </div>
+
+            <div style={{ overflowY: 'auto', padding: '8px 12px', flex: 1 }}>
+              {fichesExtraireFiltrees.length === 0 ? (
+                <div style={{ textAlign: 'center', padding: '30px', color: c.texteMuted, fontSize: '13px' }}>Aucune fiche</div>
+              ) : fichesExtraireFiltrees.map(f => {
+                const checked = selectionExtraire.includes(f.id)
+                return (
+                  <label key={f.id} style={{
+                    display: 'flex', alignItems: 'center', gap: '10px', padding: '9px 10px', borderRadius: '8px', cursor: 'pointer',
+                    background: checked ? accentClair : 'transparent'
+                  }}>
+                    <input type="checkbox" checked={checked} onChange={() => toggleSelectionExtraire(f.id)}
+                      style={{ width: '16px', height: '16px', cursor: 'pointer', accentColor: accent }} />
+                    <span style={{ fontSize: '13px', color: c.texte, flex: 1 }}>{f.nom}</span>
+                    {(f.saison || f.annee) && <span style={{ fontSize: '11px', color: c.texteMuted }}>{formatSaison(f.saison, f.annee)}</span>}
+                  </label>
+                )
+              })}
+            </div>
+
+            <div style={{ padding: '14px 20px', borderTop: `0.5px solid ${c.bordure}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px' }}>
+              <span style={{ fontSize: '12px', color: c.texteMuted }}>
+                {selectionExtraire.length} fiche{selectionExtraire.length > 1 ? 's' : ''} sélectionnée{selectionExtraire.length > 1 ? 's' : ''}
+              </span>
+              <button onClick={extraireSelection} disabled={extracting || selectionExtraire.length === 0} style={{
+                padding: '9px 18px', borderRadius: '8px', fontSize: '13px', fontWeight: '500', border: 'none',
+                cursor: (extracting || selectionExtraire.length === 0) ? 'not-allowed' : 'pointer',
+                background: (extracting || selectionExtraire.length === 0) ? c.bordure : accent,
+                color: (extracting || selectionExtraire.length === 0) ? c.texteMuted : c.texte
+              }}>{extracting ? 'Génération...' : `📊 Extraire Excel (${selectionExtraire.length})`}</button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/lib/__tests__/fichesExport.test.ts
+++ b/lib/__tests__/fichesExport.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { buildCommandeWorkbook } from '../fichesExport'
+
+const fiches = [
+  {
+    nom: 'Boeuf bourguignon',
+    ingredients: [
+      { quantite: 1.2, unite: 'kg', ingredients: { nom: 'Boeuf', unite: 'kg' } },
+      { quantite: 0.2, unite: 'kg', ingredients: { nom: 'Carottes', unite: 'kg' } },
+      // doublon (autre section) : doit être dédoublonné
+      { quantite: 0.3, unite: 'kg', ingredients: { nom: 'Carottes', unite: 'kg' } },
+      { quantite: 0.5, unite: 'L', ingredients: { nom: 'Vin rouge', unite: 'L' } },
+    ],
+  },
+  {
+    nom: 'Salade César',
+    ingredients: [
+      { quantite: 1, unite: 'u', ingredients: { nom: 'Salade', unite: 'u' } },
+    ],
+  },
+  {
+    nom: 'Fiche vide',
+    ingredients: [],
+  },
+]
+
+describe('buildCommandeWorkbook', () => {
+  it('crée une unique feuille « Commande »', async () => {
+    const wb = await buildCommandeWorkbook(fiches)
+    expect(wb.worksheets).toHaveLength(1)
+    expect(wb.worksheets[0].name).toBe('Commande')
+  })
+
+  it('écrit le nom de chaque fiche en ligne titre', async () => {
+    const wb = await buildCommandeWorkbook(fiches)
+    const ws = wb.getWorksheet('Commande')
+    const titres: string[] = []
+    ws.eachRow((row) => {
+      const v = row.getCell(1).value
+      if (typeof v === 'string') titres.push(v)
+    })
+    expect(titres).toContain('Boeuf bourguignon')
+    expect(titres).toContain('Salade César')
+    expect(titres).toContain('Fiche vide')
+  })
+
+  it('liste les ingrédients triés et dédoublonnés, avec quantité vide et unité', async () => {
+    const wb = await buildCommandeWorkbook(fiches)
+    const ws = wb.getWorksheet('Commande')
+    // Ligne 1 = titre, ligne 2 = en-tête colonnes, lignes 3+ = ingrédients
+    expect(ws.getCell(1, 1).value).toBe('Boeuf bourguignon')
+    expect(ws.getCell(2, 1).value).toBe('Ingrédient')
+    expect(ws.getCell(2, 2).value).toBe('Quantité à commander')
+    expect(ws.getCell(2, 3).value).toBe('Unité')
+    // Tri alpha : Boeuf, Carottes (dédoublonné), Vin rouge
+    expect(ws.getCell(3, 1).value).toBe('Boeuf')
+    expect(ws.getCell(4, 1).value).toBe('Carottes')
+    expect(ws.getCell(5, 1).value).toBe('Vin rouge')
+    // La case quantité est laissée vide pour saisie manuelle
+    expect(ws.getCell(3, 2).value).toBeFalsy()
+    // L'unité de commande est renseignée
+    expect(ws.getCell(3, 3).value).toBe('kg')
+    expect(ws.getCell(5, 3).value).toBe('L')
+  })
+
+  it('affiche « Aucun ingrédient » pour une fiche sans ingrédient', async () => {
+    const wb = await buildCommandeWorkbook(fiches)
+    const ws = wb.getWorksheet('Commande')
+    const cellules: string[] = []
+    ws.eachRow((row) => {
+      const v = row.getCell(1).value
+      if (typeof v === 'string') cellules.push(v)
+    })
+    expect(cellules).toContain('Aucun ingrédient')
+  })
+
+  it('ne plante pas sur une entrée vide', async () => {
+    const wb = await buildCommandeWorkbook([])
+    expect(wb.getWorksheet('Commande')).toBeTruthy()
+  })
+})

--- a/lib/fichesExport.js
+++ b/lib/fichesExport.js
@@ -1,0 +1,100 @@
+// Export Excel (.xlsx) d'une liste de commande à partir de fiches techniques.
+//
+// Une seule feuille « Commande » : pour chaque fiche sélectionnée, une ligne
+// titre (nom de la fiche) puis la liste de ses ingrédients, avec une colonne
+// « Quantité à commander » laissée vide pour que l'utilisateur la remplisse à
+// la main avant de passer commande.
+//
+// exceljs est chargé dynamiquement (await import) pour ne pas alourdir le
+// bundle initial de la page.
+
+// ── Styles exceljs ─────────────────────────────────────────────────────────
+
+const BORDER_THIN = { style: 'thin', color: { argb: 'FFCCCCCC' } }
+const BORDER_ALL = { top: BORDER_THIN, bottom: BORDER_THIN, left: BORDER_THIN, right: BORDER_THIN }
+
+const FILL_TITLE  = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFE5E7EB' } }
+const FILL_HEADER = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFF3F4F6' } }
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+// Dédoublonne les ingrédients d'une fiche (un même ingrédient peut apparaître
+// dans plusieurs sections) et trie par nom pour une liste de commande lisible.
+function dedupeIngredients(lignes) {
+  const map = new Map()
+  for (const l of lignes || []) {
+    const ing = l.ingredients
+    if (!ing || !ing.nom) continue
+    if (!map.has(ing.nom)) {
+      map.set(ing.nom, { nom: ing.nom, unite: ing.unite || l.unite || '' })
+    }
+  }
+  return [...map.values()].sort((a, b) => a.nom.localeCompare(b.nom, 'fr'))
+}
+
+// ── Excel workbook (async) ─────────────────────────────────────────────────
+
+// fiches : [{ nom, ingredients: [{ quantite, unite, ingredients: { nom, unite } }] }]
+export async function buildCommandeWorkbook(fiches) {
+  const ExcelJS = (await import('exceljs')).default
+  const wb = new ExcelJS.Workbook()
+  wb.creator = 'Skalcook'
+  wb.created = new Date()
+
+  const ws = wb.addWorksheet('Commande')
+  ws.columns = [{ width: 40 }, { width: 22 }, { width: 12 }]
+
+  for (const fiche of fiches || []) {
+    // Ligne titre : nom de la fiche (fusionné, gras, fond gris)
+    const titleRow = ws.addRow([fiche.nom || 'Sans nom', '', ''])
+    ws.mergeCells(`A${titleRow.number}:C${titleRow.number}`)
+    const tCell = ws.getCell(`A${titleRow.number}`)
+    tCell.font = { bold: true, size: 12 }
+    tCell.fill = FILL_TITLE
+    tCell.alignment = { horizontal: 'left', vertical: 'middle' }
+    titleRow.height = 20
+    titleRow.eachCell({ includeEmpty: true }, (c) => { c.border = BORDER_ALL })
+
+    // Ligne en-tête de colonnes
+    const headerRow = ws.addRow(['Ingrédient', 'Quantité à commander', 'Unité'])
+    headerRow.font = { bold: true, size: 10 }
+    headerRow.fill = FILL_HEADER
+    headerRow.alignment = { horizontal: 'left', vertical: 'middle' }
+    headerRow.eachCell((c) => { c.border = BORDER_ALL })
+
+    // Lignes ingrédients (quantité laissée vide à remplir)
+    const ingredients = dedupeIngredients(fiche.ingredients)
+    if (ingredients.length === 0) {
+      const emptyRow = ws.addRow(['Aucun ingrédient', '', ''])
+      ws.getCell(`A${emptyRow.number}`).font = { italic: true, color: { argb: 'FF999999' } }
+      emptyRow.eachCell({ includeEmpty: true }, (c) => { c.border = BORDER_ALL })
+    } else {
+      for (const ing of ingredients) {
+        const row = ws.addRow([ing.nom, '', ing.unite])
+        row.getCell(1).alignment = { horizontal: 'left' }
+        row.getCell(3).alignment = { horizontal: 'center' }
+        row.eachCell({ includeEmpty: true }, (c) => { c.border = BORDER_ALL })
+      }
+    }
+
+    // Ligne vide de séparation entre deux fiches
+    ws.addRow([])
+  }
+
+  return wb
+}
+
+export async function downloadXlsx(workbook, filename) {
+  const buffer = await workbook.xlsx.writeBuffer()
+  const blob = new Blob([buffer], {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## Objectif

Permettre d'extraire sur Excel les ingrédients utilisés dans les fiches techniques, pour préparer une commande.

## Ce que ça fait

- Nouveau bouton **📤 Extraire** sur la page des fiches, à côté du bouton Archiver.
- Ouvre une **modale** où l'on coche les fiches qui nous intéressent (recherche + « Tout sélectionner »).
- Génère un fichier **Excel (.xlsx)** avec **une seule feuille « Commande »** : pour chaque fiche, son **nom** en ligne titre, puis la **liste de ses ingrédients** (dédoublonnés, triés alpha) avec :
  - une colonne **« Quantité à commander »** laissée **vide** à remplir à la main,
  - l'**unité** de l'ingrédient en repère.

## Fichiers

- `lib/fichesExport.js` — construction du workbook (exceljs, importé dynamiquement) + helper de téléchargement.
- `components/FichesList.jsx` — bouton, modale de sélection, récupération des ingrédients (`fiche_ingredients`) et déclenchement de l'export.
- `lib/__tests__/fichesExport.test.ts` — 5 tests (feuille unique, titres des fiches, dédoublonnage/tri, case quantité vide + unité, fiche vide, entrée vide).

## Vérification

- Tests projet : **1900 passés**.
- Testé en conditions réelles via le preview (compte superadmin sur un client de prod, **lecture seule**) : bouton OK, modale avec 97 fiches sélectionnables, extraction d'un vrai `.xlsx` de ~7,3 Ko, modale qui se ferme au succès.

🤖 Generated with [Claude Code](https://claude.com/claude-code)