### PR TITLE
feat(achats): unités prédéfinies + conditionnement des ingrédients

### DIFF
--- a/app/controle-gestion/achats/[id]/page.js
+++ b/app/controle-gestion/achats/[id]/page.js
@@ -9,6 +9,7 @@ import { useTheme } from '../../../../lib/useTheme'
 import { useRole } from '../../../../lib/useRole'
 import { normDesig, makeLigneId, badgeStyleFor, statutLabel } from '../../../../lib/achatsHelpers'
 import { useFournisseursConnus } from '../../../../lib/useFournisseursConnus'
+import { unitesParSection } from '../../../../lib/constants'
 import Navbar from '../../../../components/Navbar'
 import BackButton from '../../../../components/BackButton'
 import FournisseurAutocomplete from '../../../../components/FournisseurAutocomplete'
@@ -551,12 +552,22 @@ export default function AchatsDetailPage() {
                                     />
                                   </td>
                                   <td style={td}>
-                                    <input
-                                      style={{ ...inputS, fontSize: 13, padding: '6px 8px', width: 60 }}
-                                      value={l.unite}
-                                      placeholder={t('cgAchats.common.kgPlaceholder')}
-                                      onChange={e => updateEditLigne(l._id, 'unite', e.target.value)}
-                                    />
+                                    {(() => {
+                                      const opts = unitesParSection(facture?.section)
+                                      const v = l.unite || ''
+                                      const horsListe = v && !opts.includes(v)
+                                      return (
+                                        <select
+                                          style={{ ...inputS, fontSize: 13, padding: '6px 8px', width: 76 }}
+                                          value={v}
+                                          onChange={e => updateEditLigne(l._id, 'unite', e.target.value)}
+                                        >
+                                          <option value="">—</option>
+                                          {opts.map(u => <option key={u} value={u}>{u}</option>)}
+                                          {horsListe && <option value={v}>{v}</option>}
+                                        </select>
+                                      )
+                                    })()}
                                   </td>
                                   <td style={{ ...td, textAlign: 'right' }}>
                                     <input

--- a/app/controle-gestion/achats/import/page.js
+++ b/app/controle-gestion/achats/import/page.js
@@ -13,6 +13,23 @@ import IngredientAutocomplete from '../../../../components/IngredientAutocomplet
 import FournisseurAutocomplete from '../../../../components/FournisseurAutocomplete'
 import { useFournisseursConnus } from '../../../../lib/useFournisseursConnus'
 import { normDesig, todayIso, yesterdayIso, fmtPrix, fmtDelta, fileToBase64, makeLigneId, enrichLigne } from '../../../../lib/achatsHelpers'
+import { unitesParSection, normUnite } from '../../../../lib/constants'
+
+// ─── Sélecteur d'unité (liste fermée) ───────────────────────────────────────
+// Remplace les anciens champs texte libre pour éviter les variantes ("Kg"/"kg").
+// Conserve une unité hors-liste déjà saisie pour ne jamais perdre une valeur.
+function UniteSelect({ value, onChange, section, style }) {
+  const opts = unitesParSection(section)
+  const v = value || ''
+  const horsListe = v && !opts.includes(v)
+  return (
+    <select style={style} value={v} onChange={e => onChange(e.target.value)}>
+      <option value="">—</option>
+      {opts.map(u => <option key={u} value={u}>{u}</option>)}
+      {horsListe && <option value={v}>{v}</option>}
+    </select>
+  )
+}
 
 // ─── Composant principal ─────────────────────────────────────────────────────
 
@@ -122,6 +139,10 @@ export default function AchatsImportPage() {
   // Création d'ingrédient inline : _id de la ligne en cours | null
   const [creatingIngFor, setCreatingIngFor] = useState(null)
   const [newIngNom, setNewIngNom] = useState('')
+  // Unité d'utilisation + conditionnement du nouvel ingrédient en cours de création.
+  // conditionnement = nb d'unités d'utilisation par achat (ex: 1 unité = 10 tentacules).
+  const [newIngUnite, setNewIngUnite] = useState('')
+  const [newIngCond, setNewIngCond] = useState('1')
   // Liaison à un ingrédient existant : _id de la ligne en cours | null
   const [linkingIngFor, setLinkingIngFor] = useState(null)
   const [linkSearch, setLinkSearch] = useState('')
@@ -473,8 +494,26 @@ export default function AchatsImportPage() {
 
   // ─── Sauvegarde ───────────────────────────────────────────────────────────
 
+  // Ouvre le formulaire de création inline en pré-remplissant nom + unité depuis
+  // la ligne, et conditionnement à 1 (acheté directement dans l'unité d'usage).
+  const openCreateIng = useCallback((ligne) => {
+    setCreatingIngFor(ligne._id)
+    setNewIngNom(ligne.designation)
+    setNewIngUnite(normUnite(ligne.unite) || '')
+    setNewIngCond('1')
+    setLinkingIngFor(null)
+  }, [])
+
+  const closeCreateIng = useCallback(() => {
+    setCreatingIngFor(null)
+    setNewIngNom('')
+    setNewIngUnite('')
+    setNewIngCond('1')
+  }, [])
+
   const handleCreateIngredient = useCallback(async (ligne) => {
     if (!newIngNom.trim()) return
+    const cond = Number(String(newIngCond).replace(',', '.')) || 1
     try {
       const { data: { session } } = await supabase.auth.getSession()
       const res = await fetch('/api/achats/create-ingredient', {
@@ -486,8 +525,10 @@ export default function AchatsImportPage() {
         body: JSON.stringify({
           clientId,
           nom:     newIngNom.trim(),
-          unite:   ligne.unite || null,
+          unite:   newIngUnite || ligne.unite || null,
+          // Prix de l'achat entier (côté serveur : prix_kg = prix / conditionnement)
           prix_kg: ligne.prix_unitaire_ht || null,
+          conditionnement: cond > 0 ? cond : 1,
           section,
         }),
       })
@@ -497,30 +538,33 @@ export default function AchatsImportPage() {
       const ing = result.ingredient
       // Met à jour le cache local
       setIngredientsById(prev => ({ ...prev, [ing.id]: ing }))
-      // Enrichit la ligne avec le nouvel ingrédient
+      // Enrichit la ligne avec le nouvel ingrédient. Le prix de référence stocké
+      // (ing.prix_kg) est déjà ramené à l'unité d'utilisation par le serveur.
       setLignes(prev => prev.map(l =>
         l._id !== ligne._id ? l : {
           ...l,
           ingredient_id:   ing.id,
           ingredient_nom:  ing.nom,
-          prix_actuel:     ing.prix_kg ? Number(ing.prix_kg) : null,
+          // prix_actuel = prix du conditionnement (prix_kg stocké × conditionnement)
+          prix_actuel:     ing.prix_kg ? Number(ing.prix_kg) * (Number(ing.conditionnement) > 0 ? Number(ing.conditionnement) : 1) : null,
           deltaPrix:       null,
           reconnu:         true,
           updatePrice:     false,
         }
       ))
-      setCreatingIngFor(null)
-      setNewIngNom('')
+      closeCreateIng()
     } catch (err) {
       setError(err.message)
     }
-  }, [clientId, newIngNom, section])
+  }, [clientId, newIngNom, newIngUnite, newIngCond, section, closeCreateIng])
 
   const handleLinkIngredient = useCallback((ligne, ing) => {
     // L'utilisateur avait-il déjà saisi son propre prix / TVA avant le link ?
     const userHadOwnPrice = ligne.prix_auto === false && Number(ligne.prix_unitaire_ht) > 0
     const userHadOwnTva = ligne.tva_auto === false && ligne.taux_tva != null && ligne.taux_tva !== ''
-    const prixActuel = ing.prix_kg ? Number(ing.prix_kg) : null
+    // Prix de réf ramené au prix du conditionnement (cf. enrichLigne / saveFacture).
+    const cond = Number(ing.conditionnement) > 0 ? Number(ing.conditionnement) : 1
+    const prixActuel = ing.prix_kg ? Number(ing.prix_kg) * cond : null
     const prixLigneFinal = userHadOwnPrice
       ? Number(ligne.prix_unitaire_ht)
       : (prixActuel && Number.isFinite(prixActuel) ? prixActuel : '')
@@ -1265,11 +1309,11 @@ export default function AchatsImportPage() {
                                 />
                               </td>
                               <td style={td}>
-                                <input
-                                  style={{ ...inputS, width: 60, fontSize: 13 }}
+                                <UniteSelect
+                                  style={{ ...inputS, width: 76, fontSize: 13 }}
                                   value={l.unite}
-                                  placeholder={t('cgAchats.common.kgPlaceholder')}
-                                  onChange={e => updateLigne(l._id, 'unite', e.target.value)}
+                                  section={section}
+                                  onChange={v => updateLigne(l._id, 'unite', v)}
                                 />
                               </td>
                               <td style={{ ...td, textAlign: 'right' }}>
@@ -1302,18 +1346,34 @@ export default function AchatsImportPage() {
                               </td>
                               <td style={{ ...td, textAlign: 'center' }}>
                                 {creatingIngFor === l._id ? (
-                                  <div style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 180 }}>
+                                  <div style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 200 }}>
                                     <input
                                       autoFocus
                                       style={{ ...inputS, fontSize: 12, padding: '3px 6px' }}
                                       value={newIngNom}
                                       placeholder={t('cgAchats.import.ingredientNamePlaceholder')}
                                       onChange={e => setNewIngNom(e.target.value)}
-                                      onKeyDown={e => { if (e.key === 'Enter') handleCreateIngredient(l); if (e.key === 'Escape') { setCreatingIngFor(null); setNewIngNom('') } }}
+                                      onKeyDown={e => { if (e.key === 'Enter') handleCreateIngredient(l); if (e.key === 'Escape') closeCreateIng() }}
                                     />
+                                    <div style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 11, color: c.texteMuted }}>
+                                      <span>{t('cgAchats.import.soldByPrefix')}</span>
+                                      <input
+                                        type="number" min="0" step="any"
+                                        style={{ ...inputS, fontSize: 12, padding: '3px 6px', width: 56, textAlign: 'right' }}
+                                        value={newIngCond}
+                                        onChange={e => setNewIngCond(e.target.value)}
+                                        onKeyDown={e => { if (e.key === 'Enter') handleCreateIngredient(l) }}
+                                      />
+                                      <UniteSelect
+                                        style={{ ...inputS, fontSize: 12, padding: '3px 6px', width: 72 }}
+                                        value={newIngUnite}
+                                        section={section}
+                                        onChange={setNewIngUnite}
+                                      />
+                                    </div>
                                     <div style={{ display: 'flex', gap: 4 }}>
                                       <button onClick={() => handleCreateIngredient(l)} style={{ flex: 1, padding: '2px 6px', fontSize: 11, background: c.vert, color: '#fff', border: 'none', borderRadius: 4, cursor: 'pointer' }}>{t('cgAchats.import.create')}</button>
-                                      <button onClick={() => { setCreatingIngFor(null); setNewIngNom('') }} style={{ padding: '2px 6px', fontSize: 11, background: 'transparent', border: `1px solid ${c.bordure}`, borderRadius: 4, cursor: 'pointer' }}>✕</button>
+                                      <button onClick={closeCreateIng} style={{ padding: '2px 6px', fontSize: 11, background: 'transparent', border: `1px solid ${c.bordure}`, borderRadius: 4, cursor: 'pointer' }}>✕</button>
                                     </div>
                                   </div>
                                 ) : linkingIngFor === l._id ? (
@@ -1349,7 +1409,7 @@ export default function AchatsImportPage() {
                                     {l.ingredient_nom && <span style={{ fontSize: 10, color: c.texteMuted }}>{l.ingredient_nom}</span>}
                                     <div style={{ display: 'flex', gap: 4, marginTop: 2 }}>
                                       <button onClick={() => { setLinkingIngFor(l._id); setLinkSearch(''); setCreatingIngFor(null) }} style={{ fontSize: 10, padding: '1px 5px', background: 'transparent', border: `1px solid ${c.bordure}`, color: c.texteMuted, borderRadius: 4, cursor: 'pointer' }}>{t('cgAchats.import.change')}</button>
-                                      <button onClick={() => { setCreatingIngFor(l._id); setNewIngNom(l.designation); setLinkingIngFor(null) }} style={{ fontSize: 10, padding: '1px 5px', background: 'transparent', border: `1px solid ${c.accent}`, color: c.accent, borderRadius: 4, cursor: 'pointer' }} title={t('cgAchats.import.newIngredientTitle')}>{t('cgAchats.import.newIngredient')}</button>
+                                      <button onClick={() => { openCreateIng(l) }} style={{ fontSize: 10, padding: '1px 5px', background: 'transparent', border: `1px solid ${c.accent}`, color: c.accent, borderRadius: 4, cursor: 'pointer' }} title={t('cgAchats.import.newIngredientTitle')}>{t('cgAchats.import.newIngredient')}</button>
                                     </div>
                                   </div>
                                 ) : (
@@ -1360,7 +1420,7 @@ export default function AchatsImportPage() {
                                       style={{ fontSize: 10, padding: '2px 6px', background: '#EFF6FF', border: `1px solid #BFDBFE`, color: '#1D4ED8', borderRadius: 4, cursor: 'pointer', whiteSpace: 'nowrap' }}
                                     >{t('cgAchats.import.linkIngredient')}</button>
                                     <button
-                                      onClick={() => { setCreatingIngFor(l._id); setNewIngNom(l.designation); setLinkingIngFor(null) }}
+                                      onClick={() => { openCreateIng(l) }}
                                       style={{ fontSize: 10, padding: '2px 6px', background: 'transparent', border: `1px solid ${c.accent}`, color: c.accent, borderRadius: 4, cursor: 'pointer', whiteSpace: 'nowrap' }}
                                     >{t('cgAchats.import.createIngredient')}</button>
                                   </div>
@@ -1423,17 +1483,35 @@ export default function AchatsImportPage() {
                             <p style={{ margin: '0 0 8px', fontSize: 12, color: c.texteMuted }}>→ {l.ingredient_nom}</p>
                           )}
                           {creatingIngFor === l._id ? (
-                            <div style={{ display: 'flex', gap: 6, marginBottom: 8, alignItems: 'center' }}>
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 8 }}>
                               <input
                                 autoFocus
-                                style={{ ...inputS, flex: 1, fontSize: 13 }}
+                                style={{ ...inputS, fontSize: 13 }}
                                 value={newIngNom}
                                 placeholder={t('cgAchats.import.ingredientNamePlaceholder')}
                                 onChange={e => setNewIngNom(e.target.value)}
-                                onKeyDown={e => { if (e.key === 'Enter') handleCreateIngredient(l); if (e.key === 'Escape') { setCreatingIngFor(null); setNewIngNom('') } }}
+                                onKeyDown={e => { if (e.key === 'Enter') handleCreateIngredient(l); if (e.key === 'Escape') closeCreateIng() }}
                               />
-                              <button onClick={() => handleCreateIngredient(l)} style={{ padding: '6px 10px', background: c.vert, color: '#fff', border: 'none', borderRadius: 6, cursor: 'pointer', fontSize: 13 }}>{t('cgAchats.import.create')}</button>
-                              <button onClick={() => { setCreatingIngFor(null); setNewIngNom('') }} style={{ padding: '6px 8px', background: 'transparent', border: `1px solid ${c.bordure}`, borderRadius: 6, cursor: 'pointer', fontSize: 13 }}>✕</button>
+                              <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: c.texteMuted }}>
+                                <span>{t('cgAchats.import.soldByPrefix')}</span>
+                                <input
+                                  type="number" min="0" step="any"
+                                  style={{ ...inputS, width: 70, textAlign: 'right' }}
+                                  value={newIngCond}
+                                  onChange={e => setNewIngCond(e.target.value)}
+                                  onKeyDown={e => { if (e.key === 'Enter') handleCreateIngredient(l) }}
+                                />
+                                <UniteSelect
+                                  style={{ ...inputS, width: 90 }}
+                                  value={newIngUnite}
+                                  section={section}
+                                  onChange={setNewIngUnite}
+                                />
+                              </div>
+                              <div style={{ display: 'flex', gap: 6 }}>
+                                <button onClick={() => handleCreateIngredient(l)} style={{ flex: 1, padding: '6px 10px', background: c.vert, color: '#fff', border: 'none', borderRadius: 6, cursor: 'pointer', fontSize: 13 }}>{t('cgAchats.import.create')}</button>
+                                <button onClick={closeCreateIng} style={{ padding: '6px 8px', background: 'transparent', border: `1px solid ${c.bordure}`, borderRadius: 6, cursor: 'pointer', fontSize: 13 }}>✕</button>
+                              </div>
                             </div>
                           ) : linkingIngFor === l._id ? (
                             <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 8 }}>
