### PR TITLE
chore(legal): identifiants réels AD Consulting dans les pages légales

### DIFF
--- a/app/cgu/page.js
+++ b/app/cgu/page.js
@@ -2,11 +2,11 @@ export default function CGU() {
   return (
     <div style={{ maxWidth: '720px', margin: '0 auto', padding: '40px 24px', fontFamily: 'sans-serif', color: '#18181B', lineHeight: '1.8' }}>
       <h1 style={{ fontSize: '28px', fontWeight: '700', marginBottom: '8px' }}>Conditions Générales d'Utilisation</h1>
-      <p style={{ color: '#71717A', fontSize: '13px', marginBottom: '32px' }}>Version 1.0 — Dernière mise à jour : avril 2026</p>
+      <p style={{ color: '#71717A', fontSize: '13px', marginBottom: '32px' }}>Version 1.0 — Dernière mise à jour : juillet 2026</p>
 
       <section style={{ marginBottom: '28px' }}>
         <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 1 — Objet</h2>
-        <p>Les présentes Conditions Générales d'Utilisation (CGU) régissent l'accès et l'utilisation de l'application SaaS Skalcook, éditée par Skalcook SAS. En accédant à l'application, l'utilisateur accepte sans réserve les présentes CGU.</p>
+        <p>Les présentes Conditions Générales d'Utilisation (CGU) régissent l'accès et l'utilisation de l'application SaaS Skalcook, éditée par <strong>AD Consulting</strong>, entreprise individuelle (micro-entrepreneur) dont les coordonnées figurent dans les <a href="/mentions-legales" style={{ color: '#6366F1' }}>mentions légales</a>. En accédant à l'application, l'utilisateur accepte sans réserve les présentes CGU.</p>
       </section>
 
       <section style={{ marginBottom: '28px' }}>
@@ -16,7 +16,7 @@ export default function CGU() {
 
       <section style={{ marginBottom: '28px' }}>
         <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 3 — Accès au service</h2>
-        <p>L'accès au service est réservé aux professionnels (B2B). L'utilisateur s'engage à :</p>
+        <p>L'accès au service est strictement réservé aux professionnels (B2B). L'utilisateur déclare agir dans le cadre de son activité professionnelle et renonce expressément à se prévaloir des dispositions protectrices du Code de la consommation. L'utilisateur s'engage à :</p>
         <ul style={{ paddingLeft: '20px' }}>
           <li>Créer un compte avec des informations exactes et à jour</li>
           <li>Ne pas partager ses identifiants de connexion</li>
@@ -27,37 +27,59 @@ export default function CGU() {
 
       <section style={{ marginBottom: '28px' }}>
         <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 4 — Abonnement et facturation</h2>
-        <p>L'accès au service est conditionné à la souscription d'un abonnement payant. Les tarifs en vigueur sont disponibles sur demande auprès de l'équipe commerciale. La facturation est mensuelle ou annuelle selon la formule choisie. Toute période commencée est due.</p>
+        <p>L'accès au service est conditionné à la souscription d'un abonnement payant. Les tarifs en vigueur sont communiqués à l'utilisateur avant la souscription et figurent sur la facture. La facturation est mensuelle ou annuelle selon la formule choisie. Toute période commencée est due.</p>
       </section>
 
       <section style={{ marginBottom: '28px' }}>
-        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 5 — Résiliation</h2>
-        <p>Conformément à la loi n° 2022-1158 du 16 août 2022, l'abonné peut résilier son abonnement en ligne à tout moment depuis son espace "Mon Compte", rubrique "Abonnement". La résiliation prend effet à la fin de la période d'abonnement en cours. Aucun remboursement ne sera effectué pour la période restante.</p>
+        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 5 — Retard de paiement</h2>
+        <p>Conformément à l'article L.441-10 du Code de commerce, tout retard de paiement entraîne de plein droit, sans mise en demeure préalable :</p>
+        <ul style={{ paddingLeft: '20px' }}>
+          <li>Des pénalités de retard calculées au taux d'intérêt appliqué par la Banque Centrale Européenne à son opération de refinancement la plus récente, majoré de 10 points de pourcentage</li>
+          <li>Une indemnité forfaitaire pour frais de recouvrement de 40 € (article D.441-5 du Code de commerce)</li>
+        </ul>
+        <p>En cas de non-paiement persistant, AD Consulting se réserve le droit de suspendre l'accès au service après mise en demeure restée sans effet pendant 15 jours.</p>
       </section>
 
       <section style={{ marginBottom: '28px' }}>
-        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 6 — Données et confidentialité</h2>
-        <p>Les données saisies dans l'application restent la propriété de l'utilisateur. Skalcook SAS s'engage à ne pas les exploiter à des fins commerciales. En cas de résiliation, les données sont conservées 30 jours puis supprimées définitivement, sauf demande d'export préalable. Consultez notre <a href="/politique-confidentialite" style={{ color: '#6366F1' }}>Politique de confidentialité</a> pour plus de détails.</p>
+        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 6 — Résiliation</h2>
+        <p>L'utilisateur peut résilier son abonnement à tout moment depuis son espace « Mon Compte », rubrique « Abonnement ». La résiliation prend effet à la fin de la période d'abonnement en cours. Aucun remboursement ne sera effectué pour la période restante.</p>
+        <p>AD Consulting se réserve le droit de résilier l'abonnement en cas de manquement grave de l'utilisateur aux présentes CGU, après mise en demeure restée sans effet pendant 15 jours.</p>
       </section>
 
       <section style={{ marginBottom: '28px' }}>
-        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 7 — Disponibilité du service</h2>
-        <p>Skalcook SAS s'engage à maintenir une disponibilité du service de 99% sur une base mensuelle, hors maintenances planifiées.</p>
+        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 7 — Données et confidentialité</h2>
+        <p>Les données saisies dans l'application restent la propriété de l'utilisateur. AD Consulting s'engage à ne pas les exploiter à des fins commerciales. En cas de résiliation, les données sont conservées 30 jours (fenêtre d'export/récupération) puis supprimées définitivement, sauf obligation légale de conservation. Consultez notre <a href="/politique-confidentialite" style={{ color: '#6366F1' }}>Politique de confidentialité</a> pour plus de détails.</p>
       </section>
 
       <section style={{ marginBottom: '28px' }}>
-        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 8 — Responsabilité</h2>
-        <p>L'utilisateur est seul responsable des données qu'il saisit dans l'application, notamment les informations sur les allergènes. Skalcook SAS ne peut être tenu responsable des conséquences d'informations incorrectes ou incomplètes renseignées par l'utilisateur.</p>
+        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 8 — Disponibilité du service</h2>
+        <p>AD Consulting met en œuvre les moyens raisonnables pour assurer une disponibilité du service de 99% sur une base mensuelle, hors maintenances planifiées, cas de force majeure et défaillances des sous-traitants techniques (Vercel, Supabase, Resend). L'obligation est de moyens, non de résultat.</p>
       </section>
 
       <section style={{ marginBottom: '28px' }}>
-        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 9 — Modification des CGU</h2>
-        <p>Skalcook SAS se réserve le droit de modifier les présentes CGU à tout moment. Les utilisateurs seront informés par e-mail de toute modification substantielle.</p>
+        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 9 — Propriété intellectuelle</h2>
+        <p>L'application, son code source, son interface, ses bases de données (hors données utilisateur), ses marques et logos sont la propriété exclusive d'AD Consulting. L'utilisateur bénéficie d'un droit d'usage personnel, non exclusif et non cessible, strictement limité à la durée de son abonnement.</p>
       </section>
 
       <section style={{ marginBottom: '28px' }}>
-        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 10 — Droit applicable</h2>
-        <p>Les présentes CGU sont soumises au droit français. Tout litige sera de la compétence exclusive des tribunaux français.</p>
+        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 10 — Responsabilité</h2>
+        <p>L'utilisateur est seul responsable des données qu'il saisit dans l'application, notamment les informations sur les allergènes, la composition des plats et les données réglementaires transmises à ses propres clients. AD Consulting ne peut être tenu responsable des conséquences d'informations incorrectes ou incomplètes renseignées par l'utilisateur.</p>
+        <p>La responsabilité d'AD Consulting, tous préjudices confondus, est limitée au montant des sommes effectivement versées par l'utilisateur au titre de l'abonnement au cours des 12 mois précédant le fait générateur de responsabilité.</p>
+      </section>
+
+      <section style={{ marginBottom: '28px' }}>
+        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 11 — Force majeure</h2>
+        <p>Aucune des parties ne pourra être tenue responsable d'un manquement à ses obligations résultant d'un cas de force majeure au sens de l'article 1218 du Code civil, notamment : panne d'un sous-traitant technique, attaque informatique, décision d'une autorité publique, coupure des réseaux de télécommunication.</p>
+      </section>
+
+      <section style={{ marginBottom: '28px' }}>
+        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 12 — Modification des CGU</h2>
+        <p>AD Consulting se réserve le droit de modifier les présentes CGU à tout moment. Les utilisateurs seront informés par e-mail de toute modification substantielle au moins 30 jours avant son entrée en vigueur. Le maintien de l'abonnement vaut acceptation des nouvelles CGU.</p>
+      </section>
+
+      <section style={{ marginBottom: '28px' }}>
+        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>Article 13 — Droit applicable et juridiction</h2>
+        <p>Les présentes CGU sont soumises au droit français. <strong>Tout litige relatif à leur formation, exécution ou interprétation relèvera de la compétence exclusive du Tribunal de commerce de Nanterre</strong>, y compris en cas de pluralité de défendeurs ou d'appel en garantie.</p>
       </section>
 
       <div style={{ marginTop: '40px', padding: '16px', background: '#F4F4F5', borderRadius: '8px', fontSize: '12px', color: '#71717A' }}>

--- a/app/mentions-legales/page.js
+++ b/app/mentions-legales/page.js
@@ -2,46 +2,47 @@ export default function MentionsLegales() {
   return (
     <div style={{ maxWidth: '720px', margin: '0 auto', padding: '40px 24px', fontFamily: 'sans-serif', color: '#18181B', lineHeight: '1.8' }}>
       <h1 style={{ fontSize: '28px', fontWeight: '700', marginBottom: '8px' }}>Mentions légales</h1>
-      <p style={{ color: '#71717A', fontSize: '13px', marginBottom: '32px' }}>Dernière mise à jour : avril 2026</p>
+      <p style={{ color: '#71717A', fontSize: '13px', marginBottom: '32px' }}>Dernière mise à jour : juillet 2026</p>
 
       <section style={{ marginBottom: '32px' }}>
         <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '12px', borderBottom: '1px solid #E4E4E7', paddingBottom: '8px' }}>Éditeur du site</h2>
-        <p><strong>Raison sociale :</strong> Skalcook SAS</p>
-        <p><strong>Forme juridique :</strong> Société par Actions Simplifiée (SAS)</p>
-        <p><strong>Capital social :</strong> À compléter</p>
-        <p><strong>SIRET :</strong> À compléter</p>
-        <p><strong>N° TVA intracommunautaire :</strong> À compléter</p>
-        <p><strong>Adresse du siège social :</strong> À compléter</p>
+        <p><strong>Éditeur :</strong> Antony Despaux, entrepreneur individuel exerçant sous le nom commercial <strong>AD Consulting</strong></p>
+        <p><strong>Forme juridique :</strong> Entreprise individuelle (régime micro-entrepreneur)</p>
+        <p><strong>SIREN :</strong> 884 072 687</p>
+        <p><strong>SIRET (siège) :</strong> 884 072 687 00012</p>
+        <p><strong>Code APE :</strong> 70.22Z — Conseil pour les affaires et autres conseils de gestion</p>
+        <p><strong>N° TVA intracommunautaire :</strong> non applicable — franchise en base de TVA (art. 293 B du CGI)</p>
+        <p><strong>Adresse :</strong> 30B rue de Paris, 92190 Meudon, France</p>
         <p><strong>E-mail de contact :</strong> <a href="mailto:contact@skalcook.fr" style={{ color: '#6366F1' }}>contact@skalcook.fr</a></p>
       </section>
 
       <section style={{ marginBottom: '32px' }}>
         <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '12px', borderBottom: '1px solid #E4E4E7', paddingBottom: '8px' }}>Directeur de la publication</h2>
-        <p>Le directeur de la publication est le représentant légal de Skalcook SAS.</p>
+        <p>Antony Despaux, en sa qualité d'exploitant de l'entreprise individuelle AD Consulting.</p>
       </section>
 
       <section style={{ marginBottom: '32px' }}>
         <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '12px', borderBottom: '1px solid #E4E4E7', paddingBottom: '8px' }}>Hébergement</h2>
