### PR TITLE
fix(rls): fermer l'accès anon au bucket fiches-photos + policies menu_bar_fiches

### DIFF
--- a/supabase/migrations/20260715000000_fix_fiches_photos_storage_anon.sql
+++ b/supabase/migrations/20260715000000_fix_fiches_photos_storage_anon.sql
@@ -1,0 +1,44 @@
+-- Durcissement du bucket public `fiches-photos`.
+--
+-- Avant : les policies auto-générées (Insert gxhezc_0..3) ouvraient
+--   INSERT / SELECT / UPDATE / DELETE aux rôles {anon, authenticated}, avec pour
+--   seule condition `bucket_id = 'fiches-photos'`. La clé anon étant publique
+--   (embarquée dans le client web), n'importe qui sur internet pouvait lister,
+--   écraser ou SUPPRIMER les photos de n'importe quel restaurant.
+--
+-- Après : seules les sessions authentifiées peuvent lister/écrire/supprimer.
+--   Le bucket reste public EN LECTURE par URL : getPublicUrl() ne passe pas par
+--   ces policies, donc l'affichage des photos dans l'app n'est pas impacté.
+--
+-- Limite connue (suivi) : les chemins ne sont pas scopés par tenant
+--   (`cuisine/<uuid>.jpg`), donc un utilisateur authentifié d'un resto pourrait
+--   encore énumérer les photos d'un autre. Fermeture complète = re-pathing
+--   `<client_id>/<section>/...` + scoping des policies (change lib/uploadPhoto.js
+--   et les URLs stockées). Hors périmètre de ce correctif.
+
+drop policy if exists "Insert gxhezc_0" on storage.objects;
+drop policy if exists "Insert gxhezc_1" on storage.objects;
+drop policy if exists "Insert gxhezc_2" on storage.objects;
+drop policy if exists "Insert gxhezc_3" on storage.objects;
+
+drop policy if exists "fiches_photos_select_authenticated" on storage.objects;
+drop policy if exists "fiches_photos_insert_authenticated" on storage.objects;
+drop policy if exists "fiches_photos_update_authenticated" on storage.objects;
+drop policy if exists "fiches_photos_delete_authenticated" on storage.objects;
+
+create policy "fiches_photos_select_authenticated"
+  on storage.objects for select to authenticated
+  using (bucket_id = 'fiches-photos');
+
+create policy "fiches_photos_insert_authenticated"
+  on storage.objects for insert to authenticated
+  with check (bucket_id = 'fiches-photos');
+
+create policy "fiches_photos_update_authenticated"
+  on storage.objects for update to authenticated
+  using (bucket_id = 'fiches-photos')
+  with check (bucket_id = 'fiches-photos');
+
+create policy "fiches_photos_delete_authenticated"
+  on storage.objects for delete to authenticated
+  using (bucket_id = 'fiches-photos');

--- a/supabase/migrations/20260715000100_menu_bar_fiches_rls_policies.sql
+++ b/supabase/migrations/20260715000100_menu_bar_fiches_rls_policies.sql
@@ -1,0 +1,24 @@
+-- menu_bar_fiches : RLS activé mais AUCUNE policy (advisor rls_enabled_no_policy).
+-- Résultat : table inaccessible pour anon/authenticated (feature bar cassée pour
+-- tout nouveau tenant). Ajout des 4 policies tenant standard, identiques à
+-- celles de menu_fiches (isolation via user_has_client_access(client_id)).
+
+alter table public.menu_bar_fiches enable row level security;
+
+drop policy if exists menu_bar_fiches_select on public.menu_bar_fiches;
+drop policy if exists menu_bar_fiches_insert on public.menu_bar_fiches;
+drop policy if exists menu_bar_fiches_update on public.menu_bar_fiches;
+drop policy if exists menu_bar_fiches_delete on public.menu_bar_fiches;
+
+create policy menu_bar_fiches_select on public.menu_bar_fiches
+  for select using (user_has_client_access(client_id));
+
+create policy menu_bar_fiches_insert on public.menu_bar_fiches
+  for insert with check (user_has_client_access(client_id));
+
+create policy menu_bar_fiches_update on public.menu_bar_fiches
+  for update using (user_has_client_access(client_id))
+  with check (user_has_client_access(client_id));
+
+create policy menu_bar_fiches_delete on public.menu_bar_fiches
+  for delete using (user_has_client_access(client_id));


### PR DESCRIPTION
## Contexte
Préparation à la commercialisation multi-tenant : passe de durcissement RLS suite aux advisors sécurité Supabase (prod).

## Correctifs
- **Bucket `fiches-photos`** : les policies auto-générées (`Insert gxhezc_*`) ouvraient INSERT/SELECT/UPDATE/DELETE au rôle **`anon`** (clé publique embarquée côté client) avec pour seule condition `bucket_id`. → n'importe qui pouvait **lister, écraser ou supprimer** les photos de n'importe quel restaurant. Restreint au rôle `authenticated`. L'affichage public par URL n'est pas impacté (`getPublicUrl` ne passe pas par ces policies).
- **`menu_bar_fiches`** : RLS activé mais **aucune policy** (advisor `rls_enabled_no_policy`). Ajout des 4 policies tenant standard (`user_has_client_access(client_id)`), alignées sur `menu_fiches`.

## Déploiement
Déjà appliqué en prod via `apply_migration`. Ces fichiers versionnent le changement.

## Limite connue / suivi
Les chemins du bucket ne sont pas scopés par tenant (`cuisine/<uuid>.jpg`). Un utilisateur *authentifié* pourrait encore énumérer les photos d'un autre resto. Fermeture complète = re-pathing `<client_id>/...` + scoping des policies (change `lib/uploadPhoto.js` + URLs stockées). Hors périmètre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)