### PR TITLE
fix(storage): scoper clients-logos et fiches-photos au tenant

### DIFF
--- a/supabase/migrations/20260716120000_secure_clients_logos_storage.sql
+++ b/supabase/migrations/20260716120000_secure_clients_logos_storage.sql
@@ -1,0 +1,42 @@
+-- Sécurise le bucket public `clients-logos`.
+--
+-- Problème : l'écriture était ouverte au rôle `public` (donc anon) via les
+-- policies `upload_clients_logos` (INSERT) et `update_clients_logos` (UPDATE),
+-- toutes deux `WITH CHECK/USING (bucket_id = 'clients-logos')` sans aucune
+-- vérification d'auth ni de tenant. N'importe qui sur internet pouvait donc
+-- uploader des fichiers arbitraires et ÉCRASER le logo de n'importe quel resto
+-- (défacement + hébergement de contenu servi depuis notre Supabase).
+--
+-- Correctif : les chemins sont déjà `<client_id>/logo.<ext>` (cf.
+-- app/superadmin/page.js `uploadLogo`), on scope donc INSERT/UPDATE/DELETE aux
+-- membres du client concerné, via le helper `user_has_client_access` (qui
+-- autorise aussi les superadmins). La LECTURE reste publique : le bucket est
+-- public et l'affichage passe par getPublicUrl, qui n'utilise pas ces policies.
+
+DROP POLICY IF EXISTS "upload_clients_logos" ON storage.objects;
+DROP POLICY IF EXISTS "update_clients_logos" ON storage.objects;
+
+CREATE POLICY clients_logos_insert ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'clients-logos'
+    AND public.user_has_client_access(((storage.foldername(name))[1])::uuid)
+  );
+
+CREATE POLICY clients_logos_update ON storage.objects
+  FOR UPDATE TO authenticated
+  USING (
+    bucket_id = 'clients-logos'
+    AND public.user_has_client_access(((storage.foldername(name))[1])::uuid)
+  )
+  WITH CHECK (
+    bucket_id = 'clients-logos'
+    AND public.user_has_client_access(((storage.foldername(name))[1])::uuid)
+  );
+
+CREATE POLICY clients_logos_delete ON storage.objects
+  FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'clients-logos'
+    AND public.user_has_client_access(((storage.foldername(name))[1])::uuid)
+  );

