### PR TITLE
fix(fiches): bloquer la création de sous-fiche si le nom est déjà pris

### DIFF
--- a/lib/sousFicheFromSection.js
+++ b/lib/sousFicheFromSection.js
@@ -26,6 +26,24 @@ export async function promoteSectionToSousFiche({
   const { qteBase, uniteBase } = normaliserRendement(rendement.qte, rendement.unite)
   const coutUnite = qteBase > 0 ? coutSection / qteBase : coutSection
 
+  // 0. Garde anti-doublon : l'ingrédient miroir (étape 3) porte le nom de la
+  // section et la table ingredients a une contrainte UNIQUE (client_id, nom).
+  // On vérifie AVANT de créer quoi que ce soit, sinon un nom déjà pris ferait
+  // échouer le miroir en 409 APRÈS la création de la fiche → sous-fiche orpheline.
+  const { data: nomPris, error: errCheck } = await supabase
+    .from('ingredients')
+    .select('id')
+    .eq('client_id', clientId)
+    .eq('nom', section.nom)
+    .limit(1)
+    .maybeSingle()
+  if (errCheck) throw new Error(errCheck.message)
+  if (nomPris) {
+    throw new Error(
+      `Un ingrédient nommé « ${section.nom} » existe déjà. Renommez la section avant de la transformer en sous-fiche.`,
+    )
+  }
+
   // 1. Fiche sous-fiche
   const { data: fiche, error: errFiche } = await supabase
     .from('fiches')


### PR DESCRIPTION
## Problème

Créer une sous-fiche dont le nom est déjà pris par un ingrédient (ou une sous-fiche existante) échouait avec une erreur SQL brute : `duplicate key value violates unique constraint "ingredients_client_nom_unique"` (409).

Pire : la fiche et ses lignes d'ingrédients étaient créées **avant** l'insertion de l'ingrédient miroir. Quand le miroir échouait, on se retrouvait avec une **sous-fiche orpheline** en base à chaque tentative ratée.

## Correctif

`promoteSectionToSousFiche` vérifie maintenant l'existence d'un ingrédient de même nom (`client_id` + `nom`, ce qui matche exactement la contrainte) **avant** de créer quoi que ce soit. Si le nom est pris → message clair :

> Un ingrédient nommé « X » existe déjà. Renommez la section avant de la transformer en sous-fiche.

Plus d'erreur SQL cryptique, plus de fiche orpheline.

## Note

Des orphelines déjà présentes en prod (issues de l'ancien comportement) sont nettoyées séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)