### PR TITLE
fix(legal): bouton retour vers la landing sur les pages annexes

### DIFF
--- a/app/cgu/page.js
+++ b/app/cgu/page.js
@@ -1,6 +1,9 @@
+import BackToLanding from '../../components/BackToLanding'
+
 export default function CGU() {
   return (
     <div style={{ maxWidth: '720px', margin: '0 auto', padding: '40px 24px', fontFamily: 'sans-serif', color: '#18181B', lineHeight: '1.8' }}>
+      <BackToLanding />
       <h1 style={{ fontSize: '28px', fontWeight: '700', marginBottom: '8px' }}>Conditions Générales d'Utilisation</h1>
       <p style={{ color: '#71717A', fontSize: '13px', marginBottom: '32px' }}>Version 1.0 — Dernière mise à jour : juillet 2026</p>
 

--- a/app/mentions-legales/page.js
+++ b/app/mentions-legales/page.js
@@ -1,6 +1,9 @@
+import BackToLanding from '../../components/BackToLanding'
+
 export default function MentionsLegales() {
   return (
     <div style={{ maxWidth: '720px', margin: '0 auto', padding: '40px 24px', fontFamily: 'sans-serif', color: '#18181B', lineHeight: '1.8' }}>
+      <BackToLanding />
       <h1 style={{ fontSize: '28px', fontWeight: '700', marginBottom: '8px' }}>Mentions légales</h1>
       <p style={{ color: '#71717A', fontSize: '13px', marginBottom: '32px' }}>Dernière mise à jour : juillet 2026</p>
 

--- a/app/politique-confidentialite/page.js
+++ b/app/politique-confidentialite/page.js
@@ -1,6 +1,9 @@
+import BackToLanding from '../../components/BackToLanding'
+
 export default function PolitiqueConfidentialite() {
   return (
     <div style={{ maxWidth: '720px', margin: '0 auto', padding: '40px 24px', fontFamily: 'sans-serif', color: '#18181B', lineHeight: '1.8' }}>
+      <BackToLanding />
       <h1 style={{ fontSize: '28px', fontWeight: '700', marginBottom: '8px' }}>Politique de Confidentialité</h1>
       <p style={{ color: '#71717A', fontSize: '13px', marginBottom: '32px' }}>Version 1.0 — Dernière mise à jour : juillet 2026</p>
 

--- a/components/BackToLanding.jsx
+++ b/components/BackToLanding.jsx
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+
+/**
+ * BackToLanding — lien de retour vers la landing page, destiné aux pages
+ * annexes autonomes (mentions légales, CGU, politique de confidentialité) qui
+ * n'ont sinon aucune navigation. Pointe explicitement vers « / » (et non un
+ * router.back()) pour fonctionner même en arrivée directe depuis un lien externe.
+ */
+export default function BackToLanding({ style }) {
+  return (
+    <Link
+      href="/"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '6px',
+        color: '#6366F1',
+        fontSize: '14px',
+        fontWeight: 500,
+        textDecoration: 'none',
+        marginBottom: '24px',
+        ...style,
+      }}
+    >
+      ← Retour au site
+    </Link>
+  )
+}


### PR DESCRIPTION
## Problème
Les pages annexes de la landing (mentions légales, CGU, politique de confidentialité) n'avaient **aucune navigation** : en y accédant en direct, impossible de revenir au site — cul-de-sac.

## Correction
- Nouveau composant réutilisable **`components/BackToLanding.jsx`** : lien « ← Retour au site » pointant explicitement vers `/` (fonctionne même en arrivée directe depuis un lien externe, contrairement à un `router.back()`).
- Ajouté en haut des 3 pages : `/mentions-legales`, `/cgu`, `/politique-confidentialite`.

Vérifié en preview : bouton visible, clic → retour à la landing confirmé. Build de prod OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)