### PR TITLE
fix(food cost): noter les plats avec les seuils de l'établissement, pas 30/40 en dur

### DIFF
--- a/app/menus/page.js
+++ b/app/menus/page.js
@@ -1,11 +1,13 @@
 'use client'
 import { useState, useEffect } from 'react'
-import { supabase, getClientId } from '../../lib/supabase'
+import { supabase, getClientId, getParametres } from '../../lib/supabase'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useIsMobile } from '../../lib/useIsMobile'
 import { useTheme } from '../../lib/useTheme'
 import Navbar from '../../components/Navbar'
 import ChefLoader from '../../components/ChefLoader'
+import { getSeuilsFromParams } from '../../lib/foodCost'
+import { DEFAULT_SEUILS } from '../../lib/constants'
 import MenusGrid from '../../components/contenus/MenusGrid'
 import CartesGrid from '../../components/contenus/CartesGrid'
 
@@ -20,6 +22,9 @@ export default function MenusEtCartesPage() {
 
   const initialTab = searchParams.get('tab') === 'cartes' ? 'cartes' : 'menus'
   const [tab, setTab] = useState(initialTab)
+  // Seuils food cost de l'établissement : les grilles notent le même food cost
+  // que les fiches et doivent donc utiliser les mêmes seuils.
+  const [seuils, setSeuils] = useState(DEFAULT_SEUILS.cuisine)
 
   useEffect(() => {
     checkUser()
@@ -34,6 +39,14 @@ export default function MenusEtCartesPage() {
   const loadAll = async () => {
     const clientId = await getClientId()
     if (!clientId) { setLoading(false); router.push('/'); return }
+
+    try {
+      const { seuilVert, seuilOrange } = getSeuilsFromParams(await getParametres(), 'cuisine')
+      if (Number.isFinite(seuilVert) && Number.isFinite(seuilOrange)) {
+        setSeuils({ vert: seuilVert, orange: seuilOrange })
+      }
+    } catch { /* seuils par défaut déjà en place */ }
+
     const [{ data: menusData }, { data: cartesData }] = await Promise.all([
       supabase.from('menus')
         .select(`*, menu_fiches(id, service, fiches(id, nom, categorie, cout_portion))`)
@@ -114,9 +127,9 @@ export default function MenusEtCartesPage() {
         {loading ? (
           <ChefLoader />
         ) : tab === 'menus' ? (
-          <MenusGrid c={c} isMobile={isMobile} menus={menus} onDelete={handleDeleteMenu} onCreateClick={() => router.push('/menus/nouveau')} />
+          <MenusGrid seuils={seuils} c={c} isMobile={isMobile} menus={menus} onDelete={handleDeleteMenu} onCreateClick={() => router.push('/menus/nouveau')} />
         ) : (
-          <CartesGrid c={c} isMobile={isMobile} cartes={cartes} onDelete={handleDeleteCarte} onCreateClick={() => router.push('/cartes/nouveau')} />
+          <CartesGrid seuils={seuils} c={c} isMobile={isMobile} cartes={cartes} onDelete={handleDeleteCarte} onCreateClick={() => router.push('/cartes/nouveau')} />
         )}
       </div>
     </div>

--- a/components/RecapView.jsx
+++ b/components/RecapView.jsx
@@ -1,6 +1,6 @@
 'use client'
 import { useState, useEffect } from 'react'
-import { supabase, getClientId } from '../lib/supabase'
+import { supabase, getClientId, getParametres } from '../lib/supabase'
 import { useRouter } from 'next/navigation'
 import { theme } from '../lib/theme.jsx'
 import { SAISONS, getYearsRange, formatSaison } from '../lib/saison'
@@ -8,7 +8,8 @@ import { useIsMobile } from '../lib/useIsMobile'
 import { useTheme } from '../lib/useTheme'
 import { useRole } from '../lib/useRole'
 import { log } from '../lib/useLog'
-import { estSousFiche } from '../lib/foodCost'
+import { estSousFiche, getSeuilsFromParams } from '../lib/foodCost'
+import { DEFAULT_SEUILS } from '../lib/constants'
 import * as XLSX from 'xlsx'
 import Navbar from './Navbar'
 import { Badge } from './ui'
@@ -27,7 +28,6 @@ const SECTION_CONFIG = {
     categoryIcon: '🍽',
     hasMenus: true,
     tvaFn: () => 1.10,
-    fcThresholds: { vert: 30, orange: 40 },
     loadExtraFilter: null,
     costLabel: 'Food cost',
     colors: {
@@ -49,7 +49,6 @@ const SECTION_CONFIG = {
     categoryIcon: '🍷',
     hasMenus: false,
     tvaFn: (fiche) => CATEGORIES_ALCOOL.includes(fiche?.categorie) ? 1.20 : 1.10,
-    fcThresholds: { vert: 22, orange: 28 },
     loadExtraFilter: (q) => q.neq('categorie', 'Sous-fiche'),
     costLabel: 'Bev cost',
     colors: {
@@ -69,6 +68,10 @@ export default function RecapView({ section = 'cuisine' }) {
   const [lieux, setLieux] = useState([])
   const [categories, setCategories] = useState([])
   const [loading, setLoading] = useState(true)
+  // Seuils food cost de l'établissement. Ce tableau note le même food cost/plat
+  // que la fiche : il doit utiliser les mêmes seuils, sinon le même plat reçoit
+  // deux verdicts contradictoires selon l'écran.
+  const [seuils, setSeuils] = useState(DEFAULT_SEUILS[section] ?? DEFAULT_SEUILS.cuisine)
   const [vue, setVue] = useState('lieu')
   const [saisonFiltree, setSaisonFiltree] = useState('toutes')
   const [anneeFiltree, setAnneeFiltree] = useState('toutes')
@@ -103,6 +106,15 @@ export default function RecapView({ section = 'cuisine' }) {
     try {
       const clientId = await getClientId()
       if (!clientId) { router.push('/'); return }
+
+      try {
+        const p = await getParametres()
+        const { seuilVert, seuilOrange } = getSeuilsFromParams(p, section)
+        if (Number.isFinite(seuilVert) && Number.isFinite(seuilOrange)) {
+          setSeuils({ vert: seuilVert, orange: seuilOrange })
+        }
+      } catch { /* seuils par défaut déjà en place */ }
+
       let fichesQuery = supabase.from(cfg.fichesTable)
         .select('*, lieux(id,nom,emoji), categories_plats(id,nom,emoji)')
         .eq('client_id', clientId).eq('archive', false).order('nom')
@@ -152,8 +164,8 @@ export default function RecapView({ section = 'cuisine' }) {
     return { nb: liste.length, coutMoyen: moyenne(couts), prixHTMoyen: moyenne(prixHTs), prixTTCMoyen: moyenne(prixTTCs), beneficeMoyen: moyenne(benefices), ratioMoyen: moyenne(ratios) }
   }
 
-  const fcColor = (fc) => { if (!fc) return c.texteMuted; if (fc < cfg.fcThresholds.vert) return '#3B6D11'; if (fc < cfg.fcThresholds.orange) return '#854F0B'; return '#A32D2D' }
-  const fcBg = (fc) => { if (!fc) return 'transparent'; if (fc < cfg.fcThresholds.vert) return '#EAF3DE'; if (fc < cfg.fcThresholds.orange) return '#FAEEDA'; return '#FCEBEB' }
+  const fcColor = (fc) => { if (!fc) return c.texteMuted; if (fc < seuils.vert) return '#3B6D11'; if (fc < seuils.orange) return '#854F0B'; return '#A32D2D' }
+  const fcBg = (fc) => { if (!fc) return 'transparent'; if (fc < seuils.vert) return '#EAF3DE'; if (fc < seuils.orange) return '#FAEEDA'; return '#FCEBEB' }
 
   const toggleArchive = (id) => setModifArchive(prev => ({ ...prev, [id]: !prev[id] }))
   const nbArchives = Object.values(modifArchive).filter(Boolean).length

--- a/components/contenus/CartesGrid.jsx
+++ b/components/contenus/CartesGrid.jsx
@@ -1,5 +1,6 @@
 'use client'
 import { useRouter } from 'next/navigation'
+import { DEFAULT_SEUILS } from '../../lib/constants'
 import { formatSaison } from '../../lib/saison'
 
 const calculerCouts = (carte, baseOnly = false) => {
@@ -46,15 +47,17 @@ const getRatio = (carte, baseOnly = false) => {
   return (coutMatiere / (prixTotal / 1.10) * 100).toFixed(1)
 }
 
-const fcColor = (fc) => {
+// Seuils passés par la page : ils viennent des paramètres établissement, pour
+// que le même plat ne soit pas noté différemment ici et sur sa fiche.
+const fcColor = (fc, seuils) => {
   if (!fc) return {}
   const n = parseFloat(fc)
-  if (n < 30) return { bg: '#EAF3DE', color: '#3B6D11' }
-  if (n < 40) return { bg: '#FAEEDA', color: '#854F0B' }
+  if (n < seuils.vert) return { bg: '#EAF3DE', color: '#3B6D11' }
+  if (n < seuils.orange) return { bg: '#FAEEDA', color: '#854F0B' }
   return { bg: '#FCEBEB', color: '#A32D2D' }
 }
 
-export default function CartesGrid({ c, isMobile, cartes, onDelete, onCreateClick }) {
+export default function CartesGrid({ c, isMobile, cartes, onDelete, onCreateClick, seuils = DEFAULT_SEUILS.cuisine }) {
   const router = useRouter()
 
   if (cartes.length === 0) {
@@ -85,7 +88,7 @@ export default function CartesGrid({ c, isMobile, cartes, onDelete, onCreateClic
         const ratioBase = getRatio(carte, true)
         const hasSupp = totalSuppPrix > 0
         const ratio = ratioFull
-        const rc = fcColor(ratio)
+        const rc = fcColor(ratio, seuils)
 
         return (
           <div key={carte.id} style={{
@@ -156,13 +159,13 @@ export default function CartesGrid({ c, isMobile, cartes, onDelete, onCreateClic
               <div style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
                 {hasSupp ? (
                   <>
-                    {ratioBase && (() => { const rb = fcColor(ratioBase); return (
+                    {ratioBase && (() => { const rb = fcColor(ratioBase, seuils); return (
                       <div style={{ flex: 1, borderRadius: '8px', padding: '8px', textAlign: 'center', background: rb.bg }}>
                         <div style={{ fontSize: '10px', textTransform: 'uppercase', color: rb.color }}>Ratio base</div>
                         <div style={{ fontSize: '14px', fontWeight: '500', color: rb.color }}>{ratioBase} %</div>
                       </div>
                     )})()}
-                    {ratioFull && (() => { const rf = fcColor(ratioFull); return (
+                    {ratioFull && (() => { const rf = fcColor(ratioFull, seuils); return (
                       <div style={{ flex: 1, borderRadius: '8px', padding: '8px', textAlign: 'center', background: rf.bg }}>
                         <div style={{ fontSize: '10px', textTransform: 'uppercase', color: rf.color }}>Ratio + suppl.</div>
                         <div style={{ fontSize: '14px', fontWeight: '500', color: rf.color }}>{ratioFull} %</div>

--- a/components/contenus/MenusGrid.jsx
+++ b/components/contenus/MenusGrid.jsx
@@ -1,5 +1,6 @@
 'use client'
 import { useRouter } from 'next/navigation'
+import { DEFAULT_SEUILS } from '../../lib/constants'
 import { formatSaison } from '../../lib/saison'
 
 const calculerCoutMenu = (menu) => {
@@ -14,7 +15,7 @@ const foodCostMenu = (menu) => {
   return (cout / prixHT * 100).toFixed(1)
 }
 
-export default function MenusGrid({ c, isMobile, menus, onDelete, onCreateClick }) {
+export default function MenusGrid({ c, isMobile, menus, onDelete, onCreateClick, seuils = DEFAULT_SEUILS.cuisine }) {
   const router = useRouter()
 
   if (menus.length === 0) {
@@ -91,10 +92,10 @@ export default function MenusGrid({ c, isMobile, menus, onDelete, onCreateClick 
               {fc && (
                 <div style={{
                   flex: 1, borderRadius: '8px', padding: '8px', textAlign: 'center',
-                  background: fc < 30 ? '#EAF3DE' : fc < 40 ? '#FAEEDA' : '#FCEBEB'
+                  background: fc < seuils.vert ? '#EAF3DE' : fc < seuils.orange ? '#FAEEDA' : '#FCEBEB'
                 }}>
-                  <div style={{ fontSize: '10px', textTransform: 'uppercase', color: fc < 30 ? '#3B6D11' : fc < 40 ? '#854F0B' : '#A32D2D' }}>Food cost</div>
-                  <div style={{ fontSize: '14px', fontWeight: '500', color: fc < 30 ? '#3B6D11' : fc < 40 ? '#854F0B' : '#A32D2D' }}>{fc} %</div>
+                  <div style={{ fontSize: '10px', textTransform: 'uppercase', color: fc < seuils.vert ? '#3B6D11' : fc < seuils.orange ? '#854F0B' : '#A32D2D' }}>Food cost</div>
+                  <div style={{ fontSize: '14px', fontWeight: '500', color: fc < seuils.vert ? '#3B6D11' : fc < seuils.orange ? '#854F0B' : '#A32D2D' }}>{fc} %</div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Le problème

Le récap food cost et les grilles cartes/menus notaient le food cost **par plat** contre des seuils écrits en dur :

| Fichier | Code |
|---|---|
| `components/RecapView.jsx:30` | `fcThresholds: { vert: 30, orange: 40 }` |
| `components/contenus/CartesGrid.jsx:52` | `if (n < 30) … if (n < 40)` |
| `components/contenus/MenusGrid.jsx:94` | `fc < 30 ? … : fc < 40 ?` |

Aucun de ces écrans ne lisait les paramètres de l'établissement — `app/menus/page.js` ne les chargeait même pas. La fiche du même plat, elle, utilise bien `seuil_vert_cuisine` / `seuil_orange_cuisine`. **Le même plat recevait donc deux verdicts opposés selon l'écran.**

## Constaté sur les données de production

| Établissement | Seuils configurés | Plat | Food cost | Ancien affichage | Correct |
|---|---|---|---|---|---|
| JOIA | 26 / 28 | FLEUR DE COURGETTE RICOTTA | 29,0% | 🟢 vert | 🔴 rouge |
| la-fantaisie | 28 / 30 | SALADE DE TOMATE, CONCOMBRE, FETA | 29,9% | 🟢 vert | 🟠 orange |
| la-fantaisie | 28 / 30 | NOIX D'ENTRECOTE | 29,1% | 🟢 vert | 🟠 orange |

Six plats de la-fantaisie entre 28,6 et 29,9% étaient tous verts au lieu d'orange. Un plat au-dessus du seuil rouge de l'établissement s'affichait comme sain.

## Le correctif

- `RecapView` charge les paramètres et **supprime `fcThresholds`** ; le repli s'aligne désormais sur `DEFAULT_SEUILS` (28/35) au lieu de 30/40.
- `app/menus/page.js` charge les paramètres et les transmet aux deux grilles.
- `CartesGrid` / `MenusGrid` reçoivent les seuils en prop.

Plus aucun `30`/`40` en dur dans ces trois fichiers.

## Hors périmètre, délibérément

`app/controle-gestion/food-cost` et `lib/foodCostExport` notent le **ratio matière global** de l'établissement (inventaires + achats ÷ CA), pas le food cost d'un plat. C'est une autre métrique : leurs seuils 30/35/40 relèvent d'une règle métier distincte et les aligner sur `seuil_*_cuisine` serait une erreur. À trancher avec toi séparément.

## Vérification

En conditions réelles sur JOIA (seuils 26/28), lecture des couleurs réellement calculées par le navigateur :

```
27,0%  → rgb(133, 79, 11)  = #854F0B  orange   ✅ (≥ 26)
24,3%  → rgb(59, 109, 17)  = #3B6D11  vert
23,5%, 23,4%, 20,9%, 20,8%, 20,3%, 13,8% → vert
```

Sous l'ancien code figé à 30/40, ce 27,0% s'affichait vert.

906 tests passent. Les 2 erreurs de lint restantes dans `app/menus/page.js` sont préexistantes (vérifié : 2 avant, 2 après).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
