### PR TITLE
fix(admin): message d'erreur clair quand le mot de passe fait < 8 caractères

### DIFF
--- a/app/admin/page.js
+++ b/app/admin/page.js
@@ -88,6 +88,10 @@ export default function AdminPage() {
       setError(t('admin.users.allRequired'))
       return
     }
+    if (newPassword.length < 8) {
+      setError('Le mot de passe doit contenir au moins 8 caractères.')
+      return
+    }
     setCreating(true)
     setError('')
     setSuccess('')
@@ -119,7 +123,7 @@ export default function AdminPage() {
     const data = await res.json()
 
     if (!res.ok || data.error) {
-      setError('Erreur : ' + data.error)
+      setError('Erreur : ' + formatApiError(data, 'Données invalides'))
       setCreating(false)
       return
     }


### PR DESCRIPTION
## Problème

Créer un utilisateur sur `/admin` échouait avec un **400 « Données invalides »** sec, sans expliquer la cause. En réalité le mot de passe saisi faisait moins de 8 caractères (minimum imposé par `createUserSchema`).

## Correctif

- `creerUtilisateur` utilise désormais `formatApiError` (déjà présent dans le fichier) → le message détaille le champ fautif, ex. `Données invalides — password: Mot de passe : 8 caractères minimum`.
- Garde-fou côté client : refus immédiat d'un mot de passe < 8 caractères avant l'appel API.

## Test

Saisir un mot de passe < 8 caractères → message explicite immédiat. Avec ≥ 8 caractères → création OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)