### PR TITLE
feat(ventes): objectif de CA affiché sur chaque jour du suivi

### DIFF
--- a/app/controle-gestion/ventes/page.js
+++ b/app/controle-gestion/ventes/page.js
@@ -679,6 +679,7 @@ function MonthTable({ days, totals, mois, isMobile, c, t, locale }) {
               <th style={head}>{t('cgVentes.dashboard.colCaSoft')}</th>
               <th style={head}>{t('cgVentes.dashboard.colOther')}</th>
               <th style={head}>{t('cgVentes.dashboard.colCaTotal')}</th>
+              <th style={head}>{t('cgVentes.dashboard.colObjectif')}</th>
               <th style={head} title={t('cgVentes.dashboard.mtdTooltip')}>{t('cgVentes.dashboard.colMtd')}</th>
               <th style={head} title={t('cgVentes.dashboard.fullMonthTooltip')}>{t('cgVentes.dashboard.colFullMonth')}</th>
               <th style={head}>{t('cgVentes.common.tm')}</th>
@@ -707,6 +708,9 @@ function MonthTable({ days, totals, mois, isMobile, c, t, locale }) {
                 <td style={cell}>{formatEur(d.bev_10, locale)}</td>
                 <td style={cell}>{formatEur(d.autre, locale)}</td>
                 <td style={{ ...cell, fontWeight: 600 }}>{formatEur(d.caTot, locale)}</td>
+                <td style={{ ...cell, color: c.texteMuted }}>
+                  {d.budget ? formatEur(d.budget, locale) : '—'}
+                </td>
                 <td style={budgetCellStyle(d, cell, c)} title={budgetCellTitle(d, t, locale)}>
                   {budgetCellLabel(d, locale)}
                 </td>
@@ -743,6 +747,9 @@ function MonthTable({ days, totals, mois, isMobile, c, t, locale }) {
               <td style={cell}>{formatEur(totals.bev_10, locale)}</td>
               <td style={cell}>{formatEur(totals.autre, locale)}</td>
               <td style={{ ...cell, fontWeight: 700 }}>{formatEur(totals.caTot, locale)}</td>
+              <td style={{ ...cell, fontWeight: 700, color: c.texteMuted }}>
+                {totals.budget ? formatEur(totals.budget, locale) : '—'}
+              </td>
               <td style={mtdCellStyle(totals, cell, c)} title={mtdCellTitle(totals, t, locale)}>
                 {mtdCellLabel(totals, locale)}
               </td>

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -884,6 +884,7 @@
       "colCaSoft": "Soft drinks revenue",
       "colOther": "Other",
       "colCaTotal": "Total revenue",
+      "colObjectif": "Daily target",
       "colMtd": "Month to date",
       "mtdTooltip": "Day cell: actual vs day budget gap. Total: cumulative actual vs cumulative budget over the days already entered.",
       "colFullMonth": "Δ Full month",

--- a/lib/i18n/locales/es.json
+++ b/lib/i18n/locales/es.json
@@ -884,6 +884,7 @@
       "colCaSoft": "Ventas Refrescos",
       "colOther": "Otros",
       "colCaTotal": "Ventas Total",
+      "colObjectif": "Objetivo día",
       "colMtd": "Acumulado del mes",
       "mtdTooltip": "Celda del día: diferencia real - presupuesto del día. Total: real acumulado - presupuesto acumulado de los días ya registrados.",
       "colFullMonth": "Δ Mes completo",

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -884,6 +884,7 @@
       "colCaSoft": "CA Soft",
       "colOther": "Autres",
       "colCaTotal": "CA Total",
+      "colObjectif": "Objectif jour",
       "colMtd": "Month to date",
       "mtdTooltip": "Cellule jour : écart réel - budget du jour. Total : cumul réel - cumul budget sur les jours déjà saisis.",
       "colFullMonth": "Δ Mois total",

--- a/lib/i18n/locales/it.json
+++ b/lib/i18n/locales/it.json
@@ -884,6 +884,7 @@
       "colCaSoft": "Ricavi Analcolici",
       "colOther": "Altri",
       "colCaTotal": "Ricavi Totali",
+      "colObjectif": "Obiettivo giorno",
       "colMtd": "Cumulato del mese",
       "mtdTooltip": "Cella del giorno: scarto reale - budget del giorno. Totale: reale cumulato - budget cumulato sui giorni già inseriti.",
       "colFullMonth": "Δ Mese intero",


### PR DESCRIPTION
## Besoin
Voir, sur le suivi CA journalier, **l'objectif de chaque jour** ("ce que l'on doit faire"), pas seulement l'écart.

## Constat
La page `/controle-gestion/ventes` calculait **déjà** un budget par jour (`d.budget`, dérivé des budgets par jour-de-semaine + overrides + lissage privat). Mais il n'était affiché que via la colonne d'écart coloré ; la valeur cible n'apparaissait qu'en infobulle.

## Changement
- Nouvelle colonne **« Objectif jour »** entre « CA Total » et l'écart, affichant `d.budget` en clair pour chaque jour.
- Pied de tableau : objectif du **mois entier** (`monthlyBudgetAligned`, overrides respectés).
- Réutilise la logique de budget existante — **aucune migration, aucun nouveau calcul**.
- i18n FR / EN / ES / IT.

## Vérif
- La page compile sans erreur.
- Vérif visuelle avec données réelles impossible ici (page authentifiée, pas de session dans le preview) — à confirmer côté Marsan qui a bien 275 lignes de budget 2026 configurées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)