--- a/supabase/migrations/20260716120100_secure_fiches_photos_tenant_scope.sql
+++ b/supabase/migrations/20260716120100_secure_fiches_photos_tenant_scope.sql
@@ -1,0 +1,117 @@
+-- Scope les policies du bucket public `fiches-photos` au tenant.
+--
+-- Problème : les 4 policies `fiches_photos_*_authenticated` ne vérifiaient que
+-- `bucket_id = 'fiches-photos'`, sans scoping tenant. Un utilisateur connecté du
+-- resto A pouvait donc LISTER, LIRE, ÉCRASER et SUPPRIMER les photos du resto B
+-- (limitation documentée dans 20260715000000_fix_fiches_photos_storage_anon.sql).
+--
+-- Contrainte : les chemins sont `<cuisine|bar>/<ficheId>.<ext>` — indexés par
+-- ficheId, pas par client_id. Plutôt qu'une migration de données irréversible
+-- (re-pathing + réécriture des URLs stockées), on scope via sous-requête : le
+-- ficheId extrait du chemin doit appartenir à une `fiches` (cuisine) ou
+-- `fiches_bar` accessible au user courant. Les UUID étant globalement uniques,
+-- tester les deux tables en OR est sans ambiguïté.
+--
+-- Notes :
+--  * La lecture publique par URL (getPublicUrl) n'utilise PAS la policy SELECT
+--    (bucket public) → l'affichage des photos reste fonctionnel.
+--  * Le `.list(folder, {search: ficheId})` fait par lib/uploadPhoto.js avant
+--    upload reste OK : l'utilisateur voit les fichiers de SES propres fiches.
+--  * Les fichiers orphelins (fiche supprimée) et `.emptyFolderPlaceholder`
+--    deviennent accessibles uniquement au service-role — sans impact (aucune
+--    fiche ne les référence).
+--  * `split_part(storage.filename(name), '.', 1)` isole le ficheId : les UUID
+--    ne contiennent pas de point, la comparaison se fait en texte (pas de cast
+--    → pas d'erreur sur les chemins non-UUID comme le placeholder).
+
+DROP POLICY IF EXISTS "fiches_photos_select_authenticated" ON storage.objects;
+DROP POLICY IF EXISTS "fiches_photos_insert_authenticated" ON storage.objects;
+DROP POLICY IF EXISTS "fiches_photos_update_authenticated" ON storage.objects;
+DROP POLICY IF EXISTS "fiches_photos_delete_authenticated" ON storage.objects;
+
+CREATE POLICY fiches_photos_select ON storage.objects
+  FOR SELECT TO authenticated
+  USING (
+    bucket_id = 'fiches-photos'
+    AND (
+      EXISTS (
+        SELECT 1 FROM public.fiches f
+        WHERE f.id::text = split_part(storage.filename(name), '.', 1)
+          AND public.user_has_client_access(f.client_id)
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.fiches_bar fb
+        WHERE fb.id::text = split_part(storage.filename(name), '.', 1)
+          AND public.user_has_client_access(fb.client_id)
+      )
+    )
+  );
+
+CREATE POLICY fiches_photos_insert ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'fiches-photos'
+    AND (
+      EXISTS (
+        SELECT 1 FROM public.fiches f
+        WHERE f.id::text = split_part(storage.filename(name), '.', 1)
+          AND public.user_has_client_access(f.client_id)
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.fiches_bar fb
+        WHERE fb.id::text = split_part(storage.filename(name), '.', 1)
+          AND public.user_has_client_access(fb.client_id)
+      )
+    )
+  );
+
+CREATE POLICY fiches_photos_update ON storage.objects
+  FOR UPDATE TO authenticated
+  USING (
+    bucket_id = 'fiches-photos'
+    AND (
+      EXISTS (
+        SELECT 1 FROM public.fiches f
+        WHERE f.id::text = split_part(storage.filename(name), '.', 1)
+          AND public.user_has_client_access(f.client_id)
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.fiches_bar fb
+        WHERE fb.id::text = split_part(storage.filename(name), '.', 1)
+          AND public.user_has_client_access(fb.client_id)
+      )
+    )
+  )
+  WITH CHECK (
+    bucket_id = 'fiches-photos'
+    AND (
+      EXISTS (
+        SELECT 1 FROM public.fiches f
+        WHERE f.id::text = split_part(storage.filename(name), '.', 1)
+          AND public.user_has_client_access(f.client_id)
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.fiches_bar fb
+        WHERE fb.id::text = split_part(storage.filename(name), '.', 1)
+          AND public.user_has_client_access(fb.client_id)
+      )
+    )
+  );
+
+CREATE POLICY fiches_photos_delete ON storage.objects
+  FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'fiches-photos'
+    AND (
+      EXISTS (
+        SELECT 1 FROM public.fiches f
+        WHERE f.id::text = split_part(storage.filename(name), '.', 1)
+          AND public.user_has_client_access(f.client_id)
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.fiches_bar fb
+        WHERE fb.id::text = split_part(storage.filename(name), '.', 1)
+          AND public.user_has_client_access(fb.client_id)
+      )
+    )
+  );


### PR DESCRIPTION
## Contexte
Audit pré-vente : deux trous d'isolation multi-tenant sur le **Storage Supabase** (les seuls réellement exploitables trouvés). Migrations **déjà appliquées en prod** et vérifiées ; ce PR synchronise le repo.

## Trou 1 — `clients-logos` (🔴 exploitable par anon)
Le bucket public avait INSERT/UPDATE ouverts au rôle `public` → n'importe qui sur internet pouvait uploader des fichiers arbitraires et **écraser le logo** de n'importe quel restaurant. Les chemins étant déjà `<client_id>/logo.ext`, les policies sont scopées via `user_has_client_access` (authenticated only).

## Trou 2 — `fiches-photos` (🟠 cross-tenant entre users connectés)
Les policies `authenticated` ne vérifiaient que `bucket_id` → un utilisateur du resto A pouvait **lister / écraser / supprimer** les photos du resto B. Chemins en `<cuisine|bar>/<ficheId>.ext` : scoping par sous-requête sur `fiches`/`fiches_bar` — **sans migration de données irréversible**. La lecture publique par URL (`getPublicUrl`) n'utilise pas la policy SELECT → affichage inchangé.

## Vérification (impersonation RLS en prod)
- User d'un autre tenant : **0 photo visible** (avant : les 40)
- Propriétaire : **42 photos** (40 cuisine + 2 bar) inchangé
- Advisor Supabase `public_bucket_allows_listing` sur `fiches-photos` : **résolu**

## Notes
- 5 fichiers orphelins (fiche supprimée) + 1 placeholder deviennent accessibles uniquement au service-role — sans impact.
- Reste hors périmètre de ce PR (voir rapport d'audit) : Sentry + error boundaries, `npm audit fix`, PITR à confirmer, durcissement RPC anon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)