### PR TITLE
fix(food cost): lire les seuils bar depuis les colonnes seuil_*_boissons

### DIFF
--- a/lib/__tests__/foodCost.test.ts
+++ b/lib/__tests__/foodCost.test.ts
@@ -82,6 +82,21 @@ describe('getSeuilsFromParams', () => {
     expect(result.seuilOrange).toBe(28)
   })
 
+  // Régression : les colonnes bar sont `seuil_*_boissons`, pas `seuil_*_bar`.
+  // Interpoler la section faisait retomber sur les défauts en ignorant la
+  // configuration de l'établissement (JOIA : 25/28 lu comme 22/28).
+  it('reads bar thresholds from the seuil_*_boissons columns', () => {
+    const params = {
+      seuil_vert_boissons: '25',
+      seuil_orange_boissons: '30',
+      seuil_vert_cuisine: '28',
+      seuil_orange_cuisine: '35',
+    }
+    const result = getSeuilsFromParams(params, 'bar')
+    expect(result.seuilVert).toBe(25)
+    expect(result.seuilOrange).toBe(30)
+  })
+
   it('defaults to cuisine when section unknown', () => {
     const params = {}
     const result = getSeuilsFromParams(params)

--- a/lib/foodCost.js
+++ b/lib/foodCost.js
@@ -1,5 +1,8 @@
 import { DEFAULT_SEUILS, DEFAULT_TVA, CATEGORIES_SOUS_FICHE, NOMS_SOUS_FICHE } from './constants'
 
+/** Suffixe des colonnes `clients` porteuses des seuils, par section. */
+const SUFFIXE_PARAM = { cuisine: 'cuisine', bar: 'boissons' }
+
 // ─── Calculs ─────────────────────────────────────────────────────────────────
 
 /**
@@ -36,9 +39,14 @@ export function foodCostColor(fc, seuilVert, seuilOrange) {
  */
 export function getSeuilsFromParams(params, section = 'cuisine') {
   const def = DEFAULT_SEUILS[section] ?? DEFAULT_SEUILS.cuisine
+  // Le nom de section ne peut pas être interpolé tel quel : les colonnes de
+  // `clients` sont `seuil_*_boissons` pour le bar, pas `seuil_*_bar`. Interpoler
+  // `section` faisait chercher une clé inexistante → retour systématique au
+  // défaut, donc les seuils bar configurés n'étaient jamais lus.
+  const suffixe = SUFFIXE_PARAM[section] ?? SUFFIXE_PARAM.cuisine
   return {
-    seuilVert:   parseFloat(params[`seuil_vert_${section}`]   ?? def.vert),
-    seuilOrange: parseFloat(params[`seuil_orange_${section}`] ?? def.orange),
+    seuilVert:   parseFloat(params[`seuil_vert_${suffixe}`]   ?? def.vert),
+    seuilOrange: parseFloat(params[`seuil_orange_${suffixe}`] ?? def.orange),
     tva:         parseFloat(params['tva_restauration']         ?? DEFAULT_TVA),
   }
 }


### PR DESCRIPTION
## Le bug

`getSeuilsFromParams(params, 'bar')` interpolait le nom de section :

```js
parseFloat(params[`seuil_vert_${section}`] ?? def.vert)   // → seuil_vert_bar
```

Mais `getParametres()` ne renvoie jamais cette clé — les colonnes de `clients` sont `seuil_vert_boissons` / `seuil_orange_boissons`. Le `??` retombait donc **toujours** sur les défauts, et les seuils bar configurés n'étaient jamais lus.

## Impact réel en production

| Établissement | Configuré | Appliqué par l'app |
|---|---|---|
| JOIA | 25 / 28 | **22 / 28** |
| MARSAN | 22 / 23 | **22 / 28** |

Le compteur d'alertes du dashboard bar (`app/bar/dashboard/page.js:59`) était donc calculé contre un seuil que personne n'avait choisi.

## Le correctif

Une table de correspondance section → suffixe de colonne remplace l'interpolation, qui supposait à tort que le nom de section et le nom de colonne coïncidaient.

## Vérification

Test de régression ajouté. Il **échoue sans le correctif** — vérifié en exécutant les deux versions sur les paramètres réels de JOIA :

```
JOIA configure 25 → ancien code lit: 22 | code corrigé lit: 25
```

Les 3 tests existants de `getSeuilsFromParams` ne l'attrapaient pas : celui du bar ne passait que `{}`, donc il validait le chemin par défaut, précisément celui où le bug se cache.

Suite complète : 71 tests passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
