### PR TITLE
fix(coûts): coefficient d'unité, perte et protection des fiches étoilées dans le recalcul

### DIFF
--- a/app/api/import-fiches/route.ts
+++ b/app/api/import-fiches/route.ts
@@ -1,4 +1,5 @@
 import { apiHandler } from '../../../lib/apiHandler'
+import { uniteCoefficient } from '../../../lib/cout'
 import { z } from 'zod'
 
 // Import en masse de fiches techniques (cuisine) depuis un fichier Excel parsé
@@ -162,7 +163,9 @@ export const POST = apiHandler({
       let sum = 0
       for (const l of f.lignes) {
         const ing = ingMap.get(norm(l.ingredient))
-        if (ing?.prix_kg != null) sum += ing.prix_kg * l.quantite
+        // `prix_kg` est rattaché à l'unité de base (kg/L) : sans coefficient,
+        // une ligne en grammes est comptée 1000× trop cher.
+        if (ing?.prix_kg != null) sum += ing.prix_kg * l.quantite * uniteCoefficient(l.unite)
       }
       const coutPortion = f.nb_portions > 0 ? sum / f.nb_portions : null
 

--- a/supabase/migrations/20260721120000_fix_recalcul_cout_portions_coefficient_unite.sql
+++ b/supabase/migrations/20260721120000_fix_recalcul_cout_portions_coefficient_unite.sql
@@ -1,0 +1,88 @@
+-- Corrige `recalculer_cout_portions()` / `..._bar()`, appelées par le bouton
+-- « Recalcul du coût de toutes les fiches » de l'écran d'import.
+--
+-- Deux défauts, tous deux capables de corrompre massivement les coûts :
+--
+-- 1. Coefficient d'unité absent. `SUM(prix_kg * quantite)` traite une ligne en
+--    grammes comme des kilos → coût 1000× trop élevé (100× pour cl, ml → 1000×).
+--    C'est le bug que `lib/cout.js` documente comme corrigé côté JS, resté vivant
+--    ici. On applique la même table de coefficients que `uniteCoefficient()`.
+--
+-- 2. Incompatibilité avec les préparations dosées. Une fiche étoilée produit un
+--    batch (ex. 2800 g) dont seuls quelques grammes partent par assiette ; son
+--    coût/portion est calculé par `coutPortionEtoile()` côté JS et enregistré à
+--    la sauvegarde. La somme à plat compte le batch entier : mesuré sur MARSAN,
+--    « BABA RHUBARBE » passerait de 1,80 € à 170,52 € (×95). On exclut donc
+--    toute fiche possédant des sections — son coût appartient à l'éditeur.
+--    Les fiches à plat (sans section), elles, correspondent exactement au modèle
+--    de cette fonction et restent recalculées.
+--
+-- 3. Coefficient de perte absent. L'éditeur applique `cout / (1 - perte/100)`
+--    (`calculerCoutAvecPerte()`), la fonction non : elle sous-évaluait donc les
+--    70 fiches qui déclarent une perte (jusqu'à 20% chez MARSAN). On l'ajoute
+--    pour que la fonction reproduise exactement le modèle JS.
+--
+-- Le bar n'a pas de sections (`fiche_sections` est côté cuisine) : seuls le
+-- coefficient d'unité et la perte s'y appliquent.
+
+CREATE OR REPLACE FUNCTION public.recalculer_cout_portions()
+ RETURNS void
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  UPDATE fiches f
+  SET cout_portion = (
+    SELECT SUM(
+      i.prix_kg * fi.quantite *
+      CASE
+        WHEN fi.unite IN ('g', 'ml') THEN 0.001
+        WHEN fi.unite = 'cl'         THEN 0.01
+        ELSE 1
+      END
+    )
+    -- Coefficient de perte, comme `calculerCoutAvecPerte()` côté JS.
+    / NULLIF(1 - COALESCE(f.perte, 0) / 100, 0)
+    / NULLIF(f.nb_portions, 0)
+    FROM fiche_ingredients fi
+    JOIN ingredients i ON i.id = fi.ingredient_id
+    WHERE fi.fiche_id = f.id
+    AND i.prix_kg IS NOT NULL
+  )
+  WHERE f.nb_portions > 0
+  AND f.archive = false
+  -- Coût piloté par le calcul dosé côté JS : ne pas écraser.
+  AND NOT EXISTS (
+    SELECT 1 FROM fiche_sections s WHERE s.fiche_id = f.id
+  );
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.recalculer_cout_portions_bar()
+ RETURNS void
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  UPDATE fiches_bar f
+  SET cout_portion = (
+    SELECT SUM(
+      i.prix_kg * fi.quantite *
+      CASE
+        WHEN fi.unite IN ('g', 'ml') THEN 0.001
+        WHEN fi.unite = 'cl'         THEN 0.01
+        ELSE 1
+      END
+    )
+    -- Coefficient de perte, comme `calculerCoutAvecPerte()` côté JS.
+    / NULLIF(1 - COALESCE(f.perte, 0) / 100, 0)
+    / NULLIF(f.nb_portions, 0)
+    FROM fiche_bar_ingredients fi
+    JOIN ingredients_bar i ON i.id = fi.ingredient_id
+    WHERE fi.fiche_bar_id = f.id
+    AND i.prix_kg IS NOT NULL
+  )
+  WHERE f.nb_portions > 0
+  AND f.archive = false;
+END;
+$function$;


### PR DESCRIPTION
## Le problème

`recalculer_cout_portions()` / `..._bar()` — appelées par le bouton **« Recalcul du coût de toutes les fiches »** de l'écran d'import — et la route `app/api/import-fiches` calculaient :

```sql
SUM(i.prix_kg * fi.quantite) / nb_portions
```

**Sans coefficient d'unité.** Une ligne en grammes est comptée 1000× trop cher (100× pour `cl`). C'est précisément le bug que l'en-tête de `lib/cout.js` documente comme corrigé côté JS — il était resté vivant en SQL et dans l'API d'import.

## Deux autres divergences trouvées en vérifiant

Corriger seulement le coefficient aurait causé **bien pire que le bug d'origine** :

**1. Les fiches étoilées auraient été détruites.** Une fiche à préparations dosées produit un batch (ex. 2800 g) dont quelques grammes partent par assiette ; son coût est calculé par `coutPortionEtoile()`. La somme à plat compte le batch entier :

| Fiche (MARSAN) | Coût réel | Somme à plat corrigée |
|---|---|---|
| BABA RHUBARBE | 1,80 € | **170,52 €** (×95) |
| DESSERT AUX HERBES | 3,64 € | 75,73 € |
| Chocolat cerise | 1,56 € | 51,65 € |

→ Les fiches possédant des sections sont désormais **exclues** du recalcul : leur coût appartient à l'éditeur.

**2. Le coefficient de perte était ignoré.** L'éditeur applique `cout / (1 - perte/100)`, la fonction non — elle sous-évaluait les **70 fiches** qui déclarent une perte (jusqu'à 20% chez MARSAN). Ajouté.

## Vérification

Simulation **en lecture seule** sur la base de production. Avec les trois correctifs, la fonction reproduit désormais les valeurs de l'éditeur au dix-millième près :

| Fiche | Stocké par l'éditeur | Fonction corrigée |
|---|---|---|
| TARAMA WASABI | 3,3932 | **3,3932** |
| LAYER CAKE V2 | 3,4920 | **3,4920** |

Portée : 14 fiches étoilées protégées (7 JOIA + 7 MARSAN), 262 fiches à plat recalculables, 0 fiche passant à `NULL`.

Sécurité multi-tenant vérifiée : les fonctions sont `SECURITY INVOKER` et la RLS est active sur `fiches`, donc le recalcul reste borné au client appelant.

Lint et `tsc --noEmit` propres.

## Ce que cette PR ne fait PAS

Elle **corrige l'outil, elle ne répare aucune donnée**. Des coûts périmés existent en base (« Sauce grué » à 56 598 € au lieu de 6,79 € — cause historique, non imputable au coefficient puisque cette fiche est en kg). Ils ne bougeront qu'au prochain appui volontaire sur le bouton.

À savoir avant de le presser : le recalcul ferait aussi **monter** 15 fiches MARSAN et 20 JOIA de plus de 50%, car leur coût stocké est antérieur à des hausses de prix d'ingrédients. C'est le comportement attendu, mais ça mérite un œil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
