### PR TITLE
fix(inventaire): total correct au-delà de 1000 lignes (pagination)

### DIFF
--- a/app/inventaire/[id]/page.js
+++ b/app/inventaire/[id]/page.js
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect } from 'react'
 import * as XLSX from 'xlsx'
-import { supabase, getClientId } from '../../../lib/supabase'
+import { supabase, getClientId, fetchAllRows } from '../../../lib/supabase'
 import { useRouter, useParams, useSearchParams } from 'next/navigation'
 import { useTheme } from '../../../lib/useTheme'
 import { useIsMobile } from '../../../lib/useIsMobile'
@@ -40,9 +40,11 @@ export default function DetailInventairePage() {
     const clientId = await getClientId()
     if (!clientId) { router.push('/'); return }
 
-    const [{ data: inv }, { data: lig }] = await Promise.all([
+    const [{ data: inv }, lig] = await Promise.all([
       supabase.from('inventaires').select('*').eq('id', inventaireId).eq('client_id', clientId).maybeSingle(),
-      supabase.from('inventaire_lignes').select('*').eq('inventaire_id', inventaireId).eq('client_id', clientId).order('nom_ingredient'),
+      fetchAllRows((from, to) =>
+        supabase.from('inventaire_lignes').select('*').eq('inventaire_id', inventaireId).eq('client_id', clientId).order('nom_ingredient').order('id').range(from, to)
+      ),
     ])
 
     if (!inv) { router.push(`/inventaire${queryString}`); return }

--- a/app/inventaire/[id]/saisie/page.js
+++ b/app/inventaire/[id]/saisie/page.js
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect, useCallback, useRef } from 'react'
 import * as XLSX from 'xlsx'
-import { supabase, getClientId } from '../../../../lib/supabase'
+import { supabase, getClientId, fetchAllRows } from '../../../../lib/supabase'
 import { useRouter, useParams, useSearchParams } from 'next/navigation'
 import { useTheme } from '../../../../lib/useTheme'
 import { useRole } from '../../../../lib/useRole'
@@ -62,13 +62,17 @@ export default function SaisieInventairePage() {
     if (inv.statut === 'valide') { router.push(`/inventaire/${inventaireId}${queryString}`); return }
     setInventaire(inv)
 
-    // Charger les lignes
-    const { data: lig } = await supabase
-      .from('inventaire_lignes')
-      .select('*')
-      .eq('inventaire_id', inventaireId)
-      .eq('client_id', clientId)
-      .order('nom_ingredient')
+    // Charger les lignes (pagination au-delà du plafond PostgREST de 1000)
+    const lig = await fetchAllRows((from, to) =>
+      supabase
+        .from('inventaire_lignes')
+        .select('*')
+        .eq('inventaire_id', inventaireId)
+        .eq('client_id', clientId)
+        .order('nom_ingredient')
+        .order('id')
+        .range(from, to)
+    )
 
     setLignes(lig || [])
 

--- a/app/inventaire/page.js
+++ b/app/inventaire/page.js
@@ -1,6 +1,6 @@
 'use client'
 import { useState, useEffect, useMemo } from 'react'
-import { supabase, getClientId } from '../../lib/supabase'
+import { supabase, getClientId, fetchAllRows } from '../../lib/supabase'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useTheme } from '../../lib/useTheme'
 import { useRole } from '../../lib/useRole'
@@ -54,11 +54,15 @@ export default function InventairePage() {
     // Charger les lignes du dernier inventaire validé pour le dashboard
     const lastValidated = (data || []).find(i => i.statut === 'valide')
     if (lastValidated) {
-      const { data: lignes } = await supabase
-        .from('inventaire_lignes')
-        .select('nom_ingredient, valeur_stock, ecart, cout_unitaire, quantite_theorique, est_critique')
-        .eq('inventaire_id', lastValidated.id)
-        .eq('client_id', clientId)
+      const lignes = await fetchAllRows((from, to) =>
+        supabase
+          .from('inventaire_lignes')
+          .select('nom_ingredient, valeur_stock, ecart, cout_unitaire, quantite_theorique, est_critique')
+          .eq('inventaire_id', lastValidated.id)
+          .eq('client_id', clientId)
+          .order('id')
+          .range(from, to)
+      )
       setDernierLignes(lignes || [])
     } else {
       setDernierLignes([])
@@ -69,11 +73,15 @@ export default function InventairePage() {
     // bien plus simple qu'un view SQL et largement OK pour ce volume.
     const invIds = (data || []).map(i => i.id)
     if (invIds.length > 0) {
-      const { data: allLignes } = await supabase
-        .from('inventaire_lignes')
-        .select('inventaire_id, valeur_stock')
-        .eq('client_id', clientId)
-        .in('inventaire_id', invIds)
+      const allLignes = await fetchAllRows((from, to) =>
+        supabase
+          .from('inventaire_lignes')
+          .select('inventaire_id, valeur_stock')
+          .eq('client_id', clientId)
+          .in('inventaire_id', invIds)
+          .order('id')
+          .range(from, to)
+      )
       const totals = {}
       for (const l of allLignes || []) {
         const v = Number(l.valeur_stock) || 0

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -8,6 +8,25 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: { persistSession: true, autoRefreshToken: true },
 })
 
+// Récupère TOUTES les lignes d'une requête en paginant au-delà du plafond
+// PostgREST (1000 lignes par défaut). `makeQuery(from, to)` doit renvoyer un
+// query builder Supabase déjà ordonné de façon déterministe, sur lequel on
+// applique `.range(from, to)`. Sans ça, les gros inventaires (>1000 lignes)
+// étaient silencieusement tronqués et les totaux sous-évalués.
+export const fetchAllRows = async (makeQuery, pageSize = 1000) => {
+  const all = []
+  let from = 0
+  for (;;) {
+    const { data, error } = await makeQuery(from, from + pageSize - 1)
+    if (error) throw error
+    if (!data || data.length === 0) break
+    all.push(...data)
+    if (data.length < pageSize) break
+    from += pageSize
+  }
+  return all
+}
+
 export const getClientId = async () => {
   // Client-side uniquement, avec validation stricte via acces_clients.
   if (typeof window === 'undefined') return null


### PR DESCRIPTION
## Problème
Le total de l'inventaire était **trop bas** pour les gros établissements (ex. Marsan). Les requêtes sur `inventaire_lignes` n'avaient aucune pagination et subissaient le plafond PostgREST par défaut de **1000 lignes** : au-delà, les lignes étaient silencieusement tronquées.

| Inventaire Marsan | Lignes réelles | Chargées avant |
|---|---|---|
| Brouillon bar | 1655 | 1000 |
| Brouillon cuisine | 1080 | 1000 |

La page **liste** était pire encore : elle sommait *tous* les inventaires d'un client en une requête (~6000 lignes pour Marsan) → arrêt à 1000.

## Correctif
- Nouveau helper `fetchAllRows()` dans `lib/supabase.js` : pagine par tranches de 1000 via `.range()` jusqu'à épuisement.
- Appliqué aux 4 chargements de `inventaire_lignes` : liste (dashboard + totaux par inventaire), détail, saisie.
- Chaque requête paginée a un ordre déterministe (`.order(..., 'id')`) pour une pagination stable.

## Vérif
- Les 3 routes (`/inventaire`, `/inventaire/[id]`, `/inventaire/[id]/saisie`) compilent sans erreur.
- Cause racine confirmée en base : totaux live = `SUM(valeur_stock)`, aucun total stocké à corriger rétroactivement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)