### PR TITLE
fix(i18n): corriger l'erreur d'hydratation React #418

### DIFF
--- a/components/I18nProvider.jsx
+++ b/components/I18nProvider.jsx
@@ -1,10 +1,28 @@
 'use client'
 import { useEffect } from 'react'
 import { I18nextProvider } from 'react-i18next'
-import i18n from '../lib/i18n'
+import i18n, { SUPPORTED_LOCALES, LOCALE_STORAGE_KEY } from '../lib/i18n'
 
 export default function I18nProvider({ children }) {
   useEffect(() => {
+    // i18n est initialisé en 'fr' (cf. lib/i18n) pour que SSR === 1er rendu
+    // client (pas de mismatch #418). Une fois hydraté, on applique la vraie
+    // langue de l'utilisateur : localStorage ('skalcook_locale') puis navigateur.
+    try {
+      const stored = localStorage.getItem(LOCALE_STORAGE_KEY)
+      const nav = (navigator.language || '').slice(0, 2)
+      const target = SUPPORTED_LOCALES.includes(stored)
+        ? stored
+        : SUPPORTED_LOCALES.includes(nav)
+          ? nav
+          : null
+      if (target && target !== i18n.resolvedLanguage) {
+        i18n.changeLanguage(target)
+      }
+    } catch {
+      /* détection best-effort : on reste en 'fr' si quoi que ce soit échoue */
+    }
+
     const sync = (lng) => {
       if (typeof document !== 'undefined') document.documentElement.lang = lng
     }

--- a/components/LanguageSwitcher.jsx
+++ b/components/LanguageSwitcher.jsx
@@ -1,21 +1,27 @@
 'use client'
 import { useTranslation } from 'react-i18next'
-import { SUPPORTED_LOCALES, LOCALE_LABELS } from '../lib/i18n'
+import { SUPPORTED_LOCALES, LOCALE_LABELS, LOCALE_STORAGE_KEY } from '../lib/i18n'
 
 /**
  * Sélecteur de langue compact. Variante 'nav' (sombre) ou 'light'.
- * Le choix est persisté en localStorage par i18next (skalcook_locale).
+ * Le choix est persisté manuellement en localStorage (LOCALE_STORAGE_KEY) :
+ * i18next-browser-languagedetector n'est plus utilisé (cf. lib/i18n, fix #418).
  */
 export default function LanguageSwitcher({ variant = 'nav', style }) {
   const { i18n } = useTranslation()
   const current = (i18n.resolvedLanguage || i18n.language || 'fr').slice(0, 2)
+
+  const changeLang = (lng) => {
+    i18n.changeLanguage(lng)
+    try { localStorage.setItem(LOCALE_STORAGE_KEY, lng) } catch { /* ignore */ }
+  }
 
   const dark = variant === 'nav'
   return (
     <select
       aria-label="Langue"
       value={SUPPORTED_LOCALES.includes(current) ? current : 'fr'}
-      onChange={(e) => i18n.changeLanguage(e.target.value)}
+      onChange={(e) => changeLang(e.target.value)}
       style={{
         background: dark ? 'rgba(255,255,255,0.06)' : 'transparent',
         color: dark ? 'rgba(255,255,255,0.7)' : 'inherit',

--- a/lib/i18n/index.js
+++ b/lib/i18n/index.js
@@ -1,7 +1,6 @@
 'use client'
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
-import LanguageDetector from 'i18next-browser-languagedetector'
 
 import fr from './locales/fr.json'
 import en from './locales/en.json'
@@ -10,23 +9,27 @@ import it from './locales/it.json'
 
 export const SUPPORTED_LOCALES = ['fr', 'en', 'es', 'it']
 export const LOCALE_LABELS = { fr: 'Français', en: 'English', es: 'Español', it: 'Italiano' }
+export const LOCALE_STORAGE_KEY = 'skalcook_locale'
 
 if (!i18n.isInitialized) {
   i18n
-    .use(LanguageDetector)
     .use(initReactI18next)
     .init({
       resources: { fr: { common: fr }, en: { common: en }, es: { common: es }, it: { common: it } },
+      // Langue initiale FIXE ('fr') : le rendu serveur (pas de localStorage/
+      // navigator → fallback) et le 1er rendu client DOIVENT être identiques,
+      // sinon les libellés traduits (ex. Navbar) diffèrent → erreur d'hydratation
+      // React #418. On n'utilise donc PAS i18next-browser-languagedetector au
+      // démarrage (il lisait localStorage/navigator côté client uniquement, d'où
+      // le mismatch, et son cache réécrivait localStorage à l'init). La vraie
+      // langue est détectée + appliquée APRÈS hydratation par I18nProvider, et
+      // persistée manuellement par LanguageSwitcher (clé LOCALE_STORAGE_KEY).
+      lng: 'fr',
       fallbackLng: 'fr',
       supportedLngs: SUPPORTED_LOCALES,
       defaultNS: 'common',
       ns: ['common'],
       interpolation: { escapeValue: false },
-      detection: {
-        order: ['localStorage', 'navigator'],
-        lookupLocalStorage: 'skalcook_locale',
-        caches: ['localStorage'],
-      },
       react: { useSuspense: false },
     })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@vercel/analytics": "^2.0.1",
         "exceljs": "^4.4.0",
         "i18next": "^26.3.0",
-        "i18next-browser-languagedetector": "^8.2.1",
         "isomorphic-dompurify": "^3.7.1",
         "next": "16.1.6",
         "react": "19.2.3",
@@ -7598,15 +7597,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/i18next-browser-languagedetector": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
-      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iceberg-js": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@vercel/analytics": "^2.0.1",
     "exceljs": "^4.4.0",
     "i18next": "^26.3.0",
-    "i18next-browser-languagedetector": "^8.2.1",
     "isomorphic-dompurify": "^3.7.1",
     "next": "16.1.6",
     "react": "19.2.3",


### PR DESCRIPTION
## Le bug
Erreur `Minified React error #418` (hydratation — *text content mismatch*) sur la prod, repérée sur `/fiches` pendant la mise en place de Sentry.

**Cause racine :** `lib/i18n` utilisait `i18next-browser-languagedetector` (`order: ['localStorage','navigator']`). Côté **serveur** (pas de localStorage/navigator) → `fallbackLng: 'fr'`. Côté **client** → langue stockée/navigateur. Si ≠ `fr`, les libellés traduits (la **Navbar** via `t()`, rendue sur toutes les pages authentifiées) diffèrent entre SSR et hydratation → #418.

## Le fix (pattern standard react-i18next + App Router)
- **`lib/i18n`** : init avec **`lng: 'fr'` fixe**, détecteur retiré → SSR et 1er rendu client identiques (`fr`) → plus de mismatch. Export `LOCALE_STORAGE_KEY`.
- **`I18nProvider`** : détecte la vraie langue (localStorage puis navigateur) et l'applique via `changeLanguage` **après hydratation**.
- **`LanguageSwitcher`** : persiste le choix manuellement en localStorage.
- Dépendance `i18next-browser-languagedetector` devenue inutile → **désinstallée**.

## Vérification
- Build client + serveur OK (sans la dépendance).
- Smoke test dev : avec `skalcook_locale=en`, la préférence **n'est plus écrasée** (un 1er essai gardant le détecteur la clobberait — écarté), la langue bascule bien **après** hydratation, **0 erreur console**.
- ⚠️ Repro complète sur `/fiches` impossible en local (page authentifiée). Cause racine certaine + mécanisme vérifié. **À confirmer côté prod** après déploiement : hard-refresh `/fiches` → console propre, et le #418 doit cesser d'apparaître dans Sentry.

## Effet de bord attendu (bénin)
Pour un utilisateur non-francophone, un très bref flash de français avant bascule vers sa langue (compromis standard du i18n client-side, bien meilleur qu'un crash d'hydratation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)