-        <p><strong>Hébergeur :</strong> Vercel Inc.</p>
-        <p><strong>Adresse :</strong> 440 N Barranca Ave #4133, Covina, CA 91723, États-Unis</p>
+        <p><strong>Hébergeur de l'application :</strong> Vercel Inc., 440 N Barranca Ave #4133, Covina, CA 91723, États-Unis</p>
         <p><strong>Base de données :</strong> Supabase Inc. — infrastructure hébergée en Europe (région eu-west)</p>
+        <p><strong>Envoi d'e-mails transactionnels :</strong> Resend, Inc., 2261 Market Street #5039, San Francisco, CA 94114, États-Unis</p>
       </section>
 
       <section style={{ marginBottom: '32px' }}>
         <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '12px', borderBottom: '1px solid #E4E4E7', paddingBottom: '8px' }}>Propriété intellectuelle</h2>
-        <p>L'ensemble du contenu de l'application Skalcook (textes, graphismes, logos, icônes, images, code source) est la propriété exclusive de Skalcook SAS et est protégé par les lois françaises et internationales relatives à la propriété intellectuelle.</p>
+        <p>« Skalcook » est une marque déposée. L'ensemble du contenu de l'application Skalcook (textes, graphismes, logos, icônes, images, code source) est la propriété exclusive d'AD Consulting et est protégé par les lois françaises et internationales relatives à la propriété intellectuelle.</p>
         <p>Toute reproduction, représentation, modification ou exploitation non autorisée est strictement interdite.</p>
       </section>
 
       <section style={{ marginBottom: '32px' }}>
         <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '12px', borderBottom: '1px solid #E4E4E7', paddingBottom: '8px' }}>Données personnelles</h2>
         <p>Conformément au Règlement Général sur la Protection des Données (RGPD) et à la loi Informatique et Libertés, vous disposez d'un droit d'accès, de rectification, d'effacement et de portabilité de vos données personnelles.</p>
