### PR TITLE
chore(sécurité): durcissements pré-vente #8-#10

### DIFF
--- a/app/api/docs/route.js
+++ b/app/api/docs/route.js
@@ -2,7 +2,17 @@ import { openapiSpec } from '../../../lib/openapi.js'
 
 export const dynamic = 'force-dynamic'
 
+// Ne pas exposer la cartographie complète de l'API (tous les endpoints +
+// schémas) aux anonymes en prod. Doc dispo en dev ; réactivable en prod via
+// ENABLE_API_DOCS=true si un jour placée derrière une autre protection.
+function docsDisabled() {
+  return process.env.NODE_ENV === 'production' && process.env.ENABLE_API_DOCS !== 'true'
+}
+
 export async function GET() {
+  if (docsDisabled()) {
+    return new Response('Not found', { status: 404 })
+  }
   return Response.json(openapiSpec, {
     headers: { 'Access-Control-Allow-Origin': '*' },
   })

--- a/app/api/docs/ui/route.js
+++ b/app/api/docs/ui/route.js
@@ -1,6 +1,15 @@
 export const dynamic = 'force-dynamic'
 
+// Swagger UI : désactivé en prod (voir app/api/docs/route.js). Dispo en dev,
+// réactivable via ENABLE_API_DOCS=true.
+function docsDisabled() {
+  return process.env.NODE_ENV === 'production' && process.env.ENABLE_API_DOCS !== 'true'
+}
+
 export async function GET() {
+  if (docsDisabled()) {
+    return new Response('Not found', { status: 404 })
+  }
   const html = `<!DOCTYPE html>
 <html lang="fr">
 <head>

--- a/supabase/migrations/20260720120000_revoke_anon_execute_section_helpers.sql
+++ b/supabase/migrations/20260720120000_revoke_anon_execute_section_helpers.sql
@@ -1,0 +1,14 @@
+-- Durcissement : retirer l'exposition RPC anon des helpers RLS de sections.
+--
+-- `user_can_read_section` / `user_can_write_section` sont des SECURITY DEFINER
+-- utilisés uniquement DANS les policies RLS de fiches/ingredients (toutes
+-- `TO authenticated`). Ils n'ont aucune raison d'être appelables par `anon` via
+-- /rest/v1/rpc/* (advisor `anon_security_definer_function_executable`). On
+-- révoque PUBLIC/anon et on garde `authenticated` (nécessaire à l'évaluation
+-- des policies). Aligne ces 2 fonctions sur les autres helpers déjà durcis en
+-- 20260530150000.
+
+REVOKE EXECUTE ON FUNCTION public.user_can_read_section(uuid, text) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.user_can_write_section(uuid, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.user_can_read_section(uuid, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.user_can_write_section(uuid, text) TO authenticated;

--- a/supabase/migrations/20260720120100_superadmin_policies_use_is_superadmin.sql
+++ b/supabase/migrations/20260720120100_superadmin_policies_use_is_superadmin.sql
@@ -1,0 +1,40 @@
+-- Remplacer les emails superadmin codés en dur dans les policies RLS par le
+-- helper `is_superadmin()` (source unique de vérité = profils.is_superadmin).
+--
+-- L'email `auth.jwt()->>'email'` n'est PAS spoofable (claim GoTrue vérifié),
+-- donc ce n'est pas une faille — mais c'est fragile et incohérent : une policy
+-- listait 2 emails, une autre un seul. Si `antony@skalcook.com` était créé un
+-- jour, il aurait un accès incohérent selon la table. On centralise.
+--
+-- Vérifié avant migration : seul `antony.despaux@hotmail.fr` a is_superadmin=true
+-- en base → aucun verrouillage. `is_superadmin()` est SECURITY DEFINER (lit
+-- profils en bypass RLS) → pas de récursion sur les policies profils/acces_clients.
+-- NE TOUCHE PAS `acces_clients_select_own` (accès membre, pivot de getClientId).
+
+-- ── acces_clients : consolider les 2 policies superadmin email en une seule ──
+DROP POLICY IF EXISTS "SuperAdmin manages all access" ON public.acces_clients;
+DROP POLICY IF EXISTS "acces_clients_superadmin_all" ON public.acces_clients;
+CREATE POLICY acces_clients_superadmin_all ON public.acces_clients
+  FOR ALL TO authenticated
+  USING (public.is_superadmin())
+  WITH CHECK (public.is_superadmin());
+
+-- ── profils : retirer la clause email redondante (get_my_is_superadmin() couvre) ──
+DROP POLICY IF EXISTS "Admins can view all profiles" ON public.profils;
+CREATE POLICY "Admins can view all profiles" ON public.profils
+  FOR SELECT TO public
+  USING ((get_my_role() = 'admin') OR (get_my_is_superadmin() = true));
+
+-- ── prospects : policy SELECT email redondante avec read_prospects_superadmin ──
+DROP POLICY IF EXISTS "Superadmins can see all prospects" ON public.prospects;
+
+-- ── storage.objects (documents_legaux) : email → is_superadmin() ──
+DROP POLICY IF EXISTS "Superadmins peuvent supprimer des documents" ON storage.objects;
+CREATE POLICY "Superadmins peuvent supprimer des documents" ON storage.objects
+  FOR DELETE TO authenticated
+  USING (bucket_id = 'documents_legaux' AND public.is_superadmin());
+
+DROP POLICY IF EXISTS "Superadmins peuvent uploader des documents" ON storage.objects;
+CREATE POLICY "Superadmins peuvent uploader des documents" ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (bucket_id = 'documents_legaux' AND public.is_superadmin());


### PR DESCRIPTION
Audit pré-vente, points **#8, #9, #10** (durcissements — pas de faille critique, mais surface réduite avant la vente).

## #8 — Docs API privées en prod
`/api/docs` (spec OpenAPI complète, `Access-Control-Allow-Origin: *`) + `/api/docs/ui` (Swagger UI) étaient **publics** → cartographie de toute l'API offerte aux anonymes. Désactivés en prod (404), toujours dispo en dev, réactivables via `ENABLE_API_DOCS=true`.

## #9 — Helpers RLS : retrait de l'exposition RPC anon
`REVOKE EXECUTE` `anon`/`public` sur `user_can_read_section` / `user_can_write_section` (SECURITY DEFINER, utilisés uniquement dans des policies `TO authenticated`). `GRANT authenticated` conservé (nécessaire à la RLS). Advisor `anon_security_definer_function_executable` **résolu**. _(Migration `20260720120000`, appliquée prod.)_

## #10 — Policies superadmin : email hardcodé → `is_superadmin()`
Remplace `auth.jwt()->>'email' = ANY([...emails...])` par `is_superadmin()` sur `acces_clients`, `profils`, `prospects` (redondante → drop) et storage `documents_legaux`. Non spoofable (donc pas une faille) mais fragile et incohérent (une policy listait 2 emails, une autre 1 seul). Source unique de vérité = `profils.is_superadmin`. _(Migration `20260720120100`, appliquée prod.)_

### Vérification (impersonation RLS prod)
- Superadmin : voit **14/14** `acces_clients` + **13** profils ✓
- Membre normal : voit **1** ligne (la sienne), **0 fuite** cross-tenant ✓
- `acces_clients_select_own` (pivot getClientId) **non touché**.

Build client + serveur OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)