### PR TITLE
feat: Vercel Web Analytics (sans cookies)

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -1,6 +1,7 @@
 import './globals.css'
 import './landing.css'
 import './crm.css'
+import { Analytics } from '@vercel/analytics/next'
 import Providers from '../components/Providers'
 import AnalyticsWrapper from '../components/AnalyticsWrapper'
 
@@ -24,6 +25,7 @@ export default function RootLayout({ children }) {
       </head>
       <body>
         <AnalyticsWrapper />
+        <Analytics />
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@supabase/supabase-js": "^2.99.1",
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.37.0",
+        "@vercel/analytics": "^2.0.1",
         "exceljs": "^4.4.0",
         "i18next": "^26.3.0",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -3256,6 +3257,48 @@
       "license": "MIT",
       "dependencies": {
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/coverage-v8": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@supabase/supabase-js": "^2.99.1",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.37.0",
+    "@vercel/analytics": "^2.0.1",
     "exceljs": "^4.4.0",
     "i18next": "^26.3.0",
     "i18next-browser-languagedetector": "^8.2.1",


### PR DESCRIPTION
## Pourquoi

Après le retrait d'Axeptio (#153), il n'y avait plus aucun moyen de voir le trafic :
- Axeptio ne servait qu'à compter (et gonflait le chiffre avec l'usage interne)
- GA4 était câblé mais **jamais actif** (`NEXT_PUBLIC_GA_MEASUREMENT_ID` jamais défini → ne s'est jamais chargé)

## Solution

Vercel Web Analytics : **sans cookies** (pas de bandeau de consentement requis), **gratuit** (plan Hobby), montre visiteurs uniques / pages vues / sources / pays / appareils.

## Changements

- `npm i @vercel/analytics`
- `<Analytics />` ajouté au root layout (`app/layout.js`)

## Action manuelle restante

Activer **Web Analytics** dans le dashboard Vercel (projet → onglet Analytics → Enable) pour démarrer la collecte en production.

Vérifié en local : la landing compile et rend sans erreur (console + serveur propres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)