### PR TITLE
perf(bar): paginer la liste des fiches bar comme celle de la cuisine

### DIFF
--- a/components/FichesList.jsx
+++ b/components/FichesList.jsx
@@ -47,7 +47,9 @@ const CFG = {
     redirectOnDeny: '/dashboard',
     ficheUrlPrefix: '/bar/fiches',
     newFicheUrl: '/bar/fiches/nouvelle',
-    hasPagination: false,
+    // Paginé comme la cuisine : la-fantaisie a 260 fiches bar, toutes rendues
+    // d'un coup auparavant (2941 nœuds DOM, ~60 ms par frappe dans le filtre).
+    hasPagination: true,
     hasSousFicheFilter: false,
     tvaFn: (fiche) => CATEGORIES_ALCOOL.includes(fiche?.categorie) ? 1.20 : 1.10,
     fcSeuils: { vert: 22, orange: 28 },


### PR DESCRIPTION
## Le problème

`components/FichesList.jsx` est partagé entre cuisine et bar. La config cuisine a `hasPagination: true`, la config bar avait `hasPagination: false` — **toutes les fiches étaient rendues simultanément**.

Ce n'est pas hypothétique : **la-fantaisie a 260 fiches bar aujourd'hui**.

## Mesures réelles

Sur la-fantaisie, serveur de dev :

| | Avant | Après |
|---|---|---|
| Nœuds DOM | 2941 | **377** (−87%) |
| Cartes rendues | 260 | 24 |
| Pire frappe dans le filtre | 59,7 ms | 46,6 ms |

La pagination affiche 11 pages.

## Pourquoi pas de virtualisation

`react-window` / `@tanstack/react-virtual` ne se justifient pas à cette échelle : ils ajouteraient une dépendance et casseraient Cmd+F ainsi que l'impression, pour un gain que la pagination — déjà présente, éprouvée côté cuisine, et activable en une ligne — obtient sans rien sacrifier.

## Les autres listes étaient déjà saines

Vérifié avant de conclure, sur les volumes réels de production :

| Écran | Volume | Stratégie |
|---|---|---|
| Ingrédients | 1861 (la-fantaisie) | paginé par 30 |
| Fiches cuisine | 145 | paginé par 24 |
| Récap food cost | 145 | accordéon agrégé (172 nœuds) |

À noter : la « matrice d'allergènes » n'existe pas dans le code — les allergènes sont quelques badges par fiche (`AllergenesBlock`), jamais une grille croisée. Ce n'est pas un point chaud.

Mesures prises sur un build de développement (React en mode dev) : les chiffres en production sont meilleurs, mais l'écart relatif tient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
