### PR TITLE
fix(ventes): le budget d'un mois ne fuite plus sur un autre mois

### DIFF
--- a/app/controle-gestion/ventes/page.js
+++ b/app/controle-gestion/ventes/page.js
@@ -222,6 +222,10 @@ export default function VentesMensuelPage() {
     const monthNum = Number(mStr)
     const cellMap = new Map() // key = `${jds}_${lieu}_${svc}`
     for (const b of budgetRows) {
+      // Seul le mois courant (override) ou le défaut annuel (mois = null) compte.
+      // Une cellule d'un autre mois précis ne doit jamais servir de fallback,
+      // sinon le budget d'un mois fuite sur un autre (ex : Privat de mai en juin).
+      if (b.mois !== monthNum && b.mois != null) continue
       const key = `${b.jour_semaine}_${b.lieu_service_id}_${b.service}`
       if (b.mois === monthNum) {
         cellMap.set(key, b)

--- a/lib/__tests__/rapportHebdo.test.ts
+++ b/lib/__tests__/rapportHebdo.test.ts
@@ -51,6 +51,27 @@ describe('caTtcVsBudget', () => {
     const res = caTtcVsBudget(caRows, budgetRows, '2026-05-01', '2026-05-04')
     expect(res.real).toBe(0)
   })
+
+  it('ne fait pas fuiter le budget d\'un mois précis sur un autre mois', () => {
+    // Cellule définie uniquement pour MAI (mois=5). En JUIN, sans cellule
+    // dédiée ni défaut annuel (mois=null), ce lieu ne doit rien budgéter.
+    const budgetMaiSeul = [
+      { annee: 2026, mois: 5, jour_semaine: 2, lieu_service_id: 'L3', service: 'dinner',
+        couverts_cible: 10, ca_food_cible: 5000, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+    ]
+    // Mardi 2 juin 2026 : aucune cellule juin → budget 0 (avant le fix : 5000).
+    const res = caTtcVsBudget([], budgetMaiSeul, '2026-06-02', '2026-06-02')
+    expect(res.budget).toBe(0)
+  })
+
+  it('utilise bien le défaut annuel (mois=null) comme fallback', () => {
+    const budgetDefaut = [
+      { annee: 2026, mois: null, jour_semaine: 2, lieu_service_id: 'L3', service: 'dinner',
+        couverts_cible: 10, ca_food_cible: 5000, ca_bev_20_cible: 0, ca_bev_10_cible: 0, ca_autre_cible: 0 },
+    ]
+    const res = caTtcVsBudget([], budgetDefaut, '2026-06-02', '2026-06-02')
+    expect(res.budget).toBe(5000)
+  })
 })
 
 describe('caTtcCumulMois', () => {

--- a/lib/rapportHebdo.js
+++ b/lib/rapportHebdo.js
@@ -65,6 +65,11 @@ function buildMonthCellMap(budgetRows, annee, mois) {
   const cellMap = new Map() // key = `${jds}_${lieu}_${svc}`
   for (const b of (budgetRows || [])) {
     if (b.annee != null && Number(b.annee) !== Number(annee)) continue
+    // Seule une cellule du mois courant (override) ou un défaut annuel
+    // (mois = null) est retenue. Une cellule d'un AUTRE mois précis ne doit
+    // jamais servir de fallback, sinon le budget d'un mois fuite sur un autre
+    // (ex : budget « Privat » de mai compté en juin).
+    if (b.mois !== mois && b.mois != null) continue
     const key = `${b.jour_semaine}_${b.lieu_service_id}_${b.service}`
     const isOverride = b.mois === mois
     const existing = cellMap.get(key)


### PR DESCRIPTION
## Symptôme
Écart au budget incohérent entre le **Suivi du CA** (colonne Δ MTD : **-232 €**) et le **Rapport hebdo** (cumul mois : **-12,4 %**, soit ~ -30 k€), pour un CA réalisé identique (212 248 €).

## Cause
La résolution des cellules de budget (`buildMonthCellMap` côté rapport, `budgetByDateIso` côté suivi) retombait, à défaut de cellule du mois courant, sur **n'importe quelle cellule d'un autre mois précis**, au lieu de se limiter au défaut annuel (`mois = null`).

Sur les données de prod : le lieu **« Privat »** avait un budget en **mai** (mois=5) sur jeu/ven/sam mais **pas en juin**. Ces cellules de mai (~29 700 €) **fuyaient sur juin**. Le rapport hebdo les comptait → -12 % ; le suivi CA (via son filtre de dates élues) ne les comptait pas → -232 €.

## Correctif
Le fallback n'accepte désormais que `mois = null` (vrai défaut annuel). Une cellule d'un autre mois précis est ignorée. Corrigé à l'identique dans les deux moteurs.

## Tests
- 2 nouveaux tests (`rapportHebdo.test.ts`) : pas de fuite inter-mois + le défaut annuel reste bien un fallback.
- Suite projet OK (les échecs résiduels sont dans `.claude/worktrees/*/node_modules`, libs tierces, sans rapport).

## Note
Séparément, le budget « Privat » du **lundi** (jour fermé pour cet établissement) a été neutralisé en base (override `nb_jours=0`, réversible) à la demande de l'utilisateur — il ne gonfle plus la colonne « Δ Mois total ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)