-        <p>Pour exercer ces droits, contactez notre DPO à : <a href="mailto:contact@skalcook.fr" style={{ color: '#6366F1' }}>contact@skalcook.fr</a></p>
+        <p>Pour exercer ces droits, écrivez à : <a href="mailto:contact@skalcook.fr" style={{ color: '#6366F1' }}>contact@skalcook.fr</a>. Les modalités complètes sont détaillées dans notre <a href="/politique-confidentialite" style={{ color: '#6366F1' }}>Politique de confidentialité</a>.</p>
       </section>
 
       <section style={{ marginBottom: '32px' }}>
-        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '12px', borderBottom: '1px solid #E4E4E7', paddingBottom: '8px' }}>Médiation</h2>
-        <p>En cas de litige, vous pouvez recourir à un médiateur de la consommation conformément aux articles L.612-1 et suivants du Code de la consommation.</p>
+        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '12px', borderBottom: '1px solid #E4E4E7', paddingBottom: '8px' }}>Public concerné</h2>
+        <p>Le service Skalcook est exclusivement destiné à une clientèle professionnelle (B2B). Il n'est pas accessible aux consommateurs au sens de l'article liminaire du Code de la consommation.</p>
       </section>
 
       <div style={{ marginTop: '40px', padding: '16px', background: '#F4F4F5', borderRadius: '8px', fontSize: '12px', color: '#71717A' }}>