@@ -1469,7 +1547,7 @@ export default function AchatsImportPage() {
                                 style={{ fontSize: 12, padding: '5px 10px', background: '#EFF6FF', border: `1px solid #BFDBFE`, color: '#1D4ED8', borderRadius: 6, cursor: 'pointer' }}
                               >{t('cgAchats.import.linkShort')}</button>
                               <button
-                                onClick={() => { setCreatingIngFor(l._id); setNewIngNom(l.designation); setLinkingIngFor(null) }}
+                                onClick={() => { openCreateIng(l) }}
                                 style={{ fontSize: 12, padding: '5px 10px', background: 'transparent', border: `1px solid ${c.accent}`, color: c.accent, borderRadius: 6, cursor: 'pointer' }}
                               >{t('cgAchats.import.createShort')}</button>
                             </div>
@@ -1480,7 +1558,7 @@ export default function AchatsImportPage() {
                                 style={{ fontSize: 11, padding: '3px 8px', background: 'transparent', border: `1px solid ${c.bordure}`, color: c.texteMuted, borderRadius: 6, cursor: 'pointer' }}
                               >{t('cgAchats.import.changeLinkedIngredient')}</button>
                               <button
-                                onClick={() => { setCreatingIngFor(l._id); setNewIngNom(l.designation); setLinkingIngFor(null) }}
+                                onClick={() => { openCreateIng(l) }}
                                 style={{ fontSize: 11, padding: '3px 8px', background: 'transparent', border: `1px solid ${c.accent}`, color: c.accent, borderRadius: 6, cursor: 'pointer' }}
                                 title={t('cgAchats.import.newIngredientTitle')}
                               >{t('cgAchats.import.createNew')}</button>
@@ -1495,8 +1573,8 @@ export default function AchatsImportPage() {
                             </label>
                             <label style={{ display: 'flex', flexDirection: 'column', gap: 3, fontSize: 11, color: c.texteMuted }}>
                               {t('cgAchats.import.unit')}
-                              <input style={inputS} value={l.unite} placeholder={t('cgAchats.common.kgPlaceholder')}
-                                onChange={e => updateLigne(l._id, 'unite', e.target.value)} />
+                              <UniteSelect style={inputS} value={l.unite} section={section}
+                                onChange={v => updateLigne(l._id, 'unite', v)} />
                             </label>
                             <label style={{ display: 'flex', flexDirection: 'column', gap: 3, fontSize: 11, color: c.texteMuted }}>
                               {t('cgAchats.import.unitPrice')}

--- a/components/IngredientsView.jsx
+++ b/components/IngredientsView.jsx
@@ -12,10 +12,9 @@ import Pagination from './Pagination'
 import ChefLoader from './ChefLoader'
 import EmojiPicker from './EmojiPicker'
 import { Badge } from './ui'
+import { unitesParSection } from '../lib/constants'
 
 const PAGE_SIZE = 30
-
-const UNITES = ['kg', 'g', 'L', 'cl', 'ml', 'u', 'botte', 'pièce']
 
 // Configuration par section. La table `categories_ingredients` est partagée
 // entre cuisine et bar (colonne `section` qui filtre).
@@ -56,6 +55,7 @@ const CONFIG = {
 
 export default function IngredientsView({ section = 'cuisine' }) {
   const cfg = CONFIG[section]
+  const UNITES = unitesParSection(section)
   const [ingredients, setIngredients] = useState([])
   const [categories, setCategories] = useState([])
   const [loading, setLoading] = useState(true)
@@ -73,6 +73,7 @@ export default function IngredientsView({ section = 'cuisine' }) {
   const [nouveauNom, setNouveauNom] = useState('')
   const [nouveauPrix, setNouveauPrix] = useState('')
   const [nouvelleUnite, setNouvelleUnite] = useState(cfg.defaultUnit)
+  const [nouveauCond, setNouveauCond] = useState('1')
   const [nouvelleCategorie, setNouvelleCategorie] = useState('')
 
   // Formulaire ajout catégorie
@@ -90,6 +91,7 @@ export default function IngredientsView({ section = 'cuisine' }) {
   const [editionId, setEditionId] = useState(null)
   const [editionNom, setEditionNom] = useState('')
   const [editionUnite, setEditionUnite] = useState('')
+  const [editionCond, setEditionCond] = useState('1')
   const [editionPrix, setEditionPrix] = useState('')
   const [editionCategorie, setEditionCategorie] = useState('')
 
@@ -296,16 +298,18 @@ export default function IngredientsView({ section = 'cuisine' }) {
     try {
       const clientId = await getClientId()
       if (!clientId) return
+      const condNum = parseFloat(String(nouveauCond).replace(',', '.'))
       const { error } = await supabase.from(cfg.table).insert([{
         nom: nouveauNom.trim(),
         prix_kg: nouveauPrix ? parseFloat(nouveauPrix.replace(',', '.')) : null,
         unite: nouvelleUnite,
+        conditionnement: condNum > 0 ? condNum : 1,
         client_id: clientId,
         categorie_id: nouvelleCategorie || null
       }])
       if (error) throw error
       await log({ action: 'CREATION', entite: cfg.logEntite, entite_nom: nouveauNom.trim(), section: cfg.logSection })
-      setNouveauNom(''); setNouveauPrix(''); setNouvelleUnite(cfg.defaultUnit); setNouvelleCategorie('')
+      setNouveauNom(''); setNouveauPrix(''); setNouvelleUnite(cfg.defaultUnit); setNouveauCond('1'); setNouvelleCategorie('')
       setAjoutVisible(false)
       await loadAll()
     } catch (err) {
@@ -342,6 +346,7 @@ export default function IngredientsView({ section = 'cuisine' }) {
     setEditionId(ing.id)
     setEditionNom(ing.nom || '')
     setEditionUnite(ing.unite || '')
+    setEditionCond(ing.conditionnement != null ? String(ing.conditionnement) : '1')
     setEditionPrix(ing.prix_kg ? String(ing.prix_kg) : '')
     setEditionCategorie(ing.categorie_id || '')
   }
@@ -354,9 +359,11 @@ export default function IngredientsView({ section = 'cuisine' }) {
     }
     try {
       const clientId = await getClientId()
+      const condNum = parseFloat(String(editionCond).replace(',', '.'))
       const { error } = await supabase.from(cfg.table).update({
         nom: nomTrim,
         unite: editionUnite.trim() || null,
+        conditionnement: condNum > 0 ? condNum : 1,
         prix_kg: editionPrix ? parseFloat(editionPrix.replace(',', '.')) : null,
         categorie_id: editionCategorie || null
       }).eq('id', id).eq('client_id', clientId)
@@ -587,6 +594,16 @@ export default function IngredientsView({ section = 'cuisine' }) {
                       </select>
                     </div>
                   </div>
+                  <div>
+                    <label style={{ fontSize: '12px', color: c.texteMuted, fontWeight: '500', display: 'block', marginBottom: '6px' }}>Conditionnement (vendu par)</label>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                      <input type="number" min="0" step="any" value={nouveauCond} onChange={e => setNouveauCond(e.target.value)}
+                        style={{ width: '90px', padding: '10px 12px', borderRadius: '8px', border: `0.5px solid ${c.bordure}`, fontSize: '14px', outline: 'none', color: c.texte, background: c.blanc, textAlign: 'right' }}
+                      />
+                      <span style={{ fontSize: '13px', color: c.texteMuted }}>{nouvelleUnite} par achat</span>
+                    </div>
+                    <p style={{ fontSize: '11px', color: c.texteMuted, margin: '4px 0 0' }}>{"Ex : poulpe vendu par unité de 10 tentacules → 10. Laisser 1 si acheté directement à l'unité."}</p>
+                  </div>
                   <button onClick={ajouterIngredient} disabled={saving || !nouveauNom.trim()} style={{
                     width: '100%', padding: '12px', background: saving || !nouveauNom.trim() ? c.texteMuted : c.accent,
                     color: 'white', border: 'none', borderRadius: '8px', fontSize: '13px', fontWeight: '500',
@@ -704,13 +721,23 @@ export default function IngredientsView({ section = 'cuisine' }) {
                         </td>
                         <td style={{ padding: '10px 16px', textAlign: 'right', color: c.texteMuted }}>
                           {editionId === ing.id ? (
-                            <input type="text" value={editionUnite} onChange={e => setEditionUnite(e.target.value)}
-                              onKeyDown={e => { if (e.key === 'Enter') saveEdition(ing.id); if (e.key === 'Escape') setEditionId(null) }}
-                              placeholder="kg, L, pièce…"
-                              style={{ width: '70px', padding: '4px 8px', borderRadius: '6px', border: `0.5px solid ${c.bordure}`, fontSize: '12px', outline: 'none', textAlign: 'right', background: c.blanc, color: c.texte }}
-                            />
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', alignItems: 'flex-end' }}>
+                              <select value={editionUnite} onChange={e => setEditionUnite(e.target.value)}
+                                style={{ width: '90px', padding: '4px 8px', borderRadius: '6px', border: `0.5px solid ${c.bordure}`, fontSize: '12px', outline: 'none', background: c.blanc, color: c.texte, cursor: 'pointer' }}>
+                                <option value="">—</option>
+                                {UNITES.map(u => <option key={u} value={u}>{u}</option>)}
+                                {editionUnite && !UNITES.includes(editionUnite) && <option value={editionUnite}>{editionUnite}</option>}
+                              </select>
+                              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }} title="Conditionnement : nombre d'unités par achat">
+                                <span style={{ fontSize: '11px', color: c.texteMuted }}>vendu par</span>
+                                <input type="number" min="0" step="any" value={editionCond} onChange={e => setEditionCond(e.target.value)}
+                                  onKeyDown={e => { if (e.key === 'Enter') saveEdition(ing.id); if (e.key === 'Escape') setEditionId(null) }}
+                                  style={{ width: '56px', padding: '4px 8px', borderRadius: '6px', border: `0.5px solid ${c.bordure}`, fontSize: '12px', outline: 'none', textAlign: 'right', background: c.blanc, color: c.texte }}
+                                />
+                              </div>
+                            </div>
                           ) : (
-                            <span>{ing.unite || '—'}</span>
+                            <span>{ing.unite || '—'}{ing.conditionnement > 1 ? ` ×${ing.conditionnement}` : ''}</span>
                           )}
                         </td>
                         {peutModifier && (

--- a/lib/achatsHelpers.js
+++ b/lib/achatsHelpers.js
@@ -105,7 +105,13 @@ export function enrichLigne(ligne, fournisseurMapping, ingredientsById, ingredie
   if (!ing) ing = ingredientsByNorm[norm] ?? null
 
   const ingId = ing?.id ?? null
-  const prixActuel = ing ? Number(ing.prix_kg) : null
+  // Le prix de la LIGNE représente le prix de l'achat entier (= du conditionnement).
+  // prix_kg est stocké par unité d'utilisation → on remonte au prix du
+  // conditionnement (prix_kg × conditionnement) pour que le total de la facture
+  // colle à ce qui est réellement facturé. Au save, on redivisera par le
+  // conditionnement avant d'écrire prix_kg (voir achats.service.saveFacture).
+  const cond = ing && Number(ing.conditionnement) > 0 ? Number(ing.conditionnement) : 1
+  const prixActuel = ing ? Number(ing.prix_kg) * cond : null
 
   // Distingue "prix auto-rempli" (depuis la mercuriale) vs "prix saisi par l'utilisateur".
   // - true : le prix vient d'un pré-remplissage automatique, on peut le réécrire/effacer

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -11,6 +11,49 @@ export const NOMS_SOUS_FICHE = ['Sous-fiche', 'Sous-fiches']
 /** Unités de production disponibles pour les sous-fiches. */
 export const UNITES_PRODUCTION = ['portions', 'kg', 'g', 'L', 'cl', 'ml', 'u']
 
+/**
+ * Unités canoniques d'un ingrédient / d'une ligne d'achat, par section.
+ * Liste fermée présentée en menu déroulant pour éviter les variantes texte
+ * libre ("Kg" vs "kg") qui faussaient les rapprochements et la mercuriale.
+ */
+export const UNITES_CUISINE = ['kg', 'g', 'L', 'cl', 'ml', 'u', 'pièce', 'bouteille', 'botte']
+export const UNITES_BAR = ['L', 'cl', 'ml', 'u', 'bouteille', 'kg', 'pièce']
+
+/** Retourne la liste d'unités proposée selon la section ('cuisine' | 'bar'). */
+export function unitesParSection(section) {
+  return section === 'bar' ? UNITES_BAR : UNITES_CUISINE
+}
+
+/**
+ * Variantes texte libre → unité canonique. Clé = saisie en minuscules.
+ * Sert à nettoyer l'historique et à recoller toute saisie hors liste.
+ */
+const UNITE_ALIASES = {
+  kg: 'kg', kgs: 'kg', kilo: 'kg', kilos: 'kg', kilogramme: 'kg', kilogrammes: 'kg',
+  g: 'g', gr: 'g', grs: 'g', gramme: 'g', grammes: 'g',
+  l: 'L', litre: 'L', litres: 'L', lt: 'L',
+  cl: 'cl', centilitre: 'cl', centilitres: 'cl',
+  ml: 'ml', millilitre: 'ml', millilitres: 'ml',
+  u: 'u', un: 'u', unite: 'u', unites: 'u', 'unité': 'u', 'unités': 'u', ea: 'u', article: 'u',
+  piece: 'pièce', pieces: 'pièce', 'pièce': 'pièce', 'pièces': 'pièce', pce: 'pièce', pcs: 'pièce', pc: 'pièce',
+  botte: 'botte', bottes: 'botte',
+  bouteille: 'bouteille', bouteilles: 'bouteille', btl: 'bouteille', bt: 'bouteille',
+  portion: 'portions', portions: 'portions',
+}
+
+/**
+ * Normalise une unité saisie en sa forme canonique ("Kg" → "kg", "Litre" → "L").
+ * Renvoie '' si vide, et conserve telle quelle (juste trimée) toute unité
+ * inconnue pour ne jamais perdre une donnée existante.
+ */
+export function normUnite(raw) {
+  if (raw == null) return ''
+  // Retire espaces et points de fin ("Kg." / "L." / "Bt." → "kg" / "L" / "bouteille").
+  const cleaned = String(raw).trim().replace(/[.\s]+$/, '')
+  if (!cleaned) return ''
+  return UNITE_ALIASES[cleaned.toLowerCase()] ?? cleaned
+}
+
 // ─── Seuils food cost (valeurs par défaut — surchargées par les paramètres établissement) ─
 
 export const DEFAULT_SEUILS = {

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -739,6 +739,7 @@
       "colDelta": "Δ Price",
       "colUpdatePrice": "Update price",
       "ingredientNamePlaceholder": "Ingredient name",
+      "soldByPrefix": "Sold per",
       "create": "Create",
       "searchIngredient": "Search for an ingredient…",
       "noResult": "No result",

--- a/lib/i18n/locales/es.json
+++ b/lib/i18n/locales/es.json
@@ -739,6 +739,7 @@
       "colDelta": "Δ Precio",
       "colUpdatePrice": "Act. precio",
       "ingredientNamePlaceholder": "Nombre del ingrediente",
+      "soldByPrefix": "Vendido por",
       "create": "Crear",
       "searchIngredient": "Buscar un ingrediente…",
       "noResult": "Sin resultados",

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -739,6 +739,7 @@
       "colDelta": "Δ Prix",
       "colUpdatePrice": "MAJ prix",
       "ingredientNamePlaceholder": "Nom de l'ingrédient",
+      "soldByPrefix": "Vendu par",
       "create": "Créer",
       "searchIngredient": "Rechercher un ingrédient…",
       "noResult": "Aucun résultat",

--- a/lib/i18n/locales/it.json
+++ b/lib/i18n/locales/it.json
@@ -739,6 +739,7 @@
       "colDelta": "Δ Prezzo",
       "colUpdatePrice": "Agg. prezzo",
       "ingredientNamePlaceholder": "Nome dell'ingrediente",
+      "soldByPrefix": "Venduto per",
       "create": "Crea",
       "searchIngredient": "Cerca un ingrediente…",
       "noResult": "Nessun risultato",

--- a/lib/services/achats.service.ts
+++ b/lib/services/achats.service.ts
@@ -205,13 +205,31 @@ export async function saveFacture(
   // 6. Update ingredient prices (for checked lines) + audit log + mapping — in parallel
   const toUpdate = lignes.filter((l) => l.updatePrice && l.ingredient_id)
 
+  // Conditionnement de chaque ingrédient concerné : le prix de référence stocké
+  // (prix_kg) est le prix PAR unité d'utilisation = prix de la ligne (qui porte
+  // le prix de l'achat entier) divisé par le conditionnement.
+  const condById: Record<string, number> = {}
+  if (toUpdate.length) {
+    const ids = [...new Set(toUpdate.map((l) => l.ingredient_id!))]
+    const { data: condRows } = await db
+      .from(ingredientTable)
+      .select('id, conditionnement')
+      .in('id', ids)
+      .eq('client_id', clientId)
+    for (const r of condRows ?? []) {
+      const c = Number((r as { conditionnement?: number }).conditionnement)
+      condById[(r as { id: string }).id] = Number.isFinite(c) && c > 0 ? c : 1
+    }
+  }
+
   await Promise.all([
     // Price updates
     ...toUpdate.map((l) => {
       const { prixEffectif } = computeLigneEffective(l)
+      const cond = condById[l.ingredient_id!] || 1
       return db
         .from(ingredientTable)
-        .update({ prix_kg: prixEffectif })
+        .update({ prix_kg: prixEffectif / cond })
         .eq('id', l.ingredient_id!)
         .eq('client_id', clientId)
     }),
@@ -801,6 +819,7 @@ export async function findOrCreateIngredient(
   prix_kg?: number | null,
   section: 'cuisine' | 'bar' = 'cuisine',
   categorieId?: string | null,
+  conditionnement?: number | null,
 ) {
   // Convention skalcook : tous les noms d'ingrédients en MAJUSCULES.
   const nomTrim = nom.trim().toUpperCase()
@@ -817,7 +836,7 @@ export async function findOrCreateIngredient(
   const nomLike = nomTrim.replace(/[\\%_]/g, '\\$&')
   const { data: matches } = await db
     .from(table)
-    .select('id, nom, unite, prix_kg')
+    .select('id, nom, unite, prix_kg, conditionnement')
     .eq('client_id', clientId)
     .ilike('nom', nomLike)
     .limit(1)
@@ -826,18 +845,25 @@ export async function findOrCreateIngredient(
   // 2. Création — on assigne une catégorie par défaut si fournie (les articles
   // créés depuis une facture atterrissent ainsi dans « À classer » plutôt que
   // dans « Sans catégorie », pour être faciles à retrouver et à reclasser.)
+  // Conditionnement : nombre d'unités d'utilisation par achat (défaut 1).
+  // Le prix transmis correspond au prix de l'achat entier → on le ramène au
+  // prix par unité d'utilisation pour rester cohérent avec le calcul de coût
+  // des fiches (prix_kg = prix d'achat / conditionnement).
+  const cond = conditionnement && conditionnement > 0 ? conditionnement : 1
   const insertRow: {
     client_id: string
     nom: string
     unite: string
     prix_kg: number
+    conditionnement: number
     est_sous_fiche: boolean
     categorie_id?: string
   } = {
     client_id: clientId,
     nom: nomTrim,
     unite: unite || defaultUnite,
-    prix_kg: prix_kg ?? 0,
+    prix_kg: (prix_kg ?? 0) / cond,
+    conditionnement: cond,
     est_sous_fiche: false,
   }
   if (categorieId) insertRow.categorie_id = categorieId
@@ -845,7 +871,7 @@ export async function findOrCreateIngredient(
   const { data: created, error } = await db
     .from(table)
     .insert(insertRow)
-    .select('id, nom, unite, prix_kg')
+    .select('id, nom, unite, prix_kg, conditionnement')
     .single()
 
   if (error) {
@@ -864,8 +890,8 @@ export async function createIngredient(
   db: SupabaseClient,
   input: CreateIngredientInput
 ) {
-  const { clientId, nom, unite, prix_kg, section } = input
-  return findOrCreateIngredient(db, clientId, nom, unite, prix_kg, section)
+  const { clientId, nom, unite, prix_kg, conditionnement, section } = input
+  return findOrCreateIngredient(db, clientId, nom, unite, prix_kg, section, null, conditionnement)
 }
 
 export async function getMercuriale(
@@ -1025,7 +1051,7 @@ export async function getReconciliationData(
       .eq('client_id', clientId),
     db
       .from(ingredientTable)
-      .select('id, nom, unite, prix_kg')
+      .select('id, nom, unite, prix_kg, conditionnement')
       .eq('client_id', clientId)
       .eq('est_sous_fiche', false)
       .order('nom'),

--- a/lib/validators/achats.schema.ts
+++ b/lib/validators/achats.schema.ts
@@ -92,6 +92,9 @@ export const createIngredientSchema = z.object({
   // Unité optionnelle : si absente, le service applique une unité par défaut.
   unite:    z.string().max(20).optional().nullable(),
   prix_kg:  z.coerce.number().min(0).nullable().optional().default(0),
+  // Conditionnement : nombre d'unités d'utilisation par achat (défaut 1).
+  // Ex : poulpe vendu par unité de 10 tentacules → conditionnement = 10.
+  conditionnement: z.coerce.number().positive().optional().default(1),
   section:  sectionSchema,
 })
 

--- a/supabase/migrations/20260615000000_conditionnement_et_normalisation_unites.sql
+++ b/supabase/migrations/20260615000000_conditionnement_et_normalisation_unites.sql
@@ -1,0 +1,57 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Conditionnement des ingrédients + normalisation des unités
+--
+-- 1) Ajoute `conditionnement` sur ingredients / ingredients_bar : nombre d'unités
+--    d'utilisation (unité de la recette) contenues dans UN achat.
+--    Ex : poulpe vendu par unité de 10 tentacules → unite='u', conditionnement=10.
+--        chocolat vendu par pack de 3 kg → unite='kg', conditionnement=3.
+--    Le prix de référence (prix_kg) est alors le prix PAR unité d'utilisation,
+--    calculé à l'enregistrement d'une facture = prix_ligne / conditionnement.
+--
+-- 2) Normalise les unités saisies en texte libre vers une forme canonique
+--    ("Kg" → "kg", "Litre" → "L"…) sur ingredients, ingredients_bar et
+--    achats_lignes, pour fiabiliser rapprochements et mercuriale.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- 1. Colonne conditionnement (défaut 1 = acheté directement dans l'unité d'usage)
+alter table public.ingredients
+  add column if not exists conditionnement numeric not null default 1;
+alter table public.ingredients_bar
+  add column if not exists conditionnement numeric not null default 1;
+
+comment on column public.ingredients.conditionnement is
+  'Nombre d''unités d''utilisation (unite) contenues dans un achat. prix_kg = prix d''achat / conditionnement.';
+comment on column public.ingredients_bar.conditionnement is
+  'Nombre d''unités d''utilisation (unite) contenues dans un achat. prix_kg = prix d''achat / conditionnement.';
+
+-- 2. Normalisation des unités texte libre existantes.
+do $$
+declare
+  tbl text;
+begin
+  foreach tbl in array array['ingredients', 'ingredients_bar', 'achats_lignes']
+  loop
+    execute format($f$
+      update public.%I set unite = case lower(trim(both '. ' from unite))
+        when 'kg' then 'kg' when 'kgs' then 'kg' when 'kilo' then 'kg' when 'kilos' then 'kg'
+          when 'kilogramme' then 'kg' when 'kilogrammes' then 'kg'
+        when 'g' then 'g' when 'gr' then 'g' when 'grs' then 'g'
+          when 'gramme' then 'g' when 'grammes' then 'g'
+        when 'l' then 'L' when 'litre' then 'L' when 'litres' then 'L' when 'lt' then 'L'
+        when 'cl' then 'cl' when 'centilitre' then 'cl' when 'centilitres' then 'cl'
+        when 'ml' then 'ml' when 'millilitre' then 'ml' when 'millilitres' then 'ml'
+        when 'u' then 'u' when 'un' then 'u' when 'unite' then 'u' when 'unites' then 'u'
+          when 'unité' then 'u' when 'unités' then 'u' when 'ea' then 'u' when 'article' then 'u'
+        when 'piece' then 'pièce' when 'pieces' then 'pièce'
+          when 'pièce' then 'pièce' when 'pièces' then 'pièce'
+          when 'pce' then 'pièce' when 'pcs' then 'pièce' when 'pc' then 'pièce'
+        when 'botte' then 'botte' when 'bottes' then 'botte'
+        when 'bouteille' then 'bouteille' when 'bouteilles' then 'bouteille'
+          when 'btl' then 'bouteille' when 'bt' then 'bouteille'
+        when 'portion' then 'portions' when 'portions' then 'portions'
+        else unite
+      end
+      where unite is not null and trim(unite) <> '';
+    $f$, tbl);
+  end loop;
+end $$;


### PR DESCRIPTION
## Contexte
Deux problèmes signalés sur l'enregistrement des factures/BL/avoirs :
1. Les unités, en **texte libre**, créaient des incohérences (`Kg` vs `kg`, `Kg.`, `EA`, `Article`…).
2. Impossible de dire **dans quel conditionnement** un article est vendu (ex : poulpe par unité de 10 tentacules, chocolat par pack de 3 kg) → prix de revient faux dans les fiches.

## Point 1 — unités en liste fermée
- Listes canoniques par section + helper `normUnite()` dans `lib/constants.js`.
- Les 4 champs texte libre deviennent des `<select>` : saisie de ligne à l'import (tableau + cartes), édition de facture, gestion des ingrédients. Une unité hors-liste déjà existante reste sélectionnable (rien n'est perdu).
- Migration de normalisation des unités déjà en base (`ingredients`, `ingredients_bar`, `achats_lignes`).

## Point 2 — conditionnement + conversion auto du prix
- Nouvelle colonne `conditionnement` sur `ingredients` / `ingredients_bar` (défaut `1`).
- Champ **« vendu par N {unité} »** à la création d'ingrédient (pendant l'import) et dans la page de gestion des ingrédients.
- `prix_kg` stocké = **prix d'achat / conditionnement** (prix par unité d'utilisation). La ligne de facture porte le prix du conditionnement (`prix_kg × cond`) pour que le **total de la facture corresponde à l'achat réel**.
- Les fiches techniques deviennent justes **sans modifier leur code** (`coutLigneEditor` utilise `prix_kg` directement).

## Vérifications
- ✅ 263 tests unitaires passent (vitest)
- ✅ ESLint clean sur les fichiers modifiés
- ✅ Pages `/controle-gestion/achats/import` et `/ingredients` compilent (200)
- ✅ Migration **déjà appliquée sur la prod** + normalisation vérifiée (plus aucune variante `Kg`/`EA`/`Article`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)