### PR TITLE
fix(food-cost): dates correctes dans l'export Excel (décalage de fuseau)

### DIFF
--- a/lib/__tests__/foodCostExport.test.ts
+++ b/lib/__tests__/foodCostExport.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { buildFoodCostWorkbook } from '../foodCostExport'
+
+describe('buildFoodCostWorkbook — dates', () => {
+  // Régression : le workbook est généré côté navigateur. Avec un minuit local,
+  // exceljs (qui sérialise via la valeur UTC) décalait les dates d'un jour
+  // selon le fuseau (facture du 16 affichée le 15). On vérifie que la date
+  // écrite correspond au bon jour calendaire en UTC, indépendamment du fuseau.
+  it('écrit la date de facture sur le bon jour (pas de décalage de fuseau)', async () => {
+    const wb = await buildFoodCostWorkbook({
+      periodeDebut: '2026-06-01',
+      periodeFin: '2026-06-16',
+      caFoodHt: 1000,
+      achatsHt: 300,
+      inventaireDebut: '',
+      inventaireFin: '',
+      notes: '',
+      factures: [
+        { date_facture: '2026-06-16', fournisseur: 'METRO', numero_facture: 'F1', total_ht: 300 },
+      ],
+      ajustements: [],
+    })
+
+    const wsFact = wb.getWorksheet('Factures')
+    // Ligne 1 = en-têtes, ligne 2 = première facture.
+    const cell = wsFact.getRow(2).getCell('date')
+    const d = cell.value as Date
+    expect(d).toBeInstanceOf(Date)
+    expect(d.getUTCFullYear()).toBe(2026)
+    expect(d.getUTCMonth()).toBe(5) // juin (0-indexé)
+    expect(d.getUTCDate()).toBe(16)
+  })
+})

--- a/lib/foodCostExport.js
+++ b/lib/foodCostExport.js
@@ -50,7 +50,12 @@ function esc(s) {
 
 function parseIsoDate(iso) {
   if (!iso) return null
-  return new Date(`${iso}T00:00:00`)
+  // UTC (suffixe Z) et non minuit local : le workbook est généré côté navigateur
+  // (souvent fuseau Paris UTC+1/+2), or exceljs sérialise les dates via leur
+  // valeur UTC. Minuit local donnait un getTime() la veille à 22 h/23 h UTC →
+  // Excel affichait le jour précédent (facture du 16 vue le 15, période fin -1).
+  // Minuit UTC garantit le bon jour calendaire quel que soit le fuseau.
+  return new Date(`${iso}T00:00:00Z`)
 }
 
 // ── Calculs ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Symptôme
Sur l'export Excel du food cost (ex. période 1 → 16 juin) : dates décalées d'un jour, et impression que les factures « jusqu'au 16 » ne sont pas prises en compte.

## Cause
Le workbook est généré **côté navigateur** (fuseau Paris UTC+1/+2). `parseIsoDate` créait un **minuit local** ; or exceljs sérialise les dates via leur valeur **UTC**. `getTime()` tombait donc la veille à 22 h/23 h UTC → Excel affichait le **jour précédent** (facture du 16 → 15, et « Période fin » → 15, d'où l'impression que le 16 manque).

Les données n'étaient **pas réellement exclues** : le filtre serveur est inclusif (`gte debut` / `lte fin`). Seul l'affichage des dates était décalé.

## Correctif
`parseIsoDate` utilise minuit **UTC** (`...T00:00:00Z`) → exceljs tombe sur le bon jour calendaire quel que soit le fuseau du poste.

## Test
Nouveau `foodCostExport.test.ts` : exécuté sous `TZ=Europe/Paris`, vérifie que la date d'une facture du 16/06 ressort bien au 16 (aurait échoué avant le fix). 183 tests food cost OK, lint clean.

## Note
`lib/budgetsExcelTemplate.js` utilise un motif de date similaire (`new Date(annee, mois-1, d)`) — potentiellement le même décalage sur l'export des budgets. Hors périmètre ici ; à corriger si besoin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)