--- a/app/politique-confidentialite/page.js
+++ b/app/politique-confidentialite/page.js
@@ -2,22 +2,25 @@ export default function PolitiqueConfidentialite() {
   return (
     <div style={{ maxWidth: '720px', margin: '0 auto', padding: '40px 24px', fontFamily: 'sans-serif', color: '#18181B', lineHeight: '1.8' }}>
       <h1 style={{ fontSize: '28px', fontWeight: '700', marginBottom: '8px' }}>Politique de Confidentialité</h1>
-      <p style={{ color: '#71717A', fontSize: '13px', marginBottom: '32px' }}>Version 1.0 — Dernière mise à jour : avril 2026</p>
+      <p style={{ color: '#71717A', fontSize: '13px', marginBottom: '32px' }}>Version 1.0 — Dernière mise à jour : juillet 2026</p>
 
       <section style={{ marginBottom: '28px' }}>
         <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>1. Responsable du traitement</h2>
-        <p><strong>Skalcook SAS</strong> est responsable du traitement des données personnelles collectées via l'application Skalcook.</p>
-        <p><strong>Contact DPO :</strong> <a href="mailto:contact@skalcook.fr" style={{ color: '#6366F1' }}>contact@skalcook.fr</a></p>
+        <p><strong>AD Consulting</strong>, entreprise individuelle (micro-entrepreneur) exploitée par Antony Despaux, domiciliée au 30B rue de Paris, 92190 Meudon (SIREN 884 072 687), est responsable du traitement des données personnelles collectées via l'application Skalcook.</p>
+        <p><strong>Contact :</strong> <a href="mailto:contact@skalcook.fr" style={{ color: '#6366F1' }}>contact@skalcook.fr</a></p>
+        <p style={{ fontSize: '13px', color: '#71717A' }}>AD Consulting n'a pas désigné de Délégué à la Protection des Données (DPO), cette désignation n'étant pas obligatoire au regard de la nature et du volume des traitements (art. 37 RGPD). Les demandes relatives aux données personnelles sont traitées directement par le responsable de traitement.</p>
       </section>
 
       <section style={{ marginBottom: '28px' }}>
         <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>2. Données collectées</h2>
         <ul style={{ paddingLeft: '20px' }}>
-          <li><strong>Données d'identification :</strong> nom, adresse e-mail, numéro de téléphone</li>
+          <li><strong>Données d'identification :</strong> nom, prénom, adresse e-mail</li>
+          <li><strong>Données d'authentification :</strong> mot de passe stocké sous forme de hash (via Supabase Auth), jetons de session</li>
           <li><strong>Données professionnelles :</strong> nom de l'établissement, SIRET, numéro TVA, adresse</li>
-          <li><strong>Données d'utilisation :</strong> fiches techniques, recettes, ingrédients, stocks</li>
-          <li><strong>Données de connexion :</strong> adresse IP, logs d'accès, navigateur</li>
+          <li><strong>Données d'utilisation :</strong> fiches techniques, recettes, ingrédients, stocks, inventaires, fournisseurs, fiches clients CRM, devis</li>
+          <li><strong>Données de connexion :</strong> adresse IP, logs d'accès, user-agent (navigateur)</li>
         </ul>
+        <p style={{ fontSize: '13px', color: '#71717A' }}>Aucune donnée sensible au sens de l'article 9 du RGPD (santé, opinions politiques, etc.) n'est volontairement collectée.</p>
       </section>
 
       <section style={{ marginBottom: '28px' }}>
@@ -26,8 +29,9 @@ export default function PolitiqueConfidentialite() {
           <li>Fournir le service Skalcook (exécution du contrat)</li>
           <li>Gérer votre compte et votre abonnement</li>
           <li>Assurer la sécurité et la maintenance de l'application</li>
+          <li>Envoyer les e-mails transactionnels (invitation, confirmation, réinitialisation de mot de passe)</li>
           <li>Répondre à vos demandes de support</li>
-          <li>Respecter nos obligations légales</li>
+          <li>Respecter nos obligations légales (facturation, comptabilité)</li>
         </ul>
       </section>
 
@@ -36,7 +40,7 @@ export default function PolitiqueConfidentialite() {
         <ul style={{ paddingLeft: '20px' }}>
           <li><strong>Exécution du contrat (art. 6.1.b RGPD) :</strong> traitement nécessaire à la fourniture du service</li>
           <li><strong>Obligation légale (art. 6.1.c RGPD) :</strong> conservation des données de facturation</li>
-          <li><strong>Intérêt légitime (art. 6.1.f RGPD) :</strong> sécurité, prévention des fraudes</li>
+          <li><strong>Intérêt légitime (art. 6.1.f RGPD) :</strong> sécurité, prévention des fraudes, amélioration du service</li>
         </ul>
       </section>
 
@@ -44,42 +48,62 @@ export default function PolitiqueConfidentialite() {
         <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>5. Durée de conservation</h2>
         <ul style={{ paddingLeft: '20px' }}>
           <li><strong>Données du compte :</strong> durée de l'abonnement + 30 jours après résiliation</li>
-          <li><strong>Données de facturation :</strong> 10 ans (obligation comptable)</li>
-          <li><strong>Logs de connexion :</strong> 12 mois</li>
+          <li><strong>Données de facturation :</strong> 10 ans (obligation comptable, art. L.123-22 Code de commerce)</li>
+          <li><strong>Logs de connexion :</strong> 12 mois (recommandation CNIL)</li>
+          <li><strong>E-mails transactionnels :</strong> 13 mois côté Resend</li>
         </ul>
       </section>
 
       <section style={{ marginBottom: '28px' }}>
-        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>6. Destinataires des données</h2>
-        <p>Vos données sont transmises aux sous-traitants techniques suivants :</p>
+        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>6. Destinataires et sous-traitants</h2>
+        <p>Vos données sont transmises aux sous-traitants techniques suivants, liés par un accord de traitement des données (DPA) conforme à l'article 28 du RGPD :</p>
         <ul style={{ paddingLeft: '20px' }}>
-          <li><strong>Supabase Inc.</strong> — hébergement de la base de données (serveurs en Europe)</li>
-          <li><strong>Vercel Inc.</strong> — hébergement de l'application</li>
+          <li><strong>Supabase Inc.</strong> — hébergement de la base de données et authentification. Données stockées dans l'Union européenne (région eu-west).</li>
+          <li><strong>Vercel Inc.</strong> — hébergement de l'application web. Transfert vers les États-Unis (voir §7).</li>
+          <li><strong>Resend, Inc.</strong> — envoi d'e-mails transactionnels. Transfert vers les États-Unis (voir §7).</li>
+          <li><strong>Upstash, Inc.</strong> — limitation de débit (anti-abus). Données de connexion traitées en Europe.</li>
+          <li><strong>Anthropic, PBC</strong> — fonctionnalités d'assistance par intelligence artificielle (uniquement si l'utilisateur y a recours). Transfert vers les États-Unis (voir §7).</li>
         </ul>
         <p>Nous ne vendons ni ne louons vos données à des tiers.</p>
       </section>
 
       <section style={{ marginBottom: '28px' }}>
-        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>7. Vos droits (RGPD)</h2>
+        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>7. Transferts de données hors Union européenne</h2>
+        <p>Certains sous-traitants listés au §6 (Vercel, Resend, Anthropic) sont établis aux États-Unis. Les transferts de données personnelles vers ces prestataires sont encadrés par l'une des garanties appropriées prévues par le chapitre V du RGPD :</p>
+        <ul style={{ paddingLeft: '20px' }}>
+          <li><strong>EU-US Data Privacy Framework (DPF)</strong> — décision d'adéquation de la Commission européenne du 10 juillet 2023, lorsque le prestataire y est certifié ;</li>
+          <li><strong>Clauses Contractuelles Types (CCT)</strong> adoptées par la Commission européenne le 4 juin 2021, à défaut.</li>
+        </ul>
+        <p>Vous pouvez obtenir une copie de ces garanties en écrivant à <a href="mailto:contact@skalcook.fr" style={{ color: '#6366F1' }}>contact@skalcook.fr</a>.</p>
+      </section>
+
+      <section style={{ marginBottom: '28px' }}>
+        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>8. Vos droits (RGPD)</h2>
         <ul style={{ paddingLeft: '20px' }}>
           <li><strong>Droit d'accès (art. 15) :</strong> obtenir une copie de vos données</li>
           <li><strong>Droit de rectification (art. 16) :</strong> corriger vos données</li>
           <li><strong>Droit à l'effacement (art. 17) :</strong> supprimer vos données</li>
           <li><strong>Droit à la portabilité (art. 20) :</strong> exporter vos données (disponible dans Mon Compte)</li>
           <li><strong>Droit d'opposition (art. 21) :</strong> vous opposer à certains traitements</li>
+          <li><strong>Droit de définir des directives post-mortem</strong> (art. 85 loi Informatique et Libertés)</li>
         </ul>
         <p>Contact : <a href="mailto:contact@skalcook.fr" style={{ color: '#6366F1' }}>contact@skalcook.fr</a> — Délai de réponse : 30 jours maximum.</p>
-        <p>En cas de réclamation non traitée, vous pouvez saisir la <strong>CNIL</strong> (www.cnil.fr).</p>
+        <p>En cas de réclamation non traitée, vous pouvez saisir la <strong>CNIL</strong> (<a href="https://www.cnil.fr" target="_blank" rel="noopener noreferrer" style={{ color: '#6366F1' }}>www.cnil.fr</a>).</p>
       </section>
 
       <section style={{ marginBottom: '28px' }}>
-        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>8. Sécurité</h2>
-        <p>Nous mettons en œuvre des mesures techniques et organisationnelles appropriées pour protéger vos données : chiffrement HTTPS/TLS, authentification sécurisée via Supabase Auth, accès restreint par rôles, sauvegardes régulières.</p>
+        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>9. Sécurité</h2>
+        <p>Nous mettons en œuvre des mesures techniques et organisationnelles appropriées pour protéger vos données : chiffrement HTTPS/TLS pour tous les échanges, authentification sécurisée via Supabase Auth, mots de passe stockés sous forme de hash, isolation des données par établissement via Row Level Security (RLS), accès restreint par rôles, sauvegardes régulières.</p>
       </section>
 
       <section style={{ marginBottom: '28px' }}>
-        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>9. Cookies</h2>
-        <p>L'application utilise uniquement des cookies techniques strictement nécessaires au fonctionnement (session d'authentification). Aucun cookie publicitaire ou de traçage tiers n'est utilisé.</p>
+        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>10. Cookies</h2>
+        <p>L'application utilise uniquement des cookies techniques strictement nécessaires à son fonctionnement (session d'authentification, préférences d'interface). Aucun cookie publicitaire, analytique tiers ou de traçage n'est utilisé. Ces cookies sont exemptés de consentement préalable conformément à l'article 82 de la loi Informatique et Libertés.</p>
+      </section>
+
+      <section style={{ marginBottom: '28px' }}>
+        <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '10px' }}>11. Décisions automatisées</h2>
+        <p>Aucune décision produisant des effets juridiques à votre égard n'est prise de manière exclusivement automatisée. Les fonctionnalités d'assistance par intelligence artificielle sont des outils d'aide, sans prise de décision automatisée au sens de l'article 22 du RGPD.</p>
       </section>
 
       <div style={{ marginTop: '40px', padding: '16px', background: '#EEF2FF', borderRadius: '8px', fontSize: '12px', color: '#4338CA' }}>


### PR DESCRIPTION
## Contexte
Renseignement des informations légales réelles de l'éditeur à partir de l'avis de situation SIRENE.

## Identité (avis SIRENE)
- **Éditeur** : Antony Despaux, entrepreneur individuel (micro-entrepreneur) sous le nom commercial **AD Consulting**
- **SIREN** 884 072 687 · **SIRET (siège)** 884 072 687 00012 · **APE** 70.22Z
- **Siège** : 30B rue de Paris, 92190 Meudon
- **TVA** : non applicable — franchise en base (art. 293 B CGI)
- « Skalcook » : marque déposée

## Modifications
- **Mentions légales** : éditeur, SIREN/SIRET/APE, adresse Meudon, mention marque déposée.
- **CGU** : tribunal compétent aligné sur le siège → **Nanterre** (au lieu de Paris).
- **Politique de confidentialité** : responsable de traitement, adresse, SIREN.
- Dates → juillet 2026.

> Ce commit embarque aussi la réécriture des pages légales (Skalcook SAS → AD Consulting EI) qui était déjà présente en local non commitée, cohérente avec la même démarche.

Vérifié en preview local (3 pages rendues correctement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)