### PR TITLE
fix(superadmin): normaliser les accents du slug d'établissement

### DIFF
--- a/app/superadmin/page.js
+++ b/app/superadmin/page.js
@@ -160,6 +160,16 @@ export default function SuperAdminPage() {
     return urlData.publicUrl
   }
 
+  // Normalise un slug pour respecter le schéma backend (/^[a-z0-9-]+$/) :
+  // translittère les accents (démo → demo), remplace tout le reste par des
+  // tirets, puis nettoie les tirets superflus.
+  const slugify = (s) =>
+    (s || '')
+      .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+
   // Transforme la réponse d'erreur de l'API en message lisible : si le backend
   // renvoie des détails de validation Zod (details.fieldErrors), on liste les
   // champs fautifs au lieu du générique « Données invalides ».
@@ -198,7 +208,7 @@ export default function SuperAdminPage() {
 
     const payload = {
       nom, nom_etablissement: nomEtablissement,
-      slug: slug.toLowerCase().replace(/\s+/g, '-'),
+      slug: slugify(slug),
       adresse, actif,
       couleur_principale: couleurPrincipale, couleur_accent: couleurAccent, couleur_fond: couleurFond,
       modules_actifs: modulesActifs,
@@ -428,7 +438,7 @@ export default function SuperAdminPage() {
                 <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr', gap: '16px' }}>
                   <div><label style={labelStyle}>Nom interne *</label><input value={nom} onChange={e => setNom(e.target.value)} placeholder="Ex : hotel-la-fantaisie" style={inputStyle} /><div style={{ fontSize: '11px', color: '#71717A', marginTop: '4px' }}>Identifiant interne</div></div>
                   <div><label style={labelStyle}>Nom affiché *</label><input value={nomEtablissement} onChange={e => setNomEtablissement(e.target.value)} placeholder="Ex : Hôtel La Fantaisie" style={inputStyle} /><div style={{ fontSize: '11px', color: '#71717A', marginTop: '4px' }}>Affiché dans la navbar</div></div>
-                  <div><label style={labelStyle}>Slug * (sous-domaine)</label><input value={slug} onChange={e => setSlug(e.target.value.toLowerCase().replace(/\s+/g, '-'))} placeholder="Ex : la-fantaisie" style={inputStyle} /><div style={{ fontSize: '11px', color: '#71717A', marginTop: '4px' }}>URL : <code style={{ background: '#F4F4F5', padding: '1px 6px', borderRadius: '4px' }}>{slug || 'votre-slug'}.skalcook.com</code></div></div>
+                  <div><label style={labelStyle}>Slug * (sous-domaine)</label><input value={slug} onChange={e => setSlug(e.target.value.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/[^a-z0-9-]+/g, '-'))} placeholder="Ex : la-fantaisie" style={inputStyle} /><div style={{ fontSize: '11px', color: '#71717A', marginTop: '4px' }}>URL : <code style={{ background: '#F4F4F5', padding: '1px 6px', borderRadius: '4px' }}>{slug || 'votre-slug'}.skalcook.com</code></div></div>
                   <div><label style={labelStyle}>Adresse</label><input value={adresse} onChange={e => setAdresse(e.target.value)} placeholder="Ex : 24 Rue Cadet, Paris 9ème" style={inputStyle} /></div>
                 </div>
                 <div style={{ marginTop: '16px', display: 'flex', alignItems: 'center', gap: '10px' }}>


### PR DESCRIPTION
## Problème

Suite du #189 : le message d'erreur détaillé a révélé la vraie cause du 400 à la création d'établissement. Un slug avec accents (ex. **`démo`**) est rejeté par le schéma backend `/^[a-z0-9-]+$/` — le front faisait seulement `toLowerCase()` + espaces→tiret, sans translittérer les caractères accentués.

`Erreur : Données invalides — slug (Slug invalide (a-z, 0-9, -))`

## Correctif (`app/superadmin/page.js`)

- Helper `slugify()` : `normalize('NFD')` + suppression des diacritiques (`démo` → `demo`), remplacement des caractères non alphanumériques par des tirets, nettoyage des tirets superflus.
- Appliqué au payload (`slug: slugify(slug)`) **et** en direct sur l'input (déburrage à la frappe).

Exemples : `Le Café Crème` → `le-cafe-creme`, `Bràsserie du Marché` → `brasserie-du-marche`.

## Test
- `eslint` : 0 erreur.
- Logique `slugify` vérifiée en isolé sur plusieurs entrées accentuées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)