### PR TITLE
fix(api): vol cross-tenant import-data + guard update-legal

### DIFF
--- a/app/api/client/update-legal/route.ts
+++ b/app/api/client/update-legal/route.ts
@@ -5,7 +5,11 @@ import { updateClient } from '../../../../lib/services/admin.service'
 export const POST = apiHandler({
   schema: updateClientSchema,
   guard: 'adminOrSuperadmin',
-  clientIdFrom: 'body.clientId',
+  // Le client édité EST identifié par `id` (updateClient fait `.eq('id', id)`).
+  // On lie donc l'autorisation admin à ce même `id` : un admin de A ne peut
+  // pas éditer les infos légales de B en passant id=B. (Avant : 'body.clientId'
+  // — champ inexistant dans le schéma → guard résolvait undefined → 400.)
+  clientIdFrom: 'body.id',
   handler: async ({ data, db }) => {
     const result = await updateClient(db, data)
     return Response.json(result)

--- a/app/api/import-data/route.ts
+++ b/app/api/import-data/route.ts
@@ -59,7 +59,7 @@ export const POST = apiHandler({
       { name: 'ventes_journalieres', rows: p.ventes_journalieres as Row[] },
     ]
 
-    const report: Record<string, { upserted: number; errors: number; lastError?: string }> = {}
+    const report: Record<string, { upserted: number; errors: number; blocked?: number; lastError?: string }> = {}
 
     for (const { name, rows } of tables) {
       if (!rows || rows.length === 0) {
@@ -70,9 +70,41 @@ export const POST = apiHandler({
       const batchSize = 200
       let upserted = 0
       let errors = 0
+      let blocked = 0
       let lastError: string | undefined
       for (let i = 0; i < normalized.length; i += batchSize) {
-        const batch = normalized.slice(i, i + batchSize)
+        let batch = normalized.slice(i, i + batchSize)
+
+        // Sécurité anti-vol cross-tenant : un `id` du fichier peut correspondre
+        // à une ligne EXISTANTE d'un AUTRE établissement. Comme on écrit en
+        // service_role (RLS bypassée) avec onConflict:'id', l'upsert
+        // réassignerait cette ligne à notre client_id (vol + écrasement des
+        // données du voisin). On écarte donc les ids déjà possédés par un autre
+        // tenant. Les nouveaux ids (insert) et ceux du même client (update
+        // légitime, ex. ré-import de ses propres données) passent normalement.
+        const ids = batch
+          .map((r) => (r as Row).id)
+          .filter((id): id is string => typeof id === 'string')
+        if (ids.length > 0) {
+          const { data: foreign, error: checkErr } = await db
+            .from(name)
+            .select('id')
+            .in('id', ids)
+            .neq('client_id', clientId)
+          if (checkErr) {
+            errors += batch.length
+            lastError = checkErr.message
+            continue
+          }
+          if (foreign && foreign.length > 0) {
+            const foreignIds = new Set((foreign as Array<{ id: string }>).map((r) => r.id))
+            const before = batch.length
+            batch = batch.filter((r) => !foreignIds.has((r as Row).id as string))
+            blocked += before - batch.length
+          }
+        }
+        if (batch.length === 0) continue
+
         const { error } = await db.from(name).upsert(batch, { onConflict: 'id' })
         if (error) {
           errors += batch.length
@@ -81,16 +113,18 @@ export const POST = apiHandler({
           upserted += batch.length
         }
       }
-      report[name] = { upserted, errors, ...(lastError ? { lastError } : {}) }
+      report[name] = { upserted, errors, ...(blocked ? { blocked } : {}), ...(lastError ? { lastError } : {}) }
     }
 
     const totalUpserted = Object.values(report).reduce((s, r) => s + r.upserted, 0)
     const totalErrors = Object.values(report).reduce((s, r) => s + r.errors, 0)
+    const totalBlocked = Object.values(report).reduce((s, r) => s + (r.blocked ?? 0), 0)
 
     return Response.json({
       ok: true,
       total_upserted: totalUpserted,
       total_errors: totalErrors,
+      total_blocked: totalBlocked,
       report,
     })
   },


### PR DESCRIPTION
Audit pré-vente, points **#5** et **#6**.

## #5 — `import-data` : vol de lignes cross-tenant (MED)
L'upsert en service_role `onConflict:'id'` force `client_id` à l'appelant. Un admin de l'établissement A qui soumet un fichier contenant l'**UUID d'une ligne appartenant à B** réassignait cette ligne à A (RLS bypassée en service_role) → vol + écrasement des données du voisin.

**Fix** : pré-check par batch — les ids déjà possédés par un **autre** tenant (`.in('id', ids).neq('client_id', me)`) sont écartés avant l'upsert et comptés dans un nouveau champ `blocked` du rapport. Les nouveaux ids (insert) et le ré-import de ses **propres** données (même client) passent normalement.

Prédicat vérifié sur données prod : `blocked_for_owner=0`, `blocked_for_other=1`.

## #6 — `update-legal` : guard non lié à la cible (MED latent)
`clientIdFrom: 'body.clientId'` visait un champ **absent** du schéma (qui n'a que `id`) → le guard résolvait `undefined` → **400 systématique** (route cassée, fail-closed, donc pas exploitable aujourd'hui). Mais l'autorisation n'était pas liée au client édité : piège si quelqu'un « réparait » le 400 en ajoutant un champ `clientId` séparé (un admin de A aurait pu passer `clientId=A` + `id=B`).

**Fix** : `clientIdFrom: 'body.id'` — c'est aussi la cible du `.eq('id', id)` de `updateClient`, donc l'autorisation admin est désormais liée exactement au client réellement modifié.

## Vérif
Build client + serveur OK. Changements API pure (pas d'UI). Prédicat de sécurité #5 testé sur la